### PR TITLE
General work

### DIFF
--- a/browser/browser.go
+++ b/browser/browser.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"immich-go/helpers/fshelper"
 	"slices"
 	"strings"
+
+	"github.com/simulot/immich-go/helpers/fshelper"
 )
 
 type Browser interface {
@@ -32,7 +33,6 @@ func (c *Configuration) IsValid() error {
 	c.ExcludeExtensions, _ = checkExtensions(c.ExcludeExtensions)
 
 	return jerr
-
 }
 
 func checkExtensions(l StringList) (StringList, error) {

--- a/browser/browser_test.go
+++ b/browser/browser_test.go
@@ -3,7 +3,6 @@ package browser
 import "testing"
 
 func TestStringList_Include(t *testing.T) {
-
 	tests := []struct {
 		name string
 		sl   StringList
@@ -51,7 +50,6 @@ func TestStringList_Include(t *testing.T) {
 }
 
 func TestStringList_Exclude(t *testing.T) {
-
 	tests := []struct {
 		name string
 		sl   StringList

--- a/browser/files/localassets.go
+++ b/browser/files/localassets.go
@@ -2,15 +2,16 @@ package files
 
 import (
 	"context"
-	"immich-go/browser"
-	"immich-go/helpers/fshelper"
-	"immich-go/immich/metadata"
-	"immich-go/logger"
 	"io/fs"
 	"path"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/simulot/immich-go/browser"
+	"github.com/simulot/immich-go/helpers/fshelper"
+	"github.com/simulot/immich-go/immich/metadata"
+	"github.com/simulot/immich-go/logger"
 )
 
 type LocalAssetBrowser struct {
@@ -57,7 +58,6 @@ func (la *LocalAssetBrowser) Browse(ctx context.Context) chan *browser.LocalAsse
 					}
 				}
 				return nil
-
 			})
 		if err != nil {
 			// Check if the context has been cancelled before sending the error
@@ -70,7 +70,6 @@ func (la *LocalAssetBrowser) Browse(ctx context.Context) chan *browser.LocalAsse
 			}:
 			}
 		}
-
 	}(ctx)
 
 	return fileChan
@@ -206,7 +205,6 @@ func (la *LocalAssetBrowser) ReadMetadataFromFile(a *browser.LocalAssetFile) err
 
 	// Open the file
 	r, err := a.PartialSourceReader()
-
 	if err != nil {
 		return err
 	}

--- a/browser/files/localassets_test.go
+++ b/browser/files/localassets_test.go
@@ -3,13 +3,14 @@ package files_test
 import (
 	"context"
 	"errors"
-	"immich-go/browser"
-	"immich-go/browser/files"
-	"immich-go/logger"
 	"path"
 	"reflect"
 	"sort"
 	"testing"
+
+	"github.com/simulot/immich-go/browser"
+	"github.com/simulot/immich-go/browser/files"
+	"github.com/simulot/immich-go/logger"
 
 	"github.com/kr/pretty"
 	"github.com/psanford/memfs"
@@ -31,8 +32,8 @@ func (mfs *inMemFS) addFile(name string) *inMemFS {
 		return mfs
 	}
 	dir := path.Dir(name)
-	mfs.err = errors.Join(mfs.err, mfs.MkdirAll(dir, 0777))
-	mfs.err = errors.Join(mfs.err, mfs.WriteFile(name, []byte(name), 0777))
+	mfs.err = errors.Join(mfs.err, mfs.MkdirAll(dir, 0o777))
+	mfs.err = errors.Join(mfs.err, mfs.WriteFile(name, []byte(name), 0o777))
 	return mfs
 }
 
@@ -91,8 +92,6 @@ func TestLocalAssets(t *testing.T) {
 				t.Errorf("difference\n")
 				pretty.Ldiff(t, c.expected, results)
 			}
-
 		})
-
 	}
 }

--- a/browser/gp/googlephotos.go
+++ b/browser/gp/googlephotos.go
@@ -3,13 +3,14 @@ package gp
 import (
 	"context"
 	"fmt"
-	"immich-go/browser"
-	"immich-go/helpers/fshelper"
-	"immich-go/logger"
 	"io/fs"
 	"path"
 	"strings"
 	"unicode/utf8"
+
+	"github.com/simulot/immich-go/browser"
+	"github.com/simulot/immich-go/helpers/fshelper"
+	"github.com/simulot/immich-go/logger"
 )
 
 type Takeout struct {
@@ -189,7 +190,6 @@ func (to *Takeout) Browse(ctx context.Context) chan *browser.LocalAssetFile {
 	}()
 
 	return c
-
 }
 
 // jsonAssets search assets that are linked to this JSON
@@ -203,7 +203,6 @@ func (to *Takeout) Browse(ctx context.Context) chan *browser.LocalAssetFile {
 //   the asset name is the JSON title field
 
 func (to *Takeout) jsonAssets(key jsonKey, md *GoogleMetaData) []*browser.LocalAssetFile {
-
 	var list []*browser.LocalAssetFile
 
 	yearDir := path.Join(path.Dir(md.foundInPaths[0]), fmt.Sprintf("Photos from %d", md.PhotoTakenTime.Time().Year()))
@@ -361,7 +360,6 @@ func (to *Takeout) copyGoogleMDToAsset(md *GoogleMetaData, filename string, leng
 		if album, exists := to.albumsByDir[p]; exists {
 			a.Albums = append(a.Albums, album)
 		}
-
 	}
 	return &a
 }

--- a/browser/gp/json.go
+++ b/browser/gp/json.go
@@ -3,9 +3,10 @@ package gp
 import (
 	"encoding/json"
 	"fmt"
-	"immich-go/helpers/tzone"
 	"strconv"
 	"time"
+
+	"github.com/simulot/immich-go/helpers/tzone"
 )
 
 type GoogleMetaData struct {

--- a/browser/gp/json_test.go
+++ b/browser/gp/json_test.go
@@ -7,7 +7,6 @@ import (
 )
 
 func TestPresentFields(t *testing.T) {
-
 	tcs := []struct {
 		name      string
 		json      string
@@ -132,5 +131,4 @@ func TestPresentFields(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/browser/gp/testgp_bigread_test.go
+++ b/browser/gp/testgp_bigread_test.go
@@ -5,11 +5,12 @@ package gp
 
 import (
 	"context"
-	"immich-go/browser"
-	"immich-go/helpers/fshelper"
-	"immich-go/logger"
 	"path/filepath"
 	"testing"
+
+	"github.com/simulot/immich-go/browser"
+	"github.com/simulot/immich-go/helpers/fshelper"
+	"github.com/simulot/immich-go/logger"
 )
 
 func TestReadBigTakeout(t *testing.T) {

--- a/browser/gp/testgp_samples_test.go
+++ b/browser/gp/testgp_samples_test.go
@@ -4,12 +4,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"immich-go/immich/metadata"
 	"path"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/simulot/immich-go/immich/metadata"
 
 	"github.com/psanford/memfs"
 )
@@ -30,8 +31,8 @@ func (mfs *inMemFS) addFile(name string, content []byte) *inMemFS {
 		return mfs
 	}
 	dir := path.Dir(name)
-	mfs.err = errors.Join(mfs.err, mfs.MkdirAll(dir, 0777))
-	mfs.err = errors.Join(mfs.err, mfs.WriteFile(name, content, 0777))
+	mfs.err = errors.Join(mfs.err, mfs.MkdirAll(dir, 0o777))
+	mfs.err = errors.Join(mfs.err, mfs.WriteFile(name, content, 0o777))
 	return mfs
 }
 
@@ -113,7 +114,6 @@ func simpleYear() *inMemFS {
 		addImage("TakeoutGoogle Photos/Photos from 2023/PXL_20230922_144936660.jpg", 10).
 		addJSONImage("TakeoutGoogle Photos/Photos from 2023/PXL_20230922_144956000.jpg.json", "PXL_20230922_144956000.jpg").
 		addImage("TakeoutGoogle Photos/Photos from 2023/PXL_20230922_144956000.jpg", 20)
-
 }
 
 func simpleAlbum() *inMemFS {
@@ -179,7 +179,6 @@ func titlesWithForbiddenChars() *inMemFS {
 		addImage("TakeoutGoogle Photos/Photos from 2012/27_06_12 - 1.mov", 52)
 	// addJSONImage("TakeoutGoogle Photos/Photos from 2012/27_06_12 - 1.json", "27/06/12 - 1").
 	// addImage("TakeoutGoogle Photos/Photos from 2012/27_06_12 - 1.jpg", 24)
-
 }
 
 func namesIssue39() *inMemFS {

--- a/browser/gp/testgp_test.go
+++ b/browser/gp/testgp_test.go
@@ -2,11 +2,12 @@ package gp
 
 import (
 	"context"
-	"immich-go/browser"
-	"immich-go/logger"
 	"path"
 	"reflect"
 	"testing"
+
+	"github.com/simulot/immich-go/browser"
+	"github.com/simulot/immich-go/logger"
 
 	"github.com/kr/pretty"
 )
@@ -17,14 +18,16 @@ func TestBrowse(t *testing.T) {
 		gen     func() *inMemFS
 		results []fileResult // file name / title
 	}{
-		{"simpleYear", simpleYear,
+		{
+			"simpleYear", simpleYear,
 			sortFileResult([]fileResult{
 				{name: "PXL_20230922_144936660.jpg", size: 10, title: "PXL_20230922_144936660.jpg"},
 				{name: "PXL_20230922_144956000.jpg", size: 20, title: "PXL_20230922_144956000.jpg"},
 			}),
 		},
 
-		{"simpleAlbum", simpleAlbum,
+		{
+			"simpleAlbum", simpleAlbum,
 			sortFileResult([]fileResult{
 				{name: "PXL_20230922_144936660.jpg", size: 10, title: "PXL_20230922_144936660.jpg"},
 				{name: "PXL_20230922_144934440.jpg", size: 15, title: "PXL_20230922_144934440.jpg"},
@@ -33,14 +36,16 @@ func TestBrowse(t *testing.T) {
 			}),
 		},
 
-		{"albumWithoutImage", albumWithoutImage,
+		{
+			"albumWithoutImage", albumWithoutImage,
 			sortFileResult([]fileResult{
 				{name: "PXL_20230922_144936660.jpg", size: 10, title: "PXL_20230922_144936660.jpg"},
 				{name: "PXL_20230922_144934440.jpg", size: 15, title: "PXL_20230922_144934440.jpg"},
 			}),
 		},
 
-		{"namesWithNumbers", namesWithNumbers,
+		{
+			"namesWithNumbers", namesWithNumbers,
 			sortFileResult([]fileResult{
 				{name: "IMG_3479.JPG", size: 10, title: "IMG_3479.JPG"},
 				{name: "IMG_3479(1).JPG", size: 12, title: "IMG_3479.JPG"},
@@ -48,7 +53,8 @@ func TestBrowse(t *testing.T) {
 			}),
 		},
 
-		{"namesTruncated", namesTruncated,
+		{
+			"namesTruncated", namesTruncated,
 			sortFileResult([]fileResult{
 				{name: "😀😃😄😁😆😅😂🤣🥲☺️😊😇🙂🙃😉😌😍🥰😘😗😙😚😋😛.jpg", size: 10, title: "😀😃😄😁😆😅😂🤣🥲☺️😊😇🙂🙃😉😌😍🥰😘😗😙😚😋😛😝😜🤪🤨🧐🤓😎🥸🤩🥳😏😒😞😔😟😕🙁☹️😣😖😫😩🥺😢😭😤😠😡🤬🤯😳🥵🥶.jpg"},
 				{name: "PXL_20230809_203449253.LONG_EXPOSURE-02.ORIGINA.jpg", size: 40, title: "PXL_20230809_203449253.LONG_EXPOSURE-02.ORIGINAL.jpg"},
@@ -56,20 +62,23 @@ func TestBrowse(t *testing.T) {
 			}),
 		},
 
-		{"imagesWithoutJSON", imagesEditedJSON,
+		{
+			"imagesWithoutJSON", imagesEditedJSON,
 			sortFileResult([]fileResult{
 				{name: "PXL_20220405_090123740.PORTRAIT.jpg", size: 41, title: "PXL_20220405_090123740.PORTRAIT.jpg"},
 				{name: "PXL_20220405_090123740.PORTRAIT-modifié.jpg", size: 21, title: "PXL_20220405_090123740.PORTRAIT.jpg"},
 			}),
 		},
 
-		{"titlesWithForbiddenChars", titlesWithForbiddenChars,
+		{
+			"titlesWithForbiddenChars", titlesWithForbiddenChars,
 			sortFileResult([]fileResult{
 				{name: "27_06_12 - 1.mov", size: 52, title: "27/06/12 - 1.mov"},
 				// {name: "27_06_12 - 1.jpg", size: 24, title: "27/06/12 - 1"},
 			}),
 		},
-		{"namesIssue39", namesIssue39,
+		{
+			"namesIssue39", namesIssue39,
 			sortFileResult([]fileResult{
 				{name: "Backyard_ceremony_wedding_photography_xxxxxxx_m.jpg", size: 1, title: "Backyard_ceremony_wedding_photography_xxxxxxx_magnoliastudios-371.jpg"},
 				{name: "Backyard_ceremony_wedding_photography_xxxxxxx_m(1).jpg", size: 181, title: "Backyard_ceremony_wedding_photography_xxxxxxx_magnoliastudios-181.jpg"},
@@ -79,7 +88,6 @@ func TestBrowse(t *testing.T) {
 	}
 	for _, c := range tc {
 		t.Run(c.name, func(t *testing.T) {
-
 			fsys := c.gen()
 			if fsys.err != nil {
 				t.Error(fsys.err)
@@ -104,11 +112,9 @@ func TestBrowse(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestAlbums(t *testing.T) {
-
 	type album map[string][]fileResult
 	tc := []struct {
 		name   string
@@ -155,7 +161,6 @@ func TestAlbums(t *testing.T) {
 
 	for _, c := range tc {
 		t.Run(c.name, func(t *testing.T) {
-
 			ctx := context.Background()
 			fsys := c.gen()
 			if fsys.err != nil {
@@ -185,7 +190,6 @@ func TestAlbums(t *testing.T) {
 				t.Errorf("difference\n")
 				pretty.Ldiff(t, c.albums, albums)
 			}
-
 		})
 	}
 }

--- a/browser/localfile.go
+++ b/browser/localfile.go
@@ -3,14 +3,15 @@ package browser
 import (
 	"errors"
 	"fmt"
-	"immich-go/helpers/fshelper"
-	"immich-go/immich/metadata"
 	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/simulot/immich-go/helpers/fshelper"
+	"github.com/simulot/immich-go/immich/metadata"
 )
 
 /*
@@ -110,7 +111,7 @@ func (l *LocalAssetFile) PartialSourceReader() (reader io.Reader, err error) {
 			return nil, err
 		}
 		tempDir = filepath.Join(tempDir, "immich-go")
-		os.Mkdir(tempDir, 0700)
+		os.Mkdir(tempDir, 0o700)
 		l.tempFile, err = os.CreateTemp(tempDir, "")
 		if err != nil {
 			return nil, err
@@ -171,6 +172,7 @@ func (l *LocalAssetFile) IsDir() bool { return false }
 func (l *LocalAssetFile) Name() string {
 	return l.FileName
 }
+
 func (l *LocalAssetFile) Size() int64 {
 	return int64(l.FileSize)
 }

--- a/browser/readersearch.go
+++ b/browser/readersearch.go
@@ -47,7 +47,6 @@ func searchPattern(r io.Reader, pattern []byte, maxDataLen int) ([]byte, error) 
 }
 
 func seekReaderAtPattern(r io.Reader, pattern []byte) (io.Reader, error) {
-
 	var err error
 	pos := 0
 	// Create a buffer to hold the chunk of dataZ

--- a/cmdduplicate/duplicate.go
+++ b/cmdduplicate/duplicate.go
@@ -6,15 +6,16 @@ package cmdduplicate
 import (
 	"context"
 	"flag"
-	"immich-go/helpers/gen"
-	"immich-go/immich"
-	"immich-go/logger"
-	"immich-go/ui"
 	"path"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/simulot/immich-go/helpers/gen"
+	"github.com/simulot/immich-go/immich"
+	"github.com/simulot/immich-go/logger"
+	"github.com/simulot/immich-go/ui"
 )
 
 type DuplicateCmd struct {

--- a/cmdmetadata/metadatacmd.go
+++ b/cmdmetadata/metadatacmd.go
@@ -3,14 +3,15 @@ package cmdmetadata
 import (
 	"context"
 	"flag"
-	"immich-go/helpers/docker"
-	"immich-go/immich"
-	"immich-go/immich/metadata"
-	"immich-go/logger"
 	"math"
 	"path"
 	"strings"
 	"time"
+
+	"github.com/simulot/immich-go/helpers/docker"
+	"github.com/simulot/immich-go/immich"
+	"github.com/simulot/immich-go/immich/metadata"
+	"github.com/simulot/immich-go/logger"
 )
 
 type MetadataCmd struct {

--- a/cmdstack/cmdstack.go
+++ b/cmdstack/cmdstack.go
@@ -3,13 +3,14 @@ package cmdstack
 import (
 	"context"
 	"flag"
-	"immich-go/helpers/stacking"
-	"immich-go/immich"
-	"immich-go/logger"
-	"immich-go/ui"
 	"path"
 	"sort"
 	"strconv"
+
+	"github.com/simulot/immich-go/helpers/stacking"
+	"github.com/simulot/immich-go/immich"
+	"github.com/simulot/immich-go/logger"
+	"github.com/simulot/immich-go/ui"
 )
 
 type StackCmd struct {
@@ -40,6 +41,7 @@ func initSack(xtx context.Context, ic *immich.ImmichClient, log *logger.Log, arg
 	err := cmd.Parse(args)
 	return &app, err
 }
+
 func NewStackCommand(ctx context.Context, ic *immich.ImmichClient, log *logger.Log, args []string) error {
 	app, err := initSack(ctx, ic, log, args)
 	if err != nil {

--- a/cmdtool/cmdalbum/cmdalbum.go
+++ b/cmdtool/cmdalbum/cmdalbum.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"immich-go/immich"
-	"immich-go/logger"
-	"immich-go/ui"
 	"regexp"
 	"sort"
 	"strconv"
+
+	"github.com/simulot/immich-go/immich"
+	"github.com/simulot/immich-go/logger"
+	"github.com/simulot/immich-go/ui"
 )
 
 func AlbumCommand(ctx context.Context, ic *immich.ImmichClient, log *logger.Log, args []string) error {

--- a/cmdtool/cmdtool.go
+++ b/cmdtool/cmdtool.go
@@ -3,9 +3,10 @@ package cmdtool
 import (
 	"context"
 	"fmt"
-	"immich-go/cmdtool/cmdalbum"
-	"immich-go/immich"
-	"immich-go/logger"
+
+	"github.com/simulot/immich-go/cmdtool/cmdalbum"
+	"github.com/simulot/immich-go/immich"
+	"github.com/simulot/immich-go/logger"
 )
 
 func CommandTool(ctx context.Context, ic *immich.ImmichClient, logger *logger.Log, args []string) error {

--- a/cmdupload/assets.go
+++ b/cmdupload/assets.go
@@ -2,10 +2,11 @@ package cmdupload
 
 import (
 	"fmt"
-	"immich-go/browser"
-	"immich-go/immich"
 	"path"
 	"strings"
+
+	"github.com/simulot/immich-go/browser"
+	"github.com/simulot/immich-go/immich"
 )
 
 type AssetIndex struct {

--- a/cmdupload/e2e_upload_folder_test.go
+++ b/cmdupload/e2e_upload_folder_test.go
@@ -7,16 +7,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"immich-go/immich"
-	"immich-go/logger"
 	"testing"
 	"time"
+
+	"github.com/simulot/immich-go/immich"
+	"github.com/simulot/immich-go/logger"
 
 	"github.com/joho/godotenv"
 )
 
 func TestE2eUpload(t *testing.T) {
-
 	var myEnv map[string]string
 	myEnv, err := godotenv.Read("../.env")
 	if err != nil {
@@ -100,7 +100,6 @@ func TestE2eUpload(t *testing.T) {
 
 	logger := logger.NoLogger{}
 	ic, err := immich.NewImmichClient(host, key)
-
 	if err != nil {
 		t.Error(err)
 		return

--- a/cmdupload/upload.go
+++ b/cmdupload/upload.go
@@ -7,21 +7,22 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"immich-go/browser"
-	"immich-go/browser/files"
-	"immich-go/browser/gp"
-	"immich-go/helpers/fshelper"
-	"immich-go/helpers/gen"
-	"immich-go/helpers/stacking"
-	"immich-go/immich"
-	"immich-go/immich/metadata"
-	"immich-go/logger"
 	"io/fs"
 	"math"
 	"path"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/simulot/immich-go/browser"
+	"github.com/simulot/immich-go/browser/files"
+	"github.com/simulot/immich-go/browser/gp"
+	"github.com/simulot/immich-go/helpers/fshelper"
+	"github.com/simulot/immich-go/helpers/gen"
+	"github.com/simulot/immich-go/helpers/stacking"
+	"github.com/simulot/immich-go/immich"
+	"github.com/simulot/immich-go/immich/metadata"
+	"github.com/simulot/immich-go/logger"
 
 	"github.com/google/uuid"
 )
@@ -180,7 +181,6 @@ func NewUpCmd(ctx context.Context, ic iClient, log logger.Logger, args []string)
 	app.AssetIndex.ReIndex()
 
 	return &app, err
-
 }
 
 func UploadCommand(ctx context.Context, ic iClient, log logger.Logger, args []string) error {
@@ -386,7 +386,6 @@ func (app *UpCmd) handleAsset(ctx context.Context, a *browser.LocalAssetFile) er
 	}
 	showCount = false
 	return nil
-
 }
 
 func (app *UpCmd) isInAlbum(a *browser.LocalAssetFile, album string) bool {
@@ -532,7 +531,6 @@ func (app *UpCmd) DeleteLocalAssets() error {
 		} else {
 			app.log.Warning("file %q not deleted, dry run mode", a.Title)
 		}
-
 	}
 	return nil
 }
@@ -664,13 +662,13 @@ func (ai *AssetIndex) adviceIDontKnow(la *browser.LocalAssetFile) *Advice {
 }
 
 func (ai *AssetIndex) adviceSameOnServer(sa *immich.Asset) *Advice {
-
 	return &Advice{
 		Advice:      SameOnServer,
 		Message:     fmt.Sprintf("An asset with the same name:%q, date:%q and size:%s exists on the server. No need to upload.", sa.OriginalFileName, sa.ExifInfo.DateTimeOriginal.Format(time.DateTime), formatBytes(sa.ExifInfo.FileSizeInByte)),
 		ServerAsset: sa,
 	}
 }
+
 func (ai *AssetIndex) adviceSmallerOnServer(sa *immich.Asset) *Advice {
 	return &Advice{
 		Advice:      SmallerOnServer,
@@ -678,6 +676,7 @@ func (ai *AssetIndex) adviceSmallerOnServer(sa *immich.Asset) *Advice {
 		ServerAsset: sa,
 	}
 }
+
 func (ai *AssetIndex) adviceBetterOnServer(sa *immich.Asset) *Advice {
 	return &Advice{
 		Advice:      BetterOnServer,
@@ -685,6 +684,7 @@ func (ai *AssetIndex) adviceBetterOnServer(sa *immich.Asset) *Advice {
 		ServerAsset: sa,
 	}
 }
+
 func (ai *AssetIndex) adviceNotOnServer() *Advice {
 	return &Advice{
 		Advice:  NotOnServer,
@@ -729,7 +729,6 @@ func (ai *AssetIndex) ShouldUpload(la *browser.LocalAssetFile) (*Advice, error) 
 		size := int(la.Size())
 		if err != nil {
 			return ai.adviceIDontKnow(la), nil
-
 		}
 		for _, sa = range l {
 			compareDate := compareDate(dateTaken, sa.ExifInfo.DateTimeOriginal.Time)

--- a/cmdupload/upload_test.go
+++ b/cmdupload/upload_test.go
@@ -4,38 +4,44 @@ import (
 	"cmp"
 	"context"
 	"errors"
-	"immich-go/browser"
-	"immich-go/helpers/gen"
-	"immich-go/immich"
-	"immich-go/logger"
 	"reflect"
 	"slices"
 	"testing"
 
+	"github.com/simulot/immich-go/browser"
+	"github.com/simulot/immich-go/helpers/gen"
+	"github.com/simulot/immich-go/immich"
+	"github.com/simulot/immich-go/logger"
+
 	"github.com/kr/pretty"
 )
 
-type stubIC struct {
-}
+type stubIC struct{}
 
 func (c *stubIC) GetAllAssetsWithFilter(context.Context, *immich.GetAssetOptions, func(*immich.Asset)) error {
 	return nil
 }
+
 func (c *stubIC) AssetUpload(context.Context, *browser.LocalAssetFile) (immich.AssetResponse, error) {
 	return immich.AssetResponse{}, nil
 }
+
 func (c *stubIC) DeleteAssets(context.Context, []string, bool) error {
 	return nil
 }
+
 func (c *stubIC) GetAllAlbums(context.Context) ([]immich.AlbumSimplified, error) {
 	return nil, nil
 }
+
 func (c *stubIC) AddAssetToAlbum(context.Context, string, []string) ([]immich.UpdateAlbumResult, error) {
 	return nil, nil
 }
+
 func (c *stubIC) CreateAlbum(context.Context, string, []string) (immich.AlbumSimplified, error) {
 	return immich.AlbumSimplified{}, nil
 }
+
 func (c *stubIC) UpdateAssets(ctx context.Context, IDs []string, isArchived bool, isFavorite bool, removeParent bool, stackParentId string) error {
 	return nil
 }
@@ -68,9 +74,11 @@ func (c *icCatchUploadsAssets) AssetUpload(ctx context.Context, a *browser.Local
 		ID: a.FileName,
 	}, nil
 }
+
 func (c *icCatchUploadsAssets) AddAssetToAlbum(ctx context.Context, album string, ids []string) ([]immich.UpdateAlbumResult, error) {
 	return nil, nil
 }
+
 func (c *icCatchUploadsAssets) CreateAlbum(ctx context.Context, album string, ids []string) (immich.AlbumSimplified, error) {
 	if album == "" {
 		panic("can't create album without name")

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module immich-go
+module github.com/simulot/immich-go
 
 go 1.21
 

--- a/helpers/docker/docker.go
+++ b/helpers/docker/docker.go
@@ -103,7 +103,6 @@ func (d *DockerConnect) connect(ctx context.Context, host string, container stri
 
 // Download a file from the docker container
 func (d *DockerConnect) Download(ctx context.Context, hostFile string) (io.Reader, error) {
-
 	cmd, err := d.proxy.docker(ctx, "cp", d.Container+":"+hostFile, "-")
 	if err != nil {
 		return nil, err
@@ -164,7 +163,7 @@ func (d *DockerConnect) Upload(ctx context.Context, file string, size int64, r i
 		}()
 		hdr := tar.Header{
 			Name:    path.Base(file),
-			Mode:    0644,
+			Mode:    0o644,
 			Size:    size,
 			ModTime: time.Now(),
 		}
@@ -212,13 +211,12 @@ func (d *DockerConnect) BatchUpload(ctx context.Context, dir string) (*batchUplo
 		var err error
 		tw := tar.NewWriter(mw)
 		defer func() {
-			//f.Close()
+			// f.Close()
 			tw.Close()
 			in.Close()
 			cmd.Wait()
 		}()
 		for {
-
 			select {
 			case <-ctx.Done():
 				return
@@ -229,7 +227,7 @@ func (d *DockerConnect) BatchUpload(ctx context.Context, dir string) (*batchUplo
 
 				hdr := tar.Header{
 					Name:    f.name,
-					Mode:    0644,
+					Mode:    0o644,
 					Size:    int64(len(f.content)),
 					ModTime: time.Now(),
 				}
@@ -267,6 +265,7 @@ func (b *batchUploader) Upload(name string, content []byte) error {
 	err := <-b.fileErr
 	return err
 }
+
 func (b *batchUploader) Close() error {
 	close(b.fileChannel)
 	return nil

--- a/helpers/fshelper/parseArgs.go
+++ b/helpers/fshelper/parseArgs.go
@@ -3,12 +3,13 @@ package fshelper
 import (
 	"errors"
 	"fmt"
-	"immich-go/helpers/gen"
 	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
+
+	"github.com/simulot/immich-go/helpers/gen"
 )
 
 type argParser struct {

--- a/helpers/fshelper/pathfs.go
+++ b/helpers/fshelper/pathfs.go
@@ -1,13 +1,14 @@
 package fshelper
 
 import (
-	"immich-go/helpers/gen"
 	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
 	"slices"
 	"strings"
+
+	"github.com/simulot/immich-go/helpers/gen"
 )
 
 type pathFS struct {

--- a/helpers/fshelper/removefs.go
+++ b/helpers/fshelper/removefs.go
@@ -28,7 +28,6 @@ type dirRemoveFS struct {
 }
 
 func DirRemoveFS(name string) fs.FS {
-
 	fsys := &dirRemoveFS{
 		FS:  os.DirFS(name),
 		dir: name,
@@ -36,6 +35,7 @@ func DirRemoveFS(name string) fs.FS {
 
 	return fsys
 }
+
 func (fsys dirRemoveFS) Remove(name string) error {
 	return os.Remove(filepath.Join(fsys.dir, name))
 }

--- a/helpers/stacking/stack.go
+++ b/helpers/stacking/stack.go
@@ -1,13 +1,14 @@
 package stacking
 
 import (
-	"immich-go/helpers/gen"
-	"immich-go/immich"
 	"path"
 	"slices"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/simulot/immich-go/helpers/gen"
+	"github.com/simulot/immich-go/immich"
 )
 
 type Key struct {
@@ -34,7 +35,6 @@ func NewStackBuilder() *StackBuilder {
 	sb.dateRange.Set("1850-01-04,2030-01-01")
 
 	return &sb
-
 }
 
 func (sb *StackBuilder) ProcessAsset(ID string, fileName string, captureDate time.Time) {

--- a/immich/albums.go
+++ b/immich/albums.go
@@ -27,7 +27,6 @@ func (ic *ImmichClient) GetAllAlbums(ctx context.Context) ([]AlbumSimplified, er
 		return nil, err
 	}
 	return albums, nil
-
 }
 
 type AlbumContent struct {
@@ -82,7 +81,6 @@ func (ic *ImmichClient) GetAssetsAlbums(ctx context.Context, id string) ([]Album
 		return nil, err
 	}
 	return albums, nil
-
 }
 
 type UpdateAlbum struct {
@@ -96,7 +94,6 @@ type UpdateAlbumResult struct {
 }
 
 func (ic *ImmichClient) AddAssetToAlbum(ctx context.Context, albumID string, assets []string) ([]UpdateAlbumResult, error) {
-
 	var r []UpdateAlbumResult
 	body := UpdateAlbum{
 		IDS: assets,

--- a/immich/asset.go
+++ b/immich/asset.go
@@ -3,8 +3,6 @@ package immich
 import (
 	"context"
 	"fmt"
-	"immich-go/browser"
-	"immich-go/helpers/fshelper"
 	"io"
 	"mime/multipart"
 	"net/textproto"
@@ -12,6 +10,9 @@ import (
 	"path"
 	"strings"
 	"time"
+
+	"github.com/simulot/immich-go/browser"
+	"github.com/simulot/immich-go/helpers/fshelper"
 )
 
 type AssetResponse struct {
@@ -131,7 +132,6 @@ func (ic *ImmichClient) AssetUpload(ctx context.Context, la *browser.LocalAssetF
 		do(post("/asset/upload", m.FormDataContentType(), setAcceptJSON(), setBody(body)), responseJSON(&ar))
 
 	return ar, err
-
 }
 
 var quoteEscaper = strings.NewReplacer("\\", "\\\\", `"`, "\\\"")
@@ -166,7 +166,6 @@ func (ic *ImmichClient) GetAllAssets(ctx context.Context, opt *GetAssetOptions) 
 
 	err := ic.newServerCall(ctx, "GetAllAssets").do(get("/asset", setUrlValues(opt.Values()), setAcceptJSON()), responseJSON(&r))
 	return r, err
-
 }
 
 func (ic *ImmichClient) GetAllAssetsWithFilter(ctx context.Context, opt *GetAssetOptions, filter func(*Asset)) error {

--- a/immich/call.go
+++ b/immich/call.go
@@ -112,6 +112,7 @@ func (sc *serverCall) Err(req *http.Request, resp *http.Response, msg *ServerMes
 	ce.message = msg
 	return ce
 }
+
 func (sc *serverCall) joinError(err error) error {
 	sc.err = errors.Join(sc.err, err)
 	return err
@@ -120,7 +121,6 @@ func (sc *serverCall) joinError(err error) error {
 type requestFunction func(sc *serverCall) *http.Request
 
 func (sc *serverCall) request(method string, url string, opts ...serverRequestOption) *http.Request {
-
 	req, err := http.NewRequestWithContext(sc.ctx, method, url, nil)
 	if sc.joinError(err) != nil {
 		return nil
@@ -142,6 +142,7 @@ func get(url string, opts ...serverRequestOption) requestFunction {
 		return sc.request(http.MethodGet, sc.ic.endPoint+url, opts...)
 	}
 }
+
 func post(url string, ctype string, opts ...serverRequestOption) requestFunction {
 	return func(sc *serverCall) *http.Request {
 		if sc.err != nil {
@@ -235,6 +236,7 @@ func setHeader(key, value string) serverRequestOption {
 		return nil
 	}
 }
+
 func setAcceptJSON() serverRequestOption {
 	return func(sc *serverCall, req *http.Request) error {
 		req.Header.Add("Accept", "application/json")

--- a/immich/call_test.go
+++ b/immich/call_test.go
@@ -88,5 +88,4 @@ func TestCall(t *testing.T) {
 			t.Logf("response received: %#v", r)
 		})
 	}
-
 }

--- a/immich/daterange_test.go
+++ b/immich/daterange_test.go
@@ -6,7 +6,6 @@ import (
 )
 
 func TestDateRange_InRange(t *testing.T) {
-
 	tests := []struct {
 		name  string
 		check []struct {

--- a/immich/immich.go
+++ b/immich/immich.go
@@ -3,9 +3,10 @@ package immich
 import (
 	"encoding/json"
 	"errors"
-	"immich-go/helpers/tzone"
 	"sync"
 	"time"
+
+	"github.com/simulot/immich-go/helpers/tzone"
 )
 
 type UnsupportedMedia struct {

--- a/immich/metadata/direct.go
+++ b/immich/metadata/direct.go
@@ -54,7 +54,6 @@ func GetFromReader(rd io.Reader, ext string) (MetaData, error) {
 
 // readExifDateTaken pase the file for Exif DateTaken
 func readExifDateTaken(r io.Reader) (time.Time, error) {
-
 	md, err := getExifFromReader(r)
 	return md.DateTaken, err
 }
@@ -104,5 +103,4 @@ func readCR3DateTaken(r *sliceReader) (time.Time, error) {
 
 	md, err := getExifFromReader(r)
 	return md.DateTaken, err
-
 }

--- a/immich/metadata/direct_test.go
+++ b/immich/metadata/direct_test.go
@@ -4,11 +4,12 @@
 package metadata
 
 import (
-	"immich-go/helpers/tzone"
 	"os"
 	"path"
 	"testing"
 	"time"
+
+	"github.com/simulot/immich-go/helpers/tzone"
 )
 
 func mustParse(s string) time.Time {
@@ -24,7 +25,6 @@ func mustParse(s string) time.Time {
 }
 
 func TestGetFromReader(t *testing.T) {
-
 	tests := []struct {
 		name     string
 		filename string

--- a/immich/metadata/exif.go
+++ b/immich/metadata/exif.go
@@ -3,10 +3,11 @@ package metadata
 import (
 	"errors"
 	"fmt"
-	"immich-go/helpers/tzone"
 	"io"
 	"strings"
 	"time"
+
+	"github.com/simulot/immich-go/helpers/tzone"
 
 	"github.com/rwcarlsen/goexif/exif"
 )

--- a/immich/metadata/namesdate.go
+++ b/immich/metadata/namesdate.go
@@ -1,10 +1,11 @@
 package metadata
 
 import (
-	"immich-go/helpers/tzone"
 	"regexp"
 	"strconv"
 	"time"
+
+	"github.com/simulot/immich-go/helpers/tzone"
 )
 
 // TakeTimeFromName extracts time components from the given name string and returns a time.Time value.
@@ -29,7 +30,6 @@ func TakeTimeFromName(name string) time.Time {
 			if i > 0 {
 				m[i-1], _ = strconv.Atoi(mm[i])
 			}
-
 		}
 		t := time.Date(m[0], time.Month(m[1]), m[2], m[3], m[4], m[5], 0, time.UTC)
 		if t.Year() != m[0] || t.Month() != time.Month(m[1]) || t.Day() != m[2] ||

--- a/immich/metadata/namesdate_test.go
+++ b/immich/metadata/namesdate_test.go
@@ -1,16 +1,16 @@
 package metadata
 
 import (
-	"immich-go/helpers/tzone"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/simulot/immich-go/helpers/tzone"
 )
 
 func TestTakeTimeFromName(t *testing.T) {
 	os.Setenv("TZ", "Europe/Paris")
 	local, err := tzone.Local()
-
 	if err != nil {
 		t.Error(err)
 		return
@@ -45,7 +45,7 @@ func TestTakeTimeFromName(t *testing.T) {
 		},
 		{
 			name:     "2023_07_20_10_09_20.mp4",
-			expected: time.Date(2023, 07, 20, 12, 9, 20, 0, local),
+			expected: time.Date(2023, 0o7, 20, 12, 9, 20, 0, local),
 		},
 		{
 			name:     "19991231",

--- a/immich/metadata/quicktime.go
+++ b/immich/metadata/quicktime.go
@@ -33,7 +33,7 @@ If any of the optional fields are present, the size of the atom would increase a
 */
 
 type MvhdAtom struct {
-	Marker           []byte //4 bytes
+	Marker           []byte // 4 bytes
 	Version          uint8
 	Flags            []byte // 3 bytes
 	CreationTime     time.Time
@@ -48,7 +48,6 @@ type MvhdAtom struct {
 }
 
 func decodeMvhdAtom(r *sliceReader) (*MvhdAtom, error) {
-
 	a := &MvhdAtom{}
 
 	// Read the mvhd marker (4 bytes)
@@ -82,6 +81,7 @@ func decodeMvhdAtom(r *sliceReader) (*MvhdAtom, error) {
 func convertTime32(timestamp uint32) time.Time {
 	return time.Unix(int64(timestamp)-int64(2082844800), 0)
 }
+
 func convertTime64(timestamp uint64) time.Time {
 	// Unix epoch starts on January 1, 1970, subtracting the number of seconds from January 1, 1904 to January 1, 1970.
 	epochOffset := int64(2082844800)

--- a/immich/metadata/search.go
+++ b/immich/metadata/search.go
@@ -23,7 +23,6 @@ func (r *sliceReader) ReadSlice(l int) ([]byte, error) {
 }
 
 func searchPattern(r io.Reader, pattern []byte, buffer []byte) (*sliceReader, error) {
-
 	var err error
 	pos := 0
 	ofs := 0

--- a/immich/metadata/search_test.go
+++ b/immich/metadata/search_test.go
@@ -16,7 +16,7 @@ func GenRandomBytes(size int) (blk []byte) {
 }
 
 func Test_searchPattern(t *testing.T) {
-	var searchBufferSize = 20
+	searchBufferSize := 20
 	tests := []struct {
 		name    string
 		r       io.Reader

--- a/immich/metadata/sidecar.go
+++ b/immich/metadata/sidecar.go
@@ -44,11 +44,9 @@ func (sc *SideCar) Open(fsys fs.FS, name string) (io.ReadCloser, error) {
 	}
 
 	return io.NopCloser(b), nil
-
 }
 
 func (sc *SideCar) Bytes() ([]byte, error) {
-
 	b := bytes.NewBuffer(nil)
 	err := sidecarTemplate.Execute(b, sc)
 	if err != nil {

--- a/immich/trace.go
+++ b/immich/trace.go
@@ -22,6 +22,7 @@ func (sb *smartBodyCloser) Close() error {
 	fmt.Println("\n--- BODY ---")
 	return sb.body.Close()
 }
+
 func (sb *smartBodyCloser) Read(b []byte) (int, error) {
 	return sb.r.Read(b)
 }
@@ -40,6 +41,7 @@ func setTraceJSONRequest() serverRequestOption {
 		return nil
 	}
 }
+
 func setTraceJSONResponse() serverResponseOption {
 	return func(sc *serverCall, resp *http.Response) error {
 		fmt.Println("--- API RESPONSE -- ")
@@ -70,5 +72,4 @@ func traceRequest(req *http.Request) {
 		tr := io.TeeReader(req.Body, os.Stdout)
 		req.Body = &smartBodyCloser{body: req.Body, r: tr}
 	}
-
 }

--- a/internal/xsync/list.go
+++ b/internal/xsync/list.go
@@ -1,0 +1,49 @@
+package xsync
+
+import "sync"
+
+// List is a concurrent safe slice of T.
+type List[T any] struct {
+	lo   sync.RWMutex
+	data []T
+}
+
+// Push pushes the given elems onto l.
+func (l *List[T]) Push(elems ...T) {
+	l.lo.Lock()
+	defer l.lo.Unlock()
+
+	l.data = append(l.data, elems...)
+}
+
+// All safely iterates over l, executing yield for every item.
+// The iterator stops once yield returns false and in turn, All
+// returns false too.
+//
+// NOTE: Once https://github.com/golang/go/issues/61405 has been merged and released
+// ouside of GOEXPERIMENTAL, all references to this method can be rewritten to a simple
+// for-loop.
+func (l *List[T]) All(yield func(T) bool) bool {
+	l.lo.RLock()
+	defer l.lo.RUnlock()
+
+	for _, elem := range l.data {
+		// make a explicit copy – with go 1.22 (https://go.dev/blog/loopvar-preview)
+		// this will not be necessary anymore.
+		elem := elem
+
+		if !yield(elem) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Len returns the number of elements in l.
+func (l *List[T]) Len() int {
+	l.lo.RLock()
+	defer l.lo.RUnlock()
+
+	return len(l.data)
+}

--- a/internal/xsync/worker.go
+++ b/internal/xsync/worker.go
@@ -1,0 +1,61 @@
+package xsync
+
+import "sync"
+
+// Worker is a goroutine pool which allows to load-balance
+// the work over n workers.
+type Worker[T any] struct {
+	// queue holds the enqueued tasks.
+	queue  chan T
+	wg     sync.WaitGroup
+	worker func(T)
+}
+
+// NewWorker returns a fully initialized [Worker] pool.
+// It starts maxWorker goroutines.
+// The max. number of elements which can be enqueued is limited by buffer.
+// For each task enqueued, the worker function will be called.
+func NewWorker[T any](maxWorker uint, worker func(T)) *Worker[T] {
+	wk := &Worker[T]{
+		queue:  make(chan T),
+		worker: worker,
+	}
+
+	wk.startWorker(maxWorker)
+
+	return wk
+}
+
+func (w *Worker[T]) startWorker(n uint) {
+	for i := uint(0); i < n; i++ {
+		w.wg.Add(1)
+		go w.rawWorker()
+	}
+}
+
+// rawWorker is a single worker routine waiting for work.
+func (w *Worker[T]) rawWorker() {
+	defer w.wg.Done()
+
+	for tt := range w.queue {
+		w.worker(tt)
+	}
+}
+
+// Wait waits until all work has been done.
+func (w *Worker[T]) Wait() {
+	w.wg.Wait()
+}
+
+// Finish informs w that no further work will be enqueued.
+// After calling this method, no work shall be enqueued!
+func (w *Worker[T]) Finish() {
+	close(w.queue)
+}
+
+// Enqueue enqueues task to be processed by one of the workers.
+// The method blocks until one of the workers is able to pick up the
+// task.
+func (w *Worker[T]) Enqueue(task T) {
+	w.queue <- task
+}

--- a/logger/log.go
+++ b/logger/log.go
@@ -132,30 +132,35 @@ func (l *Log) DebugObject(name string, v any) {
 	}
 	fmt.Fprintln(l.out)
 }
+
 func (l *Log) Info(f string, v ...any) {
 	if l == nil || l.out == nil {
 		return
 	}
 	l.Message(Info, f, v...)
 }
+
 func (l *Log) OK(f string, v ...any) {
 	if l == nil || l.out == nil {
 		return
 	}
 	l.Message(OK, f, v...)
 }
+
 func (l *Log) Warning(f string, v ...any) {
 	if l == nil || l.out == nil {
 		return
 	}
 	l.Message(Warning, f, v...)
 }
+
 func (l *Log) Error(f string, v ...any) {
 	if l == nil || l.out == nil {
 		return
 	}
 	l.Message(Error, f, v...)
 }
+
 func (l *Log) Fatal(f string, v ...any) {
 	if l == nil || l.out == nil {
 		return

--- a/main.go
+++ b/main.go
@@ -5,16 +5,17 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"immich-go/cmdduplicate"
-	"immich-go/cmdmetadata"
-	"immich-go/cmdstack"
-	"immich-go/cmdtool"
-	"immich-go/cmdupload"
-	"immich-go/helpers/tzone"
-	"immich-go/immich"
-	"immich-go/logger"
 	"os"
 	"os/signal"
+
+	"github.com/simulot/immich-go/cmdduplicate"
+	"github.com/simulot/immich-go/cmdmetadata"
+	"github.com/simulot/immich-go/cmdstack"
+	"github.com/simulot/immich-go/cmdtool"
+	"github.com/simulot/immich-go/cmdupload"
+	"github.com/simulot/immich-go/helpers/tzone"
+	"github.com/simulot/immich-go/immich"
+	"github.com/simulot/immich-go/logger"
 )
 
 var (
@@ -26,7 +27,7 @@ var (
 func main() {
 	fmt.Printf("immich-go  %s, commit %s, built at %s\n", version, commit, date)
 	var err error
-	var log = logger.NewLogger(logger.OK, true, false)
+	log := logger.NewLogger(logger.OK, true, false)
 	// Create a context with cancel function to gracefully handle Ctrl+C events
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -65,7 +66,6 @@ type Application struct {
 
 	Immich *immich.ImmichClient // Immich client
 	Logger *logger.Log          // Program's logger
-
 }
 
 func Run(ctx context.Context, log *logger.Log) (*logger.Log, error) {


### PR DESCRIPTION
This PR, for one, corrects the golang module path in `go.mod` (and all corresponding files).

Additionally, a first base implementation to support multi-core processing is added.

<hr />

As noted in `internal/xsync/list.go`, statements like
```go
		_ = app.deleteServerList.All(func(da *immich.Asset) bool {
			ids = append(ids, da.ID)
			return true
		})
```
can be simplified to
```go
		for ds := range app.deleteServerList.All {
			ids = append(ids, da.ID)
		}
```
once https://github.com/golang/go/issues/61405 is published in a Go release and can be used without a `GOEXPERIMENTAL` flag.

<hr />

- In `browser/gp/googlephotos.go` -> `walk(..)`, there is the following code snippet:
```go
		ext := strings.ToLower(path.Ext(name))
		switch ext {
		case ".json":
			md, err := fshelper.ReadJSON[GoogleMetaData](fsys, name)
			if err == nil {
				// ...
			}
		default:
			// ...
		}

		return nil
```

Is there a case where `fshelper.ReadJSON` will return an error and it should be ignored?


<hr />

In `cmdupload/upload.go` -> `ShouldUpload(...)`:
```go
// ...

	// check all files with the same name
	n := filepath.Base(filename)
	l = ai.ByName(n)
	if len(l) == 0 {
		// n = strings.TrimSuffix(n, filepath.Ext(n))
		l = ai.byName[n]
	}

// ...
```

I removed the `len(l) == 0` check since it does nothing. Is there a special reason why `n = strings.TrimSuffix(n, filepath.Ext(n))` was commented out?