### PR TITLE
Adding --skip-problem-assets global param

### DIFF
--- a/app/cmd/upload/upload.go
+++ b/app/cmd/upload/upload.go
@@ -30,9 +30,8 @@ func (m UpLoadMode) String() string {
 
 // UploadOptions represents a set of common flags used for filtering assets.
 type UploadOptions struct {
-	// TODO place this option at the top
 	NoUI bool // Disable UI
-
+	SkipProblemAssets bool // Skip assets that cause upload issues
 	Filters []filters.Filter
 }
 
@@ -46,6 +45,7 @@ func NewUploadCommand(ctx context.Context, a *app.Application) *cobra.Command {
 	app.AddClientFlags(ctx, cmd, a, false)
 	cmd.TraverseChildren = true
 	cmd.PersistentFlags().BoolVar(&options.NoUI, "no-ui", false, "Disable the user interface")
+	cmd.PersistentFlags().BoolVar(&options.SkipProblemAssets, "skip-problem-assets", false, "Continue uploading when encountering problematic assets (like oversized files)")
 	cmd.PersistentPreRunE = app.ChainRunEFunctions(cmd.PersistentPreRunE, options.Open, ctx, cmd, a)
 
 	cmd.AddCommand(NewFromFolderCommand(ctx, cmd, a, options))


### PR DESCRIPTION
 When performing large Google Photos uploads, I kept getting a halting "413 Request Entity Too Large" error, and excluding each file as it came up became too cumbersome, so this lets the user optionally skip those files, so they can go back and manually deal with them by referencing the log.