### PR TITLE
Fix: support large file sizes on 32 bit archs

### DIFF
--- a/cmd/upload/assets.go
+++ b/cmd/upload/assets.go
@@ -46,7 +46,7 @@ func (ai *AssetIndex) AddLocalAsset(la *browser.LocalAssetFile, immichID string)
 		DeviceAssetID:    la.DeviceAssetID(),
 		OriginalFileName: strings.TrimSuffix(path.Base(la.Title), path.Ext(la.Title)),
 		ExifInfo: immich.ExifInfo{
-			FileSizeInByte:   int(la.Size()),
+			FileSizeInByte:   int64(la.Size()),
 			DateTimeOriginal: immich.ImmichTime{Time: la.Metadata.DateTaken},
 			Latitude:         la.Metadata.Latitude,
 			Longitude:        la.Metadata.Longitude,

--- a/cmd/upload/upload.go
+++ b/cmd/upload/upload.go
@@ -833,7 +833,7 @@ type Advice struct {
 	LocalAsset  *browser.LocalAssetFile
 }
 
-func formatBytes(s int) string {
+func formatBytes(s int64) string {
 	suffixes := []string{"B", "KB", "MB", "GB"}
 	bytes := float64(s)
 	base := 1024.0
@@ -912,7 +912,7 @@ func (ai *AssetIndex) ShouldUpload(la *browser.LocalAssetFile) (*Advice, error) 
 
 	if len(l) > 0 {
 		dateTaken := la.Metadata.DateTaken
-		size := int(la.Size())
+		size := int64(la.Size())
 
 		for _, sa = range l {
 			compareDate := compareDate(dateTaken, sa.ExifInfo.DateTimeOriginal.Time)

--- a/immich/immich.go
+++ b/immich/immich.go
@@ -152,7 +152,7 @@ type ExifInfo struct {
 	Model            string     `json:"model"`
 	ExifImageWidth   int        `json:"exifImageWidth"`
 	ExifImageHeight  int        `json:"exifImageHeight"`
-	FileSizeInByte   int        `json:"fileSizeInByte"`
+	FileSizeInByte   int64      `json:"fileSizeInByte"`
 	Orientation      string     `json:"orientation"`
 	DateTimeOriginal ImmichTime `json:"dateTimeOriginal,omitempty"`
 	// 	ModifyDate       time.Time `json:"modifyDate"`

--- a/ui/size.go
+++ b/ui/size.go
@@ -5,7 +5,7 @@ import (
 	"math"
 )
 
-func FormatBytes(s int) string {
+func FormatBytes(s int64) string {
 	suffixes := []string{"B", "KB", "MB", "GB"}
 	bytes := float64(s)
 	base := 1024.0


### PR DESCRIPTION
Fixes the following error message:

```
cannot unmarshal number into Go struct field
ExifInfo.Assets.items.exifInfo.fileSizeInByte of type int
```

This is caused by a video in immich that is larger than can fit into an int32.