### PR TITLE
Add Bulgarian translation in documentation

### DIFF
--- a/adapters/googlePhotos/json_test.go
+++ b/adapters/googlePhotos/json_test.go
@@ -354,6 +354,23 @@ func TestPresentFields(t *testing.T) {
 			title:     "IMG_0186.HEIC",
 			dateTaken: time.Date(2023, 6, 9, 10, 19, 47, 0, time.UTC),
 		},
+		{
+			name: "bulgarian 1",
+			json: `{
+  "title": "Фокус върху един ден"
+}`,
+			isPartner: false,
+			isAlbum:   true,
+			title:     "Фокус върху един ден",
+		},
+		{
+			name: "empty",
+			json: `{
+}`,
+			isPartner: false,
+			isAlbum:   false,
+			title:     "",
+		},
 	}
 
 	for _, c := range tcs {

--- a/docs/google-takeout.md
+++ b/docs/google-takeout.md
@@ -83,7 +83,7 @@ takeout-20240712T112341Z-010.zip:
 | Slovak     | Fotky Google         | metadáta.json    |                   |
 | German     | Google Fotos         | Metadaten.json   | \*-bearbeitet.\*  |
 | Russian    | Google Фото          | метаданные.json  |                   |
-
+| Bulgarian  | Google Снимки        | метаданни.json   |                   |
 
 
 


### PR DESCRIPTION
Introduce additional test cases for Bulgarian JSON inputs in the Google Photos adapter and update the Google Takeout documentation to include Bulgarian entries.