### PR TITLE
Fix panic: time: missing Location in call to Time.In when using the archive command

### DIFF
--- a/app/cmd/archive/archive.go
+++ b/app/cmd/archive/archive.go
@@ -111,6 +111,7 @@ func NewFromGooglePhotosCommand(ctx context.Context, parent *cobra.Command, app 
 			app.SetJnl(fileevent.NewRecorder(app.Log().Logger))
 			app.Jnl().SetLogger(app.Log().SetLogWriter(os.Stdout))
 		}
+		options.TZ = app.GetTZ()
 		p, err := cmd.Flags().GetString("write-to-folder")
 		if err != nil {
 			return err

--- a/internal/e2eTests/archive/e2e_archive_test.go
+++ b/internal/e2eTests/archive/e2e_archive_test.go
@@ -1,0 +1,40 @@
+package archive
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/simulot/immich-go/app/cmd"
+	"github.com/simulot/immich-go/internal/e2eTests/e2e"
+)
+
+func TestArchiveFromGooglePhotos(t *testing.T) {
+	e2e.InitMyEnv()
+	e2e.ResetImmich(t)
+
+	ctx := context.Background()
+
+	tmpDir := os.TempDir()
+	tmpDir, err := os.MkdirTemp(tmpDir, "upload_test_folder")
+	if err != nil {
+		t.Fatalf("os.MkdirTemp() error = %v", err)
+		return
+	}
+	t.Cleanup(func() {
+		os.RemoveAll(tmpDir)
+	})
+
+	c, a := cmd.RootImmichGoCommand(ctx)
+	c.SetArgs([]string{
+		"archive", "from-google-photos",
+		"--write-to-folder=" + tmpDir,
+		e2e.MyEnv("IMMICHGO_TESTFILES") + "/demo takeout/Takeout.zip",
+	})
+
+	// let's start
+	err = c.ExecuteContext(ctx)
+	if err != nil && a.Log().GetSLog() != nil {
+		a.Log().Error(err.Error())
+	}
+}


### PR DESCRIPTION
The changes address a panic that occurs when using the archive command with Google Photos. The timezone option is now correctly set, preventing the missing Location error. Additionally, an end-to-end test has been added to ensure the functionality works as expected.

Fixes #595