### PR TITLE
Add hint to use -google-photos option under upload documentation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -96,6 +96,8 @@ Example: Immich-go check the server's SSL certificate. you can disable this beha
 
 Use this command for uploading photos and videos from a local directory, a zipped folder or all zip files that the Google Photos takeout procedure has generated.
 
+> ℹ️ If you are uploading from Google Photos don't forget the `-google-photos` option (see below documentation for more details)
+
 ### Switches and options:
 
 | **Parameter**                        | **Description**                                                                                 | **Default value**                                                                         |


### PR DESCRIPTION
If a user is skimming the documentation it can be easy to miss (e.g. #473), add a small hint to make it more obvious.