### PR TITLE
Enhance API tracing with correlation tag and thread safety

### DIFF
--- a/immich/call.go
+++ b/immich/call.go
@@ -318,9 +318,6 @@ func setJSONBody(object any) serverRequestOption {
 	return func(sc *serverCall, req *http.Request) error {
 		b := bytes.NewBuffer(nil)
 		enc := json.NewEncoder(b)
-		if sc.ic.apiTraceWriter != nil && sc.endPoint != EndPointGetJobs {
-			enc.SetIndent("", " ")
-		}
 		err := enc.Encode(object)
 		if err != nil {
 			return err
@@ -370,16 +367,12 @@ func responseJSON[T any](object *T) serverResponseOption {
 					fmt.Fprintln(sc.ic.apiTraceWriter, "  Status:", resp.Status)
 					fmt.Fprintln(sc.ic.apiTraceWriter, "-- response body start --")
 					defer fmt.Fprint(sc.ic.apiTraceWriter, "\n-- response body end --\n\n")
-
 				}
 
 				err := json.NewDecoder(resp.Body).Decode(object)
 				if err != nil {
 					err = fmt.Errorf("can't decode JSON response: %w", err)
 				}
-				// if sc.ic.apiTraceWriter != nil && sc.endPoint != EndPointGetJobs {
-				// 	fmt.Fprint(sc.ic.apiTraceWriter, "\n-- response body end --\n\n")
-				// }
 				return err
 			}
 		}

--- a/immich/call.go
+++ b/immich/call.go
@@ -348,8 +348,11 @@ func responseJSON[T any](object *T) serverResponseOption {
 				if resp.StatusCode == http.StatusNoContent {
 					return nil
 				}
-				err := json.NewDecoder(resp.Body).Decode(object)
+
 				if sc.ic.apiTraceWriter != nil && sc.endPoint != EndPointGetJobs {
+					sc.ic.apiTraceLock.Lock()
+					defer sc.ic.apiTraceLock.Unlock()
+					resp.Body = hijackBody(resp.Body, sc.ic.apiTraceWriter)
 					seq := sc.ctx.Value(ctxCallSequenceID)
 					fmt.Fprintln(
 						sc.ic.apiTraceWriter,
@@ -360,13 +363,23 @@ func responseJSON[T any](object *T) serverResponseOption {
 						resp.Request.Method,
 						resp.Request.URL.String(),
 					)
+					fmt.Fprintln(sc.ic.apiTraceWriter, "  Header:")
+					for k, v := range resp.Header {
+						fmt.Fprintln(sc.ic.apiTraceWriter, "    ", k, ":", strings.Join(v, "; "))
+					}
 					fmt.Fprintln(sc.ic.apiTraceWriter, "  Status:", resp.Status)
-					fmt.Fprintln(sc.ic.apiTraceWriter, "-- response body --")
-					dec := json.NewEncoder(newLimitWriter(sc.ic.apiTraceWriter, 100))
-					dec.SetIndent("", " ")
-					_ = dec.Encode(object)
-					fmt.Fprint(sc.ic.apiTraceWriter, "-- response body end --\n\n")
+					fmt.Fprintln(sc.ic.apiTraceWriter, "-- response body start --")
+					defer fmt.Fprint(sc.ic.apiTraceWriter, "\n-- response body end --\n\n")
+
 				}
+
+				err := json.NewDecoder(resp.Body).Decode(object)
+				if err != nil {
+					err = fmt.Errorf("can't decode JSON response: %w", err)
+				}
+				// if sc.ic.apiTraceWriter != nil && sc.endPoint != EndPointGetJobs {
+				// 	fmt.Fprint(sc.ic.apiTraceWriter, "\n-- response body end --\n\n")
+				// }
 				return err
 			}
 		}

--- a/immich/client.go
+++ b/immich/client.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/simulot/immich-go/internal/filetypes"
@@ -17,14 +18,16 @@ Immich API documentation https://documentation.immich.app/docs/api/introduction
 */
 
 type ImmichClient struct {
-	client              *http.Client
-	roundTripper        *http.Transport
-	endPoint            string                   // Server API url
-	key                 string                   // User KEY
-	DeviceUUID          string                   // Device
-	Retries             int                      // Number of attempts on 500 errors
-	RetriesDelay        time.Duration            // Duration between retries
-	apiTraceWriter      io.Writer                // If not nil, logs API calls to this writer
+	client         *http.Client
+	roundTripper   *http.Transport
+	endPoint       string        // Server API url
+	key            string        // User KEY
+	DeviceUUID     string        // Device
+	Retries        int           // Number of attempts on 500 errors
+	RetriesDelay   time.Duration // Duration between retries
+	apiTraceWriter io.Writer     // If not nil, logs API calls to this writer
+	apiTraceLock   sync.Mutex    // Lock for API trace
+
 	supportedMediaTypes filetypes.SupportedMedia // Server's list of supported medias
 	dryRun              bool                     //  If true, do not send any data to the server
 }

--- a/immich/trace.go
+++ b/immich/trace.go
@@ -56,6 +56,11 @@ func (lw *limitWriter) Close() error {
 	return nil
 }
 
+func hijackBody(body io.ReadCloser, tracer io.Writer) io.ReadCloser {
+	b := io.TeeReader(body, tracer)
+	return &smartBodyCloser{r: b, body: body, w: tracer}
+}
+
 type smartBodyCloser struct {
 	r    io.Reader
 	body io.ReadCloser
@@ -63,7 +68,7 @@ type smartBodyCloser struct {
 }
 
 func (sb *smartBodyCloser) Close() error {
-	fmt.Fprint(sb.w, "-- request body end --\n\n")
+	fmt.Fprint(sb.w, "-- body end --\n\n")
 	return sb.body.Close()
 }
 
@@ -73,6 +78,9 @@ func (sb *smartBodyCloser) Read(b []byte) (int, error) {
 
 func setTraceRequest() serverRequestOption {
 	return func(sc *serverCall, req *http.Request) error {
+		sc.ic.apiTraceLock.Lock()
+		defer sc.ic.apiTraceLock.Unlock()
+		// Trace request
 		seq := sc.ctx.Value(ctxCallSequenceID)
 		fmt.Fprintln(sc.ic.apiTraceWriter, time.Now().Format(time.RFC3339), "QUERY", seq, sc.endPoint, req.Method, req.URL.String())
 		for h, v := range req.Header {
@@ -95,13 +103,11 @@ func setTraceRequest() serverRequestOption {
 		if req.Header.Get("Content-Type") == "application/json" {
 			fmt.Fprintln(sc.ic.apiTraceWriter, "-- request JSON Body --")
 			if req.Body != nil {
-				// tr := io.TeeReader(req.Body, newLimitWriter(sc.ic.apiTraceWriter, 100))
-				tr := io.TeeReader(req.Body, sc.ic.apiTraceWriter)
-				req.Body = &smartBodyCloser{body: req.Body, r: tr, w: sc.ic.apiTraceWriter}
+				req.Body = hijackBody(req.Body, sc.ic.apiTraceWriter)
 			}
 		} else {
 			if req.Body != nil {
-				fmt.Fprintln(sc.ic.apiTraceWriter, "-- Empty body or binary body not dumped --")
+				fmt.Fprintln(sc.ic.apiTraceWriter, "-- binary body not dumped --")
 			}
 		}
 		return nil

--- a/immich/trace.go
+++ b/immich/trace.go
@@ -101,7 +101,7 @@ func setTraceRequest() serverRequestOption {
 			}
 		}
 		if req.Header.Get("Content-Type") == "application/json" {
-			fmt.Fprintln(sc.ic.apiTraceWriter, "-- request JSON Body --")
+			fmt.Fprintln(sc.ic.apiTraceWriter, "-- body start --")
 			if req.Body != nil {
 				req.Body = hijackBody(req.Body, sc.ic.apiTraceWriter)
 			}

--- a/internal/e2eTests/upload/e2e_from_google_photos_test.go
+++ b/internal/e2eTests/upload/e2e_from_google_photos_test.go
@@ -28,11 +28,12 @@ func TestUploadFromGooglePhotos(t *testing.T) {
 		"upload", "from-google-photos",
 		"--server=" + e2e.MyEnv("IMMICHGO_SERVER"),
 		"--api-key=" + e2e.MyEnv("IMMICHGO_APIKEY"),
-		"--on-server-errors=stop",
+		"--on-server-errors=5",
 		"--log-level=DEBUG",
 		"--api-trace",
 		// "--no-ui",
-		e2e.MyEnv("IMMICHGO_TESTFILES") + "/full_takeout/takeout-20240816T155855Z-*.zip",
+		e2e.MyEnv("IMMICHGO_TESTFILES") + "/demo takeout/zip/takeout-20240123T180723Z-*.zip",
+		// e2e.MyEnv("IMMICHGO_TESTFILES") + "/full_takeout/takeout-20240816T155855Z-*.zip",
 	})
 
 	// let's start

--- a/internal/fileevent/fileevents.go
+++ b/internal/fileevent/fileevents.go
@@ -181,7 +181,7 @@ func (r *Recorder) Report() {
 		AnalysisAssociatedMetadata,
 		AnalysisMissingAssociatedMetadata,
 	} {
-		countAnalysis += int(r.counts[c])
+		countAnalysis += int(atomic.LoadInt64(&r.counts[c]))
 	}
 
 	if countAnalysis > 0 {


### PR DESCRIPTION
Improvements to API tracing include the addition of a correlation tag for better traceability and the implementation of mutex locks to ensure thread safety during API calls. The request and response bodies are now hijacked for logging, providing clearer insights into API interactions. Additionally, tests have been updated to reflect these changes.

Fixes #778