### PR TITLE
Ignore extension when deduplicating option

### DIFF
--- a/cmd/duplicate/duplicate.go
+++ b/cmd/duplicate/duplicate.go
@@ -21,10 +21,10 @@ import (
 
 type DuplicateCmd struct {
 	*cmd.SharedFlags
-	AssumeYes       bool             	// When true, doesn't ask to the user
-	DateRange       immich.DateRange 	// Set capture date range
-	IgnoreTZErrors  bool             	// Enable TZ error tolerance
-	IgnoreExtension bool				// Ignore file extensions when checking for duplicates
+	AssumeYes       bool             // When true, doesn't ask to the user
+	DateRange       immich.DateRange // Set capture date range
+	IgnoreTZErrors  bool             // Enable TZ error tolerance
+	IgnoreExtension bool             // Ignore file extensions when checking for duplicates
 
 	assetsByID          map[string]*immich.Asset
 	assetsByBaseAndDate map[duplicateKey][]*immich.Asset
@@ -52,7 +52,7 @@ func NewDuplicateCmd(ctx context.Context, common *cmd.SharedFlags, args []string
 	cmd.BoolFunc("ignore-tz-errors", "Ignore timezone difference to check duplicates (default: FALSE).", myflag.BoolFlagFn(&app.IgnoreTZErrors, false))
 	cmd.BoolFunc("yes", "When true, assume Yes to all actions", myflag.BoolFlagFn(&app.AssumeYes, false))
 	cmd.Var(&app.DateRange, "date", "Process only documents having a capture date in that range.")
-	cmd.BoolFunc("ignore-extension", "When true, ignores extensions when checking for duplicates (defailt: FALSE)", myflag.BoolFlagFn(&app.IgnoreExtension, false))
+	cmd.BoolFunc("ignore-extension", "When true, ignores extensions when checking for duplicates (default: FALSE)", myflag.BoolFlagFn(&app.IgnoreExtension, false))
 	err := cmd.Parse(args)
 	if err != nil {
 		return nil, err
@@ -89,9 +89,9 @@ func DuplicateCommand(ctx context.Context, common *cmd.SharedFlags, args []strin
 			Name: strings.ToUpper(a.OriginalFileName + path.Ext(a.OriginalPath)),
 			Type: a.Type,
 		}
-		
+
 		if app.IgnoreExtension {
-			k.Name, _, _ = strings.Cut(k.Name, path.Ext(a.OriginalPath))
+			k.Name = strings.TrimSuffix(k.Name, path.Ext(a.OriginalPath))
 		}
 		l := app.assetsByBaseAndDate[k]
 		if len(l) > 0 {

--- a/cmd/duplicate/duplicate.go
+++ b/cmd/duplicate/duplicate.go
@@ -52,7 +52,7 @@ func NewDuplicateCmd(ctx context.Context, common *cmd.SharedFlags, args []string
 	cmd.BoolFunc("ignore-tz-errors", "Ignore timezone difference to check duplicates (default: FALSE).", myflag.BoolFlagFn(&app.IgnoreTZErrors, false))
 	cmd.BoolFunc("yes", "When true, assume Yes to all actions", myflag.BoolFlagFn(&app.AssumeYes, false))
 	cmd.Var(&app.DateRange, "date", "Process only documents having a capture date in that range.")
-	cmd.BoolFunc("ignore-ext", "When true, ignores extensions when checking for duplicates (defailt: FALSE)", myflag.BoolFlagFn(&app.IgnoreExtension, false))
+	cmd.BoolFunc("ignore-extension", "When true, ignores extensions when checking for duplicates (defailt: FALSE)", myflag.BoolFlagFn(&app.IgnoreExtension, false))
 	err := cmd.Parse(args)
 	if err != nil {
 		return nil, err

--- a/cmd/duplicate/duplicate.go
+++ b/cmd/duplicate/duplicate.go
@@ -21,9 +21,10 @@ import (
 
 type DuplicateCmd struct {
 	*cmd.SharedFlags
-	AssumeYes      bool             // When true, doesn't ask to the user
-	DateRange      immich.DateRange // Set capture date range
-	IgnoreTZErrors bool             // Enable TZ error tolerance
+	AssumeYes       bool             	// When true, doesn't ask to the user
+	DateRange       immich.DateRange 	// Set capture date range
+	IgnoreTZErrors  bool             	// Enable TZ error tolerance
+	IgnoreExtension bool				// Ignore file extensions when checking for duplicates
 
 	assetsByID          map[string]*immich.Asset
 	assetsByBaseAndDate map[duplicateKey][]*immich.Asset
@@ -32,6 +33,7 @@ type DuplicateCmd struct {
 type duplicateKey struct {
 	Date time.Time
 	Name string
+	Type string
 }
 
 func NewDuplicateCmd(ctx context.Context, common *cmd.SharedFlags, args []string) (*DuplicateCmd, error) {
@@ -50,6 +52,7 @@ func NewDuplicateCmd(ctx context.Context, common *cmd.SharedFlags, args []string
 	cmd.BoolFunc("ignore-tz-errors", "Ignore timezone difference to check duplicates (default: FALSE).", myflag.BoolFlagFn(&app.IgnoreTZErrors, false))
 	cmd.BoolFunc("yes", "When true, assume Yes to all actions", myflag.BoolFlagFn(&app.AssumeYes, false))
 	cmd.Var(&app.DateRange, "date", "Process only documents having a capture date in that range.")
+	cmd.BoolFunc("ignore-ext", "When true, ignores extensions when checking for duplicates (defailt: FALSE)", myflag.BoolFlagFn(&app.IgnoreExtension, false))
 	err := cmd.Parse(args)
 	if err != nil {
 		return nil, err
@@ -84,8 +87,12 @@ func DuplicateCommand(ctx context.Context, common *cmd.SharedFlags, args []strin
 		k := duplicateKey{
 			Date: d,
 			Name: strings.ToUpper(a.OriginalFileName + path.Ext(a.OriginalPath)),
+			Type: a.Type,
 		}
-
+		
+		if app.IgnoreExtension {
+			k.Name, _, _ = strings.Cut(k.Name, path.Ext(a.OriginalPath))
+		}
 		l := app.assetsByBaseAndDate[k]
 		if len(l) > 0 {
 			dupCount++

--- a/readme.md
+++ b/readme.md
@@ -147,6 +147,7 @@ Before deleting the inferior copies, the system get all albums they belong to, a
 | `-yes`                     | Assume Yes to all questions                                 | `FALSE`                 |
 | `-date`                    | Check only assets have a date of capture in the given range | `1850-01-04,2030-01-01` |
 | `-ignore-tz-errors <bool>` | Ignore timezone difference when searching for duplicates    | `FALSE`                 |
+| `-ignore-extension`        | Ignore filetype extensions when searching for duplicates    | `FALSE`                 |
 
 ### Example Usage: clean the `immich` server after having merged a google photo archive and original files
 


### PR DESCRIPTION
Implements duplication checking while ignoring file extensions. Addresses feature request I had mentioned in #191. Uses `a.Type` to add an extra layer of security when determining if files are duplicates. Feature can be invoked using `-ignore-extension` in the command line