### PR TITLE
fix: release on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: Release Pipeline
 
 on:
-  workflow_dispatch:
   push:
     tags: ["**"]
 
@@ -31,11 +30,11 @@ jobs:
 
       - name: Get the current commit
         id: get_commit
-        run: echo "::set-output name=commit::$(git rev-parse HEAD)"
+        run: echo "commit=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
       - name: Get the current date
         id: get_date
-        run: echo "::set-output name=date::$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+        run: echo "date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
 
       - name: Build binary
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
   push:
     tags: ["**"]
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,8 @@ name: Release Pipeline
 
 on:
   workflow_dispatch:
+  push:
+    tags: ["**"]
 
 jobs:
   build:
@@ -24,10 +26,6 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
-      - name: Get the current tag
-        id: get_tag
-        run: echo "::set-output name=version::$(git describe --tags --abbrev=0)"
-
       - name: Get the current commit
         id: get_commit
         run: echo "::set-output name=commit::$(git rev-parse HEAD)"
@@ -38,7 +36,7 @@ jobs:
 
       - name: Build binary
         run: |
-          VERSION=${{ steps.get_tag.outputs.version }}
+          VERSION=${{ github.ref_name }}
           COMMIT=${{ steps.get_commit.outputs.commit }}
           DATE=${{ steps.get_date.outputs.date }}
           GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} CGO_ENABLED=0 go build -o immich-go-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.os == 'windows' && '.exe' || '' }} -ldflags="-s -w -extldflags=-static -X version.Version=$VERSION -X version.Commit=$COMMIT -X version.Date=$DATE" main.go
@@ -49,8 +47,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ steps.get_tag.outputs.version }}
-          release_name: Release ${{ steps.get_tag.outputs.version }}
+          tag_name: ${{ github.ref_name }}
+          release_name: Release ${{ github.ref_name }}
           draft: false
           prerelease: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
+          name: ${{ matrix.os }}-${{ matrix.arch}}
           path: "./immich-go-*"
           if-no-files-found: error
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,33 +41,23 @@ jobs:
           DATE=${{ steps.get_date.outputs.date }}
           GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} CGO_ENABLED=0 go build -o immich-go-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.os == 'windows' && '.exe' || '' }} -ldflags="-s -w -extldflags=-static -X version.Version=$VERSION -X version.Commit=$COMMIT -X version.Date=$DATE" main.go
 
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
         with:
-          tag_name: ${{ github.ref_name }}
-          release_name: Release ${{ github.ref_name }}
+          path: "./immich-go-*"
+          if-no-files-found: error
+
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: "./artifacts"
+  
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: "./artifacts/**"
           draft: false
           prerelease: false
-
-      - name: Upload binary
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./immich-go-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.os == 'windows' && '.exe' || '' }}
-          asset_name: immich-go-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.os == 'windows' && '.exe' || '' }}
-          asset_content_type: application/octet-stream
-      - name: Upload checksum
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./immich-go-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.os == 'windows' && '.exe' || '' }}.sha256
-          asset_name: immich-go-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.os == 'windows' && '.exe' || '' }}.sha256
-          asset_content_type: text/plain
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,7 @@ jobs:
           if-no-files-found: error
 
   release:
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - name: Download artifacts


### PR DESCRIPTION
This PR updates the release workflow to:
1. Trigger when a new tag is pushed
2. Pass all the artifacts from the build matrix to a separate release job
3. Use modern actions & syntax