### PR TITLE
Add support for -use-full-path-album-name to be able to use the full path to the file as album name/title

### DIFF
--- a/browser/files/localassets.go
+++ b/browser/files/localassets.go
@@ -275,6 +275,7 @@ func (la *LocalAssetBrowser) assetFromFile(fsys fs.FS, name string) (*browser.Lo
 	if fsys, ok := fsys.(fshelper.NameFS); ok {
 		fullPath = filepath.Join(fsys.Name(), name)
 	}
+
 	a.Metadata.DateTaken = metadata.TakeTimeFromPath(fullPath)
 
 	i, err := fs.Stat(fsys, name)

--- a/cmd/upload/upload_test.go
+++ b/cmd/upload/upload_test.go
@@ -466,7 +466,51 @@ func TestUpload(t *testing.T) {
 				},
 			},
 		},
-
+		{
+			name: "folder and albums creation using full path",
+			args: []string{
+				"-create-album-folder",
+				"-use-full-path-album-name",
+				"TEST_DATA/Takeout2",
+			},
+			expectedAssets: []string{
+				"Google Photos/Photos from 2023/PXL_20231006_063528961.jpg",
+				"Google Photos/Photos from 2023/PXL_20231006_063000139.jpg",
+				"Google Photos/Sans titre(9)/PXL_20231006_063108407.jpg",
+			},
+			expectedAlbums: map[string][]string{
+				"Google Photos Photos from 2023": {
+					"Google Photos/Photos from 2023/PXL_20231006_063000139.jpg",
+					"Google Photos/Photos from 2023/PXL_20231006_063528961.jpg",
+				},
+				"Google Photos Sans titre(9)": {
+					"Google Photos/Sans titre(9)/PXL_20231006_063108407.jpg",
+				},
+			},
+		},
+		{
+			name: "folder and albums creation using full path and custom separator",
+			args: []string{
+				"-create-album-folder",
+				"-use-full-path-album-name",
+				"-album-name-path-separator= & ",
+				"TEST_DATA/Takeout2",
+			},
+			expectedAssets: []string{
+				"Google Photos/Photos from 2023/PXL_20231006_063528961.jpg",
+				"Google Photos/Photos from 2023/PXL_20231006_063000139.jpg",
+				"Google Photos/Sans titre(9)/PXL_20231006_063108407.jpg",
+			},
+			expectedAlbums: map[string][]string{
+				"Google Photos & Photos from 2023": {
+					"Google Photos/Photos from 2023/PXL_20231006_063000139.jpg",
+					"Google Photos/Photos from 2023/PXL_20231006_063528961.jpg",
+				},
+				"Google Photos & Sans titre(9)": {
+					"Google Photos/Sans titre(9)/PXL_20231006_063108407.jpg",
+				},
+			},
+		},
 		//		// {
 		//		// 	name: "google photo, homonyms, keep partner",
 		//		// 	args: []string{

--- a/readme.md
+++ b/readme.md
@@ -95,17 +95,19 @@ Use this command for uploading photos and videos from a local directory, a zippe
 
 ### Switches and options:
 
-| **Parameter**                        | **Description**                                                                                    | **Default value**                                                                         |
-| ------------------------------------ | -------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| `-album="ALBUM NAME"`                | Import assets into the Immich album `ALBUM NAME`.                                                  |                                                                                           |
-| `-dry-run`                           | Preview all actions as they would be done.                                                         | `FALSE`                                                                                   |
-| `-create-album-folder`               | Generate immich albums after folder names.                                                         | `FALSE`                                                                                   |
-| `-create-stacks`                     | Stack jpg/raw or bursts.                                                                           | `FALSE`                                                                                   |
-| `-stack-jpg-raw`                     | Control the stacking of jpg/raw photos.                                                            | `FALSE`                                                                                   |
-| `-stack-burst`                       | Control the stacking bursts.                                                                       | `FALSE`                                                                                    |
-| `-select-types=".ext,.ext,.ext..."`  | List of accepted extensions.                                                                       |                                                                                           |
-| `-exclude-types=".ext,.ext,.ext..."` | List of excluded extensions.                                                                       |                                                                                           |
-| `-when-no-date=FILE\|NOW`            | When the date of take can't be determined, use the FILE's date or the current time NOW.            | `FILE`                                                                                    |
+| **Parameter**                        | **Description**                                                                                 | **Default value**                                                                         |
+|--------------------------------------|-------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|
+| `-album="ALBUM NAME"`                | Import assets into the Immich album `ALBUM NAME`.                                               |                                                                                           |
+| `-dry-run`                           | Preview all actions as they would be done.                                                      | `FALSE`                                                                                   |
+| `-create-album-folder`               | Generate immich albums after folder names.                                                      | `FALSE`                                                                                   |
+| `-use-full-path-album-name`          | Use the full path to the file to determine the album name.                                      | `FALSE`                                                                                   |
+| `-album-name-path-separator`         | Determines how multiple (sub) folders, if any, will be joined                                   | ` `                                                                                       |
+| `-create-stacks`                     | Stack jpg/raw or bursts.                                                                        | `FALSE`                                                                                   |
+| `-stack-jpg-raw`                     | Control the stacking of jpg/raw photos.                                                         | `FALSE`                                                                                   |
+| `-stack-burst`                       | Control the stacking bursts.                                                                    | `FALSE`                                                                                   |
+| `-select-types=".ext,.ext,.ext..."`  | List of accepted extensions.                                                                    |                                                                                           |
+| `-exclude-types=".ext,.ext,.ext..."` | List of excluded extensions.                                                                    |                                                                                           |
+| `-when-no-date=FILE\|NOW`            | When the date of take can't be determined, use the FILE's date or the current time NOW.         | `FILE`                                                                                    |
 | `-exclude-files=pattern`             | Ignore files based on a pattern. Case insensitive. Repeat the option for each pattern do you need. | `@eaDir/`<br>`@__thumb/`<br>`SYNOFILE_THUMB_*.*`<br>`Lightroom Catalog/`<br>`thumbnails/` |
 
 ### Date selection:


### PR DESCRIPTION
As discussed in https://github.com/simulot/immich-go/issues/159, this adds a feature flag to use the full path towards the asset for determing the album name, instead of always picking the deepest subfolder. 