### PR TITLE
Automatically pick go version from go.mod file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21.x
+          go-version-file: "go.mod"
           cache-dependency-path: "go.sum"
 
       - name: golangci-lint


### PR DESCRIPTION
With this PR, you would no longer need to update go version in workflow file as it would be picked directly from go.mod file.

See: https://github.com/actions/setup-go?tab=readme-ov-file#getting-go-version-from-the-gomod-file