### PR TITLE
Add tests for Snapchat filename date extraction and filename sanitization

### DIFF
--- a/adapters/googlePhotos/json_test.go
+++ b/adapters/googlePhotos/json_test.go
@@ -641,6 +641,7 @@ func TestSanitizedTitle(t *testing.T) {
 		{input: "Hello:World", expected: "Hello_World"},
 		{input: "Hello\nWorld", expected: "Hello_World"},
 		{input: "Some/File|Name?", expected: "Some_File_Name_"},
+		{input: "123123\\.JPG", expected: "123123_.JPG"},
 	}
 
 	for _, c := range cases {

--- a/internal/filenames/namesdate_test.go
+++ b/internal/filenames/namesdate_test.go
@@ -106,6 +106,14 @@ func TestTakeTimeFromPath(t *testing.T) {
 			name:     "something_2011-05-11 something/IMG_1234.JPG",
 			expected: time.Date(2011, 0o5, 11, 0, 0, 0, 0, time.UTC),
 		},
+		{
+			name:     "2021-05-27_overlay~zip-9C801DD4-6F9C-4E7B-A2D1-08C136E43C0.webp",
+			expected: time.Date(2021, 0o5, 27, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:     "2020-06-25_js-EjQSFXMSRzqjMGZ4WTBjulPZ21MRG9KVxoAGgAyAQdIAIAEYAE.mp4",
+			expected: time.Date(2020, 0o6, 25, 0, 0, 0, 0, time.UTC),
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Enhance the test suite by adding cases for extracting dates from Snapchat export filenames and handling filenames with backslashes in sanitized titles. This addresses the feature request for importing Snapchat files and improves robustness against filename formatting issues.

#740, #706