### PR TITLE
Ignore MVIMG files to prevent upload errors and change error log level for UI initialization failures

### DIFF
--- a/app/cmd/upload/run.go
+++ b/app/cmd/upload/run.go
@@ -64,7 +64,7 @@ func (upCmd *UpCmd) run(ctx context.Context, adapter adapters.Reader, app *app.A
 	}
 	_, err := tcell.NewScreen()
 	if err != nil {
-		upCmd.app.Log().Error("can't initialize the screen for the UI mode. Falling back to no-gui mode")
+		upCmd.app.Log().Warn("can't initialize the screen for the UI mode. Falling back to no-gui mode", "err", err)
 		fmt.Println("can't initialize the screen for the UI mode. Falling back to no-gui mode")
 		runner = upCmd.runNoUI
 	}

--- a/internal/e2eTests/upload/e2e_from_folder_test.go
+++ b/internal/e2eTests/upload/e2e_from_folder_test.go
@@ -323,3 +323,30 @@ func generateRandomImage(path string) error {
 
 	return nil
 }
+
+// #786 MVIM*.MP4 files should be ignored to avoid upload errors
+func TestDiscardMVIMGFiles(t *testing.T) {
+	e2e.InitMyEnv()
+	e2e.ResetImmich(t)
+
+	ctx := context.Background()
+	c, a := cmd.RootImmichGoCommand(ctx)
+	c.SetArgs([]string{
+		"upload", "from-folder",
+		"--server=" + e2e.MyEnv("IMMICHGO_SERVER"),
+		"--api-key=" + e2e.MyEnv("IMMICHGO_APIKEY"),
+		"--no-ui",
+		"--into-album=ALBUM",
+		"--log-level=debug",
+		"--api-trace",
+		"--manage-raw-jpeg=KeepRaw",
+		"--manage-burst=stack",
+		e2e.MyEnv("IMMICHGO_TESTFILES") + "/#786 Filter MVIMG files",
+	})
+
+	// let's start
+	err := c.ExecuteContext(ctx)
+	if err != nil && a.Log().GetSLog() != nil {
+		a.Log().Error(err.Error())
+	}
+}

--- a/internal/filetypes/supported.go
+++ b/internal/filetypes/supported.go
@@ -100,7 +100,7 @@ func (sm SupportedMedia) IsUseLess(name string) bool {
 	}
 
 	// MVIMG* is a Google Motion Photo movie part, not useful
-	if ext == "" && strings.HasPrefix(strings.ToUpper(name), "MVIMG") {
+	if (ext == "" || sm.TypeFromExt(ext) == TypeVideo) && strings.HasPrefix(strings.ToUpper(name), "MVIMG") {
 		return true
 	}
 	return false


### PR DESCRIPTION
Ignore MVIMG*.MP4 files to prevent upload errors during the upload process. Change the error log to a warning when UI mode initialization fails, improving the clarity of log messages. Fixes #786