### PR TITLE
fix: add missing flags on upload from google photos

### DIFF
--- a/adapters/googlePhotos/options.go
+++ b/adapters/googlePhotos/options.go
@@ -107,6 +107,7 @@ func (o *ImportFlags) AddFromGooglePhotosFlags(cmd *cobra.Command, parent *cobra
 	cmd.Flags().BoolVar(&o.SessionTag, "session-tag", false, "Tag uploaded photos with a tag \"{immich-go}/YYYY-MM-DD HH-MM-SS\"")
 	cmd.Flags().BoolVar(&o.TakeoutTag, "takeout-tag", true, "Tag uploaded photos with a tag \"{takeout}/takeout-YYYYMMDDTHHMMSSZ\"")
 	cmd.Flags().BoolVar(&o.PeopleTag, "people-tag", true, "Tag uploaded photos with tags \"people/name\" found in the JSON file")
+	cliflags.AddInclusionFlags(cmd, &o.InclusionFlags)
 
 	// exif.AddExifToolFlags(cmd, &o.ExifToolFlags)
 	o.SupportedMedia = filetypes.DefaultSupportedMedia


### PR DESCRIPTION
This is to fix the inability to use --date-range for upload from Google Photos