### PR TITLE
Automatically trim / from url, rm main.go from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ immich-go
 .vscode/launch.json
 .vscode/settings.json
 immich-go
-main.go
 
 !readme.md
 

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 
 	"github.com/simulot/immich-go/cmdduplicate"
 	"github.com/simulot/immich-go/cmdmetadata"
@@ -93,6 +94,8 @@ func Run(ctx context.Context, log *logger.Log) (*logger.Log, error) {
 	flag.BoolVar(&app.Debug, "debug", false, "enable debug messages")
 	flag.StringVar(&app.TimeZone, "time-zone", "", "Override the system time zone")
 	flag.Parse()
+
+	app.Server = strings.TrimSuffix(app.Server, "/")
 
 	_, err = tzone.SetLocal(app.TimeZone)
 	if err != nil {


### PR DESCRIPTION
This PR fixes this issue:
```
$ ./immich-go -server 'https://example.com/' -key xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx upload -google-photos /path/to/export/*.zip
immich-go  0.9.1, commit eb5078844270bab6e076931e8bec9b6fd070d725, built at 2023-12-13T17:58:58Z

PingServer, GET, https://example.com//api/server-info/ping, 200 OK
invalid character '<' looking for beginning of value
invalid character '<' looking for beginning of value
```

While 'https://example.com/' is giving above error, 'https://example.com' is working fine.

Currently, there is no error handling, but we don't need to - it's fine to automatically remove `/` from the end of `-server` value if it exists.

Also I've removed `main.go` from `.gitignore` as I assume it was added by accident? This fixes my recently raised https://github.com/simulot/immich-go/issues/101.