### PR TITLE
Fix stack command

### DIFF
--- a/cmd/stack/stack.go
+++ b/cmd/stack/stack.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"path"
 	"sort"
 	"strconv"
 
@@ -65,7 +64,7 @@ func NewStackCommand(ctx context.Context, common *cmd.SharedFlags, args []string
 			return nil
 		}
 		assetCount += 1
-		sb.ProcessAsset(a.ID, a.OriginalFileName+path.Ext(a.OriginalPath), a.ExifInfo.DateTimeOriginal.Time)
+		sb.ProcessAsset(a.ID, a.OriginalFileName, a.ExifInfo.DateTimeOriginal.Time)
 		return nil
 	})
 	if err != nil {

--- a/cmd/stack/stack.go
+++ b/cmd/stack/stack.go
@@ -20,7 +20,7 @@ type StackCmd struct {
 	DateRange immich.DateRange // Set capture date range
 }
 
-func initSack(ctx context.Context, common *cmd.SharedFlags, args []string) (*StackCmd, error) {
+func initStack(ctx context.Context, common *cmd.SharedFlags, args []string) (*StackCmd, error) {
 	cmd := flag.NewFlagSet("stack", flag.ExitOnError)
 	validRange := immich.DateRange{}
 
@@ -48,7 +48,7 @@ func initSack(ctx context.Context, common *cmd.SharedFlags, args []string) (*Sta
 }
 
 func NewStackCommand(ctx context.Context, common *cmd.SharedFlags, args []string) error {
-	app, err := initSack(ctx, common, args)
+	app, err := initStack(ctx, common, args)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Issue
I noticed that `immich-go 0.17.1` doesn't find stackable photos on my instance of `Immich 1.106.4` so I started debugging from the source code and found out that it was adding an extra extension to the image name (for example, image `Agc20230714_115348466.dng` was being found as `Agc20230714_115348466.dng.dng` by `immich-go` in the `immich.Asset` var thus not recognising it as stackable).

### How i fixed it
I fixed it by removing the extra extension as a.OriginalFileName already contains the extension of the file. I also fixed a typo meanwhile.

### PR
This PR fixes stack command and should close issues #235 and #240

If anything needs to be changed let me know