### PR TITLE
Ability to exclude directories from local file uploads

### DIFF
--- a/browser/browser.go
+++ b/browser/browser.go
@@ -2,8 +2,24 @@ package browser
 
 import (
 	"context"
+	"regexp"
 )
 
 type Browser interface {
-	Browse(cxt context.Context) chan *LocalAssetFile
+	Browse(cxt context.Context, excludeFiles []string) chan *LocalAssetFile
+}
+
+// Matches takes a directory (not the full path, just the name) and matches it
+// against a set of regexp patterns, returning true if matched.
+func Matches(directory string, regexpPatterns []string) bool {
+	for _, pattern := range regexpPatterns {
+		match, err := regexp.MatchString(pattern, directory)
+		if err != nil {
+			return false
+		}
+		if match {
+			return true
+		}
+	}
+	return false
 }

--- a/browser/files/localassets.go
+++ b/browser/files/localassets.go
@@ -49,6 +49,10 @@ func (la *LocalAssetBrowser) Browse(ctx context.Context, excludePaths []string) 
 						return ctx.Err()
 					default:
 						if d.IsDir() {
+							// TODO:  We're just matching the directory name, here.  If you wanted to be
+							//        more configurable, you could match the full path (i.e., the name variable).
+							//        Probably the best implementation for this would be to have separate -exclude-dirs
+							//        and -exclude-paths, for simplicity.
 							if browser.Matches(d.Name(), excludePaths) {
 								return fs.SkipDir
 							}

--- a/browser/files/localassets.go
+++ b/browser/files/localassets.go
@@ -30,7 +30,7 @@ func NewLocalFiles(ctx context.Context, log *logger.Journal, fsyss ...fs.FS) (*L
 
 var toOldDate = time.Date(1980, 1, 1, 0, 0, 0, 0, time.UTC)
 
-func (la *LocalAssetBrowser) Browse(ctx context.Context) chan *browser.LocalAssetFile {
+func (la *LocalAssetBrowser) Browse(ctx context.Context, excludePaths []string) chan *browser.LocalAssetFile {
 	fileChan := make(chan *browser.LocalAssetFile)
 	// Browse all given FS to collect the list of files
 	go func(ctx context.Context) {
@@ -49,6 +49,9 @@ func (la *LocalAssetBrowser) Browse(ctx context.Context) chan *browser.LocalAsse
 						return ctx.Err()
 					default:
 						if d.IsDir() {
+							if browser.Matches(d.Name(), excludePaths) {
+								return fs.SkipDir
+							}
 							return la.handleFolder(ctx, fsys, fileChan, name)
 						}
 					}

--- a/browser/gp/googlephotos.go
+++ b/browser/gp/googlephotos.go
@@ -403,13 +403,19 @@ func matchForgottenDuplicates(jsonName string, fileName string) bool {
 // Walkers are rewind, and scanned again
 // each file net yet sent to immich is sent with associated metadata
 
-func (to *Takeout) Browse(ctx context.Context) chan *browser.LocalAssetFile {
+func (to *Takeout) Browse(ctx context.Context, excludePaths []string) chan *browser.LocalAssetFile {
 	to.uploaded = map[fileKey]any{}
 	assetChan := make(chan *browser.LocalAssetFile)
 
 	go func() {
 		defer close(assetChan)
 		for _, w := range to.fsyss {
+
+			// TODO:  UpDryTwist, 2024-01-19:  Should be processing the path exclusion using something like:
+			//        if browser.Matches(dirName, excludePatterns) then don't process this directory further.
+			//        However, I don't have a Google Photos account set up to test this, so not implementing at
+			//        this point . . .
+
 			err := to.passTwoWalk(ctx, w, assetChan)
 			if err != nil {
 				assetChan <- &browser.LocalAssetFile{Err: err}

--- a/cmdupload/upload.go
+++ b/cmdupload/upload.go
@@ -56,6 +56,7 @@ type UpCmd struct {
 	Import                 bool             // Import instead of upload
 	DeviceUUID             string           // Set a device UUID
 	Paths                  []string         // Path to explore
+	ExcludePaths           []string         // Paths to exclude
 	DateRange              immich.DateRange // Set capture date range
 	ImportFromAlbum        string           // Import assets from this albums
 	CreateAlbums           bool             // Create albums when exists in the source
@@ -157,6 +158,9 @@ func NewUpCmd(ctx context.Context, ic iClient, log logger.Logger, args []string)
 	cmd.Var(&app.BrowserConfig.SelectExtensions, "select-types", "list of selected extensions separated by a comma")
 	cmd.Var(&app.BrowserConfig.ExcludeExtensions, "exclude-types", "list of excluded extensions separated by a comma")
 
+	var excludePaths string
+	cmd.StringVar(&excludePaths, "exclude-dirs", "", "list of excluded dirs (regexp) separated by a comma")
+
 	err = cmd.Parse(args)
 	if err != nil {
 		return nil, err
@@ -234,7 +238,7 @@ func (app *UpCmd) Run(ctx context.Context, fsyss []fs.FS) error {
 	}
 	app.Journal.Message(logger.OK, "Done.")
 
-	assetChan := browser.Browse(ctx)
+	assetChan := browser.Browse(ctx, app.ExcludePaths)
 assetLoop:
 	for {
 		select {

--- a/cmdupload/upload.go
+++ b/cmdupload/upload.go
@@ -167,6 +167,9 @@ func NewUpCmd(ctx context.Context, ic iClient, log logger.Logger, args []string)
 	}
 
 	app.ExcludePaths = strings.Split(excludePaths, ",")
+	for i, str := range app.ExcludePaths {
+		app.ExcludePaths[i] = strings.TrimSpace(str)
+	}
 
 	if err = app.BrowserConfig.IsValid(); err != nil {
 		return nil, err

--- a/cmdupload/upload.go
+++ b/cmdupload/upload.go
@@ -162,6 +162,8 @@ func NewUpCmd(ctx context.Context, ic iClient, log logger.Logger, args []string)
 		return nil, err
 	}
 
+	app.ExcludePaths = strings.Split(excludePaths, ",")
+
 	if err = app.BrowserConfig.IsValid(); err != nil {
 		return nil, err
 	}

--- a/readme.md
+++ b/readme.md
@@ -71,7 +71,9 @@ Use this command for uploading photos and videos from a local directory, a zippe
 `-stack-burst <bool>`Control the stacking bursts (default TRUE).<br>
 `-select-types .ext,.ext,.ext...` List of accepted extensions. <br>
 `-exclude-types .ext,.ext,.ext...` List of excluded extensions. <br>
-`-exclude-dirs dir-regex,dir-regex...` List of directories (specified by regular expression, separated by commas) to exclude.  Not working for GP - only local directories<br> 
+`-exclude-dirs dir-regex,dir-regex...` List of directories (specified by regular expression, separated by commas) to exclude.  Not working for GP - only local directories.
+  Note that the regular expression will match any portion of the string if not started with ^.  So, for example, 1980 will match MyFiles-1980-Etc.  If you just wanted to match
+  explicitly, say, directories starting with 1980, use ^1980.*<br> 
 
 ### Date selection:
 Fine-tune import based on specific dates:<br>

--- a/readme.md
+++ b/readme.md
@@ -71,6 +71,7 @@ Use this command for uploading photos and videos from a local directory, a zippe
 `-stack-burst <bool>`Control the stacking bursts (default TRUE).<br>
 `-select-types .ext,.ext,.ext...` List of accepted extensions. <br>
 `-exclude-types .ext,.ext,.ext...` List of excluded extensions. <br>
+`-exclude-dirs dir-regex,dir-regex...` List of directories (specified by regular expression, separated by commas) to exclude.  Not working for GP - only local directories<br> 
 
 ### Date selection:
 Fine-tune import based on specific dates:<br>


### PR DESCRIPTION

Added the ability to exclude directories (specified by a regular expression, multiple separated by commas) from upload by using the -exclude-dirs flag.  As I don't have GP, only implemented this for a local directory, but put a TODO in the code where this could/should be possibly extended to cover GP as well (in googlephotos.go).

Example:
  immich-go -server https://blah -key blah upload -exclude-dirs "DoNotIncludeMe, NorAnythingLike.*, .*1987.*" /my/local/photos

Which would then exclude (as examples):
- DoNotIncludeMe
- NorAnythingLikeThisOrOthers
- Photos-1987-EmbarassingCollegeYears

Note that it only matches on the directory name, not the full path.  I left a TODO in the code with a recommendation for how to extend to the full path (I think I'd do it with a separate flag - -exclude-paths - for clarity).