### PR TITLE
Validate asset IDs in CreateStack and add test case for bad requests

### DIFF
--- a/immich/stacks.go
+++ b/immich/stacks.go
@@ -2,12 +2,24 @@ package immich
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/google/uuid"
 )
 
 // CreateStack create a stack with the given assets, the 1st asset is the cover, return the stack ID
 func (ic *ImmichClient) CreateStack(ctx context.Context, ids []string) (string, error) {
+	// remove the empty ids
+	for i := 0; i < len(ids); i++ {
+		if ids[i] == "" {
+			ids = append(ids[:i], ids[i+1:]...)
+			i--
+		}
+	}
+	if len(ids) < 2 {
+		return "", fmt.Errorf("stack must have at least 2 assets")
+	}
+
 	if ic.dryRun {
 		return uuid.NewString(), nil
 	}

--- a/internal/e2eTests/upload/e2e_bad_request_test.go
+++ b/internal/e2eTests/upload/e2e_bad_request_test.go
@@ -6,6 +6,7 @@ package upload
 import (
 	"context"
 	"os"
+	"os/exec"
 	"testing"
 
 	"github.com/simulot/immich-go/app/cmd"
@@ -120,4 +121,51 @@ func Test_BadRequest(t *testing.T) {
 		a.Log().Error(err.Error())
 		t.Fatal(err)
 	}
+}
+
+func Test_BadRequestByAzwillnj(t *testing.T) {
+	t.Log("Test_BadRequestByAzwillnj")
+
+	client, err := e2e.GetImmichClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	e2e.InitMyEnv()
+	e2e.ResetImmich(t)
+
+	ctx := context.Background()
+
+	// Upload with immich-go v0.21.1
+	err = exec.CommandContext(ctx, e2e.MyEnv("IMMICHGO_TESTFILES")+"/#700 Error 500 when upload/lbmh/immich-go.v0.21.1",
+		"upload",
+		"-server="+e2e.MyEnv("IMMICHGO_SERVER"),
+		"-key="+e2e.MyEnv("IMMICHGO_APIKEY"),
+		"-google-photos",
+		e2e.MyEnv("IMMICHGO_TESTFILES")+"/#700 Error 500 when upload/azwillnj/Photos from 2016").Run()
+	if err != nil {
+		t.Log(err)
+	}
+
+	e2e.WaitingForJobsEnding(ctx, client, t)
+
+	// Same upload with current immich-go
+	c, a := cmd.RootImmichGoCommand(ctx)
+	c.SetArgs([]string{
+		"upload", "from-google-photos",
+		"--server=" + e2e.MyEnv("IMMICHGO_SERVER"),
+		"--api-key=" + e2e.MyEnv("IMMICHGO_APIKEY"),
+		"--no-ui",
+		"--api-trace",
+		"--log-level=debug",
+		e2e.MyEnv("IMMICHGO_TESTFILES") + "/#700 Error 500 when upload/azwillnj/Photos from 2016",
+	})
+
+	err = c.ExecuteContext(ctx)
+	if err != nil && a.Log().GetSLog() != nil {
+		a.Log().Error(err.Error())
+		t.Fatal(err)
+	}
+
+	e2e.WaitingForJobsEnding(ctx, client, t)
 }

--- a/internal/e2eTests/upload/e2e_bad_request_test.go
+++ b/internal/e2eTests/upload/e2e_bad_request_test.go
@@ -142,7 +142,7 @@ func Test_BadRequestByAzwillnj(t *testing.T) {
 		"-server="+e2e.MyEnv("IMMICHGO_SERVER"),
 		"-key="+e2e.MyEnv("IMMICHGO_APIKEY"),
 		"-google-photos",
-		e2e.MyEnv("IMMICHGO_TESTFILES")+"/#700 Error 500 when upload/azwillnj/Photos from 2016").Run()
+		e2e.MyEnv("IMMICHGO_TESTFILES")+"/#700 Error 500 when upload/azwillnj/takeout/Photos from 2016").Run()
 	if err != nil {
 		t.Log(err)
 	}
@@ -158,7 +158,7 @@ func Test_BadRequestByAzwillnj(t *testing.T) {
 		"--no-ui",
 		"--api-trace",
 		"--log-level=debug",
-		e2e.MyEnv("IMMICHGO_TESTFILES") + "/#700 Error 500 when upload/azwillnj/Photos from 2016",
+		e2e.MyEnv("IMMICHGO_TESTFILES") + "/#700 Error 500 when upload/azwillnj/takeout",
 	})
 
 	err = c.ExecuteContext(ctx)


### PR DESCRIPTION
Ensure that the CreateStack function validates asset IDs and requires at least two assets. Add a test case to confirm the behavior for bad requests. Update test file paths to reflect these changes.

Fix #750