### PR TITLE
fix: Do not require value for version call

### DIFF
--- a/main.go
+++ b/main.go
@@ -50,10 +50,12 @@ func getCommitInfo() string {
 	return commit
 }
 
+func printVersion() {
+	fmt.Printf("immich-go  %s, commit %s, built at %s\n", version, getCommitInfo(), date)
+}
+
 func main() {
 	var err error
-
-	fmt.Printf("immich-go  %s, commit %s, built at %s\n", version, getCommitInfo(), date)
 
 	// Create a context with cancel function to gracefully handle Ctrl+C events
 	ctx, cancel := context.WithCancel(context.Background())
@@ -87,7 +89,7 @@ func Run(ctx context.Context) error {
 	}
 	fs := flag.NewFlagSet("main", flag.ExitOnError)
 	fs.BoolFunc("version", "Get immich-go version", func(s string) error {
-		fmt.Println("immich-go", version)
+		printVersion()
 		os.Exit(0)
 		return nil
 	})
@@ -100,6 +102,8 @@ func Run(ctx context.Context) error {
 		app.Log.Error(err.Error())
 		return err
 	}
+
+	printVersion()
 	fmt.Println(app.Banner.String())
 
 	if len(fs.Args()) == 0 {

--- a/main.go
+++ b/main.go
@@ -86,7 +86,7 @@ func Run(ctx context.Context) error {
 		Banner: ui.NewBanner(version, commit, date),
 	}
 	fs := flag.NewFlagSet("main", flag.ExitOnError)
-	fs.Func("version", "Get immich-go version", func(s string) error {
+	fs.BoolFunc("version", "Get immich-go version", func(s string) error {
 		fmt.Println("immich-go", version)
 		os.Exit(0)
 		return nil


### PR DESCRIPTION
The current `-version` call requires an additional "value" to exist, although it is not used.
I assume it should've been the `BoolFunc` function that does not require a value to be set.
But the output still contains the default header, so the output of `immich-go -version` command looks like:

```
immich-go  0.18.2, commit 4fa283d1a41f33c83df71618f1115e737b1e19fc, built at 2024-07-03T08:48:52Z
immich-go 0.18.2
```

Is this the expected behaviour?
