### PR TITLE
chore: update StackAssets after deprecation of stackParentId

### DIFF
--- a/cmd/stack/stack.go
+++ b/cmd/stack/stack.go
@@ -92,7 +92,7 @@ func NewStackCommand(ctx context.Context, common *cmd.SharedFlags, args []string
 			}
 		}
 		if yes {
-			err := app.Immich.StackAssets(ctx, cover, s.IDs)
+			_, err := app.Immich.StackAssets(ctx, cover, s.IDs)
 			if err != nil {
 				fmt.Printf("Can't stack images: %s\n", err)
 			}

--- a/cmd/upload/upload.go
+++ b/cmd/upload/upload.go
@@ -378,7 +378,7 @@ assetLoop:
 				}
 				app.Log.Info(fmt.Sprintf("Stacking %s...", strings.Join(s.Names, ", ")))
 				if !app.DryRun {
-					err = app.Immich.StackAssets(ctx, s.CoverID, s.IDs)
+					_, err = app.Immich.StackAssets(ctx, s.CoverID, s.IDs)
 					if err != nil {
 						app.Log.Error(fmt.Sprintf("Can't stack images: %s", err))
 					}

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -5,6 +5,12 @@
 - [Github Sponsor page](https://github.com/sponsors/simulot)
 - [paypal donor page](https://www.paypal.com/donate/?hosted_button_id=VGU2SQE88T2T4)
 
+## Release 0.22.1
+
+### Fixes:
+- [#509](https://github.com/simulot/immich-go/issues/509)      
+
+
 ## Release 0.22.0
 Many thanks to @maybeanerd for their meticulous proofreading of the documentation files.
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -5,6 +5,36 @@
 - [Github Sponsor page](https://github.com/sponsors/simulot)
 - [paypal donor page](https://www.paypal.com/donate/?hosted_button_id=VGU2SQE88T2T4)
 
+## Release 0.22.0
+Many thanks to @maybeanerd for their meticulous proofreading of the documentation files.
+
+### New feature: Use the full image path as album name
+Thanks to @giejay for their contribution
+When the `-use-full-path-album-name` option is enabled, photos are added to a new album named after their full file path.
+The path separator can be replaced using the `-album-name-path-separator=CHAR`
+
+
+### New feature: google photos archived photos are imported as immich archive by default
+Thanks to @Alex1607 for their contribution
+Use the option `-auto-archive=FALSE` to disable this feature.
+
+### What's Changed
+* fix Takeout zip is unsupported file type #357 by @simulot in https://github.com/simulot/immich-go/pull/415
+* docs: fix typos in readme by @maybeanerd in https://github.com/simulot/immich-go/pull/421
+* Program errors out due to no ping API response despite API responding by @simulot in https://github.com/simulot/immich-go/pull/431
+* remove "GetJobs" call from API traces by @simulot in https://github.com/simulot/immich-go/pull/442
+* Add support for -use-full-path-album-name to be able to use the full path to the file as album name/title by @giejay in https://github.com/simulot/immich-go/pull/444
+* Documentation-update by @simulot in https://github.com/simulot/immich-go/pull/446
+* Add new AutoArchive option by @Alex1607 in https://github.com/simulot/immich-go/pull/450
+* Update README.md, google-takeout.md, and motivation.md by @aaronjrodrigues in https://github.com/simulot/immich-go/pull/454
+
+### New Contributors
+* @maybeanerd made their first contribution in https://github.com/simulot/immich-go/pull/421
+* @giejay made their first contribution in https://github.com/simulot/immich-go/pull/444
+* @Alex1607 made their first contribution in https://github.com/simulot/immich-go/pull/450
+
+**Full Changelog**: https://github.com/simulot/immich-go/compare/0.21.0...0.22.0
+
 ## Release 0.21.1
 
 ### Fixes:

--- a/immich/asset.go
+++ b/immich/asset.go
@@ -312,11 +312,14 @@ func (ic *ImmichClient) UpdateAsset(ctx context.Context, id string, a *browser.L
 	return &r, err
 }
 
-func (ic *ImmichClient) StackAssets(ctx context.Context, coverID string, ids []string) error {
-	cover, err := ic.GetAssetByID(ctx, coverID)
-	if err != nil {
-		return err
+func (ic *ImmichClient) StackAssets(ctx context.Context, coverID string, ids []string) (*Stack, error) {
+	stackIds := append([]string{coverID}, ids...)
+	body := struct {
+		AssetIDs []string `json:"assetIds"`
+	}{
+		AssetIDs: stackIds,
 	}
-
-	return ic.UpdateAssets(ctx, ids, cover.IsArchived, cover.IsFavorite, cover.ExifInfo.Latitude, cover.ExifInfo.Longitude, false, coverID)
+	stackResponse := Stack{}
+	err := ic.newServerCall(ctx, "stackAssets").do(postRequest("/stacks", "application/json", setJSONBody(body)), responseJSON(&stackResponse))
+	return &stackResponse, err
 }

--- a/immich/client.go
+++ b/immich/client.go
@@ -113,9 +113,9 @@ func NewImmichClient(endPoint string, key string, options ...clientOption) (*Imm
 func (ic *ImmichClient) PingServer(ctx context.Context) error {
 	r := PingResponse{}
 	b := bytes.NewBuffer(nil)
-	err := ic.newServerCall(ctx, EndPointPingServer).do(getRequest("/server-info/ping", setAcceptJSON()), responseCopy(b), responseJSON(&r))
+	err := ic.newServerCall(ctx, EndPointPingServer).do(getRequest("/server/ping", setAcceptJSON()), responseCopy(b), responseJSON(&r))
 	if err != nil {
-		return fmt.Errorf("unexpected response to the immich's ping API at this address: %s:\n%s", ic.endPoint+"/server-info/ping", b.String())
+		return fmt.Errorf("unexpected response to the immich's ping API at this address: %s:\n%s", ic.endPoint+"/server/ping", b.String())
 	}
 	if r.Res != "pong" {
 		return fmt.Errorf("incorrect ping response: %s", r.Res)
@@ -163,7 +163,7 @@ type ServerStatistics struct {
 func (ic *ImmichClient) GetServerStatistics(ctx context.Context) (ServerStatistics, error) {
 	var s ServerStatistics
 
-	err := ic.newServerCall(ctx, EndPointGetServerStatistics).do(getRequest("/server-info/statistics", setAcceptJSON()), responseJSON(&s))
+	err := ic.newServerCall(ctx, EndPointGetServerStatistics).do(getRequest("/server/statistics", setAcceptJSON()), responseJSON(&s))
 	return s, err
 }
 
@@ -204,7 +204,7 @@ var DefaultSupportedMedia = SupportedMedia{
 func (ic *ImmichClient) GetSupportedMediaTypes(ctx context.Context) (SupportedMedia, error) {
 	var s map[string][]string
 
-	err := ic.newServerCall(ctx, EndPointGetSupportedMediaTypes).do(getRequest("/server-info/media-types", setAcceptJSON()), responseJSON(&s))
+	err := ic.newServerCall(ctx, EndPointGetSupportedMediaTypes).do(getRequest("/server/media-types", setAcceptJSON()), responseJSON(&s))
 	if err != nil {
 		return nil, err
 	}

--- a/immich/immich.go
+++ b/immich/immich.go
@@ -37,7 +37,7 @@ type ImmichInterface interface {
 	GetAssetAlbums(ctx context.Context, ID string) ([]AlbumSimplified, error)
 	DeleteAlbum(ctx context.Context, id string) error
 
-	StackAssets(ctx context.Context, cover string, IDs []string) error
+	StackAssets(ctx context.Context, cover string, IDs []string) (*Stack, error)
 
 	SupportedMedia() SupportedMedia
 	GetJobs(ctx context.Context) (map[string]Job, error)
@@ -207,4 +207,10 @@ func (t ImmichTime) MarshalJSON() ([]byte, error) {
 	}
 
 	return json.Marshal(t.Time.Format("\"" + time.RFC3339 + "\""))
+}
+
+type Stack struct {
+	ID             string  `json:"id"`
+	PrimateAssetID string  `json:"primaryAssetId"`
+	Assets         []Asset `json:"assets"`
 }

--- a/internal/fakeImmich/immich.go
+++ b/internal/fakeImmich/immich.go
@@ -38,8 +38,8 @@ func (c *MockedCLient) UpdateAssets(ctx context.Context, ids []string, isArchive
 	return nil
 }
 
-func (c *MockedCLient) StackAssets(ctx context.Context, cover string, ids []string) error {
-	return nil
+func (c *MockedCLient) StackAssets(ctx context.Context, cover string, ids []string) (*immich.Stack, error) {
+	return nil, nil
 }
 
 func (c *MockedCLient) UpdateAsset(ctx context.Context, id string, a *browser.LocalAssetFile) (*immich.Asset, error) {


### PR DESCRIPTION
Version 0.113.0 of immich removed the `stackParentId` field in the body of requests against the `/assets` endpoint to update assets. 

Instead a `POST` against the `/stacks` endpoint is now used to explicitly create stacks for the selected assets.