### PR TITLE
Set the x-immich-checksum header when uploading

### DIFF
--- a/app/cmd/upload/advice.go
+++ b/app/cmd/upload/advice.go
@@ -214,6 +214,10 @@ func (ii *immichIndex) ShouldUpload(la *assets.Asset) (*Advice, error) {
 	// check all files with the same name
 	ids, ok := ii.byName.Load(filename)
 
+	if !ok || len(ids) == 0 {
+		ids, ok = ii.byName.Load(la.OriginalFileName)
+	}
+
 	if ok && len(ids) > 0 {
 		dateTaken := la.CaptureDate
 		if dateTaken.IsZero() {

--- a/immich/call.go
+++ b/immich/call.go
@@ -300,6 +300,13 @@ func setAcceptJSON() serverRequestOption {
 	}
 }
 
+func setChecksum(sum string) serverRequestOption {
+	return func(sc *serverCall, req *http.Request) error {
+		req.Header.Add("x-immich-checksum", sum)
+		return nil
+	}
+}
+
 func setOctetStream() serverRequestOption {
 	return func(sc *serverCall, req *http.Request) error {
 		req.Header.Add("Accept", "application/octet-stream")

--- a/immich/upload.go
+++ b/immich/upload.go
@@ -2,6 +2,7 @@ package immich
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/simulot/immich-go/internal/assets"
+	"github.com/simulot/immich-go/internal/fshelper/hash"
 )
 
 const (
@@ -94,11 +96,13 @@ func (ic *ImmichClient) uploadAsset(ctx context.Context, la *assets.Asset, endPo
 		}
 	}()
 
+	checksum, _ := hash.GetSHA1Hash(f)
+
 	var errCall error
 	switch endPoint {
 	case EndPointAssetUpload:
 		errCall = ic.newServerCall(ctx, EndPointAssetUpload).
-			do(postRequest("/assets", m.FormDataContentType(), setContextValue(callValues), setAcceptJSON(), setBody(body)), responseJSON(&ar))
+			do(postRequest("/assets", m.FormDataContentType(), setContextValue(callValues), setAcceptJSON(), setBody(body), setChecksum(hex.EncodeToString(checksum))), responseJSON(&ar))
 	case EndPointAssetReplace:
 		errCall = ic.newServerCall(ctx, EndPointAssetReplace).
 			do(putRequest("/assets/"+replaceID+"/original", setContextValue(callValues), setAcceptJSON(), setContentType(m.FormDataContentType()), setBody(body)), responseJSON(&ar))


### PR DESCRIPTION
This enables Immich to detect duplicates without saving the file or calculating the checksum itself. Avoids hitting the filesystem or database, and avoids generating a database key constraint error too.

There are conditions when immich-go doesn't find duplicates using filename/date/size matching and attempts to upload a duplicate file anyway. Immich can detect this quickly if the header x-immich-checksum is set, but if it's not it will generate an error like this: https://github.com/immich-app/immich/issues/15051 which is confusing. 

This patch sets the header, so Immich can quickly respond that the file is a duplicate.

