### PR TITLE
Fix stack creation error when uploading assets with same name

### DIFF
--- a/adapters/googlePhotos/googlephotos.go
+++ b/adapters/googlePhotos/googlephotos.go
@@ -268,6 +268,8 @@ func (to *Takeout) passOneFsWalk(ctx context.Context, w fs.FS) error {
 					baseName: base,
 					size:     finfo.Size(),
 				}
+
+				// TODO: remove debugging code
 				tracking, _ := to.fileTracker.Load(key) // tracking := to.fileTracker[key]
 				tracking.paths = append(tracking.paths, dir)
 				tracking.count++
@@ -537,9 +539,11 @@ func (to *Takeout) makeAsset(_ context.Context, dir string, f *assetFile, md *as
 
 	// get the original file name from metadata
 	if md != nil && md.FileName != "" {
-		a.OriginalFileName = md.FileName
-
 		title := md.FileName
+
+		// a.OriginalFileName = md.FileName
+		// title := md.FileName
+
 		// trim superfluous extensions
 		titleExt := path.Ext(title)
 		fileExt := path.Ext(file)

--- a/app/cmd/upload/advice.go
+++ b/app/cmd/upload/advice.go
@@ -98,16 +98,16 @@ func (ai *AssetIndex) adviceNotOnServer() *Advice {
 //
 // The server may have different assets with the same name. This happens with photos produced by digital cameras.
 // The server may have the asset, but in lower resolution. Compare the taken date and resolution
+//
+// la - local asset
+// la.File.Name() is the full path to the file as it is on the source
+// la.OriginalFileName is the name of the file as it was on the device before it was uploaded to the server
 
 func (ai *AssetIndex) ShouldUpload(la *assets.Asset) (*Advice, error) {
-	filename := la.OriginalFileName
-	if path.Ext(filename) == "" {
-		filename += path.Ext(la.File.Name())
-	}
+	filename := la.File.Name()
+	DeviceAssetID := fmt.Sprintf("%s-%d", path.Base(filename), la.FileSize)
 
-	ID := la.DeviceAssetID()
-
-	sa := ai.byID[ID]
+	sa := ai.byDeviceAssetID[DeviceAssetID]
 	if sa != nil {
 		// the same ID exist on the server
 		return ai.adviceSameOnServer(sa), nil

--- a/app/cmd/upload/run.go
+++ b/app/cmd/upload/run.go
@@ -220,27 +220,6 @@ func (upCmd *UpCmd) handleAsset(ctx context.Context, a *assets.Asset) error {
 		return err
 	}
 
-	// If the asset exists on the server, at full size, or smaller, we should get its tags and not tag it again.
-	if advice.ServerAsset != nil {
-		serverAsset, err := upCmd.app.Client().Immich.GetAssetInfo(ctx, advice.ServerAsset.ID)
-		if err == nil {
-			newList := []assets.Tag{}
-			for _, t := range a.Tags {
-				keepMe := true
-				for _, st := range serverAsset.Tags {
-					if t.Name == st.Name {
-						keepMe = false
-						break
-					}
-				}
-				if keepMe {
-					newList = append(newList, t)
-				}
-			}
-			a.Tags = newList
-		}
-	}
-
 	switch advice.Advice {
 	case NotOnServer: // Upload and manage albums
 		err = upCmd.uploadAsset(ctx, a)

--- a/app/cmd/upload/run.go
+++ b/app/cmd/upload/run.go
@@ -343,6 +343,7 @@ func (upCmd *UpCmd) replaceAsset(ctx context.Context, ID string, a *assets.Asset
 	if ar.Status == immich.UploadDuplicate {
 		upCmd.app.Jnl().Record(ctx, fileevent.UploadServerDuplicate, a.File, "reason", "the server has this file")
 	} else {
+		a.ID = ID
 		upCmd.app.Jnl().Record(ctx, fileevent.UploadUpgraded, a.File)
 	}
 	return nil

--- a/internal/assets/asset.go
+++ b/internal/assets/asset.go
@@ -25,9 +25,10 @@ import (
 
 type Asset struct {
 	// File system and file name
-	File     fshelper.FSAndName
-	FileDate time.Time // File creation date
-	ID       string    // Immich ID after upload
+	File          fshelper.FSAndName
+	FileDate      time.Time // File creation date
+	ID            string    // Immich ID after upload
+	DeviceAssetID string    // file name on the input (as delivered in the takeout) + file size
 
 	// Common fields
 	OriginalFileName string // File name as delivered to Immich/Google

--- a/internal/assets/assetFile.go
+++ b/internal/assets/assetFile.go
@@ -1,16 +1,14 @@
 package assets
 
 import (
-	"fmt"
-
 	"github.com/simulot/immich-go/internal/fshelper/cachereader"
 	"github.com/simulot/immich-go/internal/fshelper/debugfiles"
 	"github.com/simulot/immich-go/internal/fshelper/osfs"
 )
 
-func (a *Asset) DeviceAssetID() string {
-	return fmt.Sprintf("%s-%d", a.OriginalFileName, a.FileSize)
-}
+// func (a *Asset) DeviceAssetID() string {
+// 	return fmt.Sprintf("%s-%d", path.Base(a.File.Name()), a.FileSize)
+// }
 
 // OpenFile return an os.File whatever the type of source reader is.
 // It can be called several times for the same asset.


### PR DESCRIPTION
Resolve an issue where uploading a takeout with duplicate photo names led to a stack creation error due to incorrect asset ID handling. Refactor the asset management to utilize DeviceAssetID for better identification of images with the same name, ensuring compatibility with previous versions. This change addresses the bad request error encountered when uploading assets with identical names. Fixes #749