### PR TITLE
Add support for reading Sony A6400 .ARW RAW file metadata

### DIFF
--- a/internal/e2eTests/metadata/reader/main.go
+++ b/internal/e2eTests/metadata/reader/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/simulot/immich-go/internal/exif"
+)
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: reader <file>")
+		return
+	}
+	err := run(os.Args[1])
+	if err != nil {
+		fmt.Println(err)
+	}
+}
+
+func run(file string) error {
+	f, err := os.Open(file)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	m, err := exif.MetadataFromDirectRead(f, file, time.Local)
+	if err != nil {
+		return err
+	}
+
+	slog.Info("Metadata", "m", m)
+
+	return nil
+}

--- a/internal/exif/direct.go
+++ b/internal/exif/direct.go
@@ -26,7 +26,7 @@ func MetadataFromDirectRead(f io.Reader, name string, localTZ *time.Location) (*
 	switch strings.ToLower(ext) {
 	case ".heic", ".heif":
 		md, err = readHEIFMetadata(f, localTZ)
-	case ".jpg", ".jpeg", ".dng", ".cr2":
+	case ".jpg", ".jpeg", ".dng", ".cr2", ".arw":
 		md, err = readExifMetadata(f, localTZ)
 	case ".mp4", ".mov":
 		md, err = readMP4Metadata(f)


### PR DESCRIPTION
Enhance the metadata reading functionality to include support for Sony A6400 .ARW RAW files. This change addresses the issue where .ARW files could not be processed, preventing proper stacking in the application.

Fixes #582