### PR TITLE
update create time when remote does not have one

### DIFF
--- a/cmd/upload/assets.go
+++ b/cmd/upload/assets.go
@@ -23,13 +23,12 @@ func (ai *AssetIndex) ReIndex() {
 	ai.byID = map[string]*immich.Asset{}
 
 	for _, a := range ai.assets {
-		ext := path.Ext(a.OriginalPath)
-		ID := fmt.Sprintf("%s-%d", strings.ToUpper(path.Base(a.OriginalFileName)+ext), a.ExifInfo.FileSizeInByte)
+		ID := fmt.Sprintf("%s-%d", strings.ToUpper(path.Base(a.OriginalFileName)), a.ExifInfo.FileSizeInByte)
 		l := ai.byHash[a.Checksum]
 		l = append(l, a)
 		ai.byHash[a.Checksum] = l
 
-		n := a.OriginalFileName + ext
+		n := a.OriginalFileName
 		l = ai.byName[n]
 		l = append(l, a)
 		ai.byName[n] = l

--- a/immich/asset.go
+++ b/immich/asset.go
@@ -226,21 +226,25 @@ func (ic *ImmichClient) UpdateAssets(ctx context.Context, ids []string,
 
 func (ic *ImmichClient) UpdateAsset(ctx context.Context, id string, a *browser.LocalAssetFile) (*Asset, error) {
 	type updAsset struct {
-		IsArchived  bool    `json:"isArchived"`
-		IsFavorite  bool    `json:"isFavorite"`
-		Latitude    float64 `json:"latitude,omitempty"`
-		Longitude   float64 `json:"longitude,omitempty"`
-		Description string  `json:"description,omitempty"`
+		DateTimeOriginal string   `json:"dateTimeOriginal"`
+		IDs              []string `json:"ids"`
+		IsArchived       bool     `json:"isArchived"`
+		IsFavorite       bool     `json:"isFavorite"`
+		Latitude         float64  `json:"latitude,omitempty"`
+		Longitude        float64  `json:"longitude,omitempty"`
+		Description      string   `json:"description,omitempty"`
 	}
 	param := updAsset{
-		Description: a.Description,
-		IsArchived:  a.Archived,
-		IsFavorite:  a.Favorite,
-		Latitude:    a.Latitude,
-		Longitude:   a.Longitude,
+		DateTimeOriginal: a.DateTaken.Format(time.RFC3339),
+		IDs:              []string{id},
+		Description:      a.Description,
+		IsArchived:       a.Archived,
+		IsFavorite:       a.Favorite,
+		Latitude:         a.Latitude,
+		Longitude:        a.Longitude,
 	}
 	r := Asset{}
-	err := ic.newServerCall(ctx, "updateAsset").do(put("/asset/"+id, setJSONBody(param)), responseJSON(&r))
+	err := ic.newServerCall(ctx, "updateAsset").do(put("/asset/", setJSONBody(param)), responseJSON(&r))
 	return &r, err
 }
 

--- a/logger/journal.go
+++ b/logger/journal.go
@@ -14,26 +14,27 @@ type Journal struct {
 type Action string
 
 const (
-	DiscoveredFile     Action = "File"
-	ScannedImage       Action = "Scanned image"
-	ScannedVideo       Action = "Scanned video"
-	Discarded          Action = "Discarded"
-	Uploaded           Action = "Uploaded"
-	Upgraded           Action = "Server's asset upgraded"
-	ERROR              Action = "Error"
-	LocalDuplicate     Action = "Local duplicate"
-	ServerDuplicate    Action = "Server has photo"
-	Stacked            Action = "Stacked"
-	ServerBetter       Action = "Server's asset is better"
-	Album              Action = "Added to an album"
-	LivePhoto          Action = "Live photo"
-	FailedVideo        Action = "Failed video"
-	Unsupported        Action = "File type not supported"
-	Metadata           Action = "Metadata files"
-	AssociatedMetadata Action = "Associated with metadata"
-	INFO               Action = "Info"
-	NotSelected        Action = "Not selected because options"
-	ServerError        Action = "Server error"
+	DiscoveredFile      Action = "File"
+	ScannedImage        Action = "Scanned image"
+	ScannedVideo        Action = "Scanned video"
+	Discarded           Action = "Discarded"
+	Uploaded            Action = "Uploaded"
+	Upgraded            Action = "Server's asset upgraded"
+	ERROR               Action = "Error"
+	LocalDuplicate      Action = "Local duplicate"
+	ServerDuplicate     Action = "Server has photo"
+	Stacked             Action = "Stacked"
+	ServerBetter        Action = "Server's asset is better"
+	LocalMetadataBetter Action = "Server's asset is identical, but better local metadata"
+	Album               Action = "Added to an album"
+	LivePhoto           Action = "Live photo"
+	FailedVideo         Action = "Failed video"
+	Unsupported         Action = "File type not supported"
+	Metadata            Action = "Metadata files"
+	AssociatedMetadata  Action = "Associated with metadata"
+	INFO                Action = "Info"
+	NotSelected         Action = "Not selected because options"
+	ServerError         Action = "Server error"
 )
 
 func NewJournal(log Logger) *Journal {
@@ -89,6 +90,7 @@ func (j *Journal) Report() {
 	j.Log.OK("%6d uploaded files on the server", j.counts[Uploaded])
 	j.Log.OK("%6d upgraded files on the server", j.counts[Upgraded])
 	j.Log.OK("%6d files already on the server", j.counts[ServerDuplicate])
+	j.Log.OK("%6d files adready on the server, but updated create time", j.counts[LocalMetadataBetter])
 	j.Log.OK("%6d discarded files because of options", j.counts[NotSelected])
 	j.Log.OK("%6d discarded files because duplicated in the input", j.counts[LocalDuplicate])
 	j.Log.OK("%6d discarded files because server has a better image", j.counts[ServerBetter])


### PR DESCRIPTION
I uploaded my takeout directly naively, so all the times were incorrect. I updated this tool to be able to detect when the local and remote file are the same, but the local timestamp is *older* then the remote one, which indicates that the local one is better because bad timestamps seem to always be newer than real ones as they are fabricated from when downloaded from google or when uploaded to immich

There were other bugs that needed fixing for this--OriginalFileName already had the extension, so I removed the + ext. Also, the updateAsset API seems to have been updated since you added it.

Interestingly, the timeline does *not* update correctly after this, but the metadata when you click on an image is correct. I assume this is an immich bug...