### PR TITLE
Don't filter any images in GetAllAssets so we can find all duplicates

### DIFF
--- a/immich/metadata.go
+++ b/immich/metadata.go
@@ -63,7 +63,7 @@ func (ic *ImmichClient) callSearchMetadata(ctx context.Context, query *SearchMet
 func (ic *ImmichClient) GetAllAssets(ctx context.Context) ([]*Asset, error) {
 	var assets []*Asset
 
-	req := SearchMetadataQuery{Page: 1, WithExif: true, IsVisible: true, WithDeleted: true}
+	req := SearchMetadataQuery{Page: 1, WithExif: true, WithDeleted: true}
 	err := ic.callSearchMetadata(ctx, &req, func(asset *Asset) error {
 		assets = append(assets, asset)
 		return nil
@@ -76,7 +76,7 @@ func (ic *ImmichClient) GetAllAssets(ctx context.Context) ([]*Asset, error) {
 
 func (ic *ImmichClient) GetAllAssetsWithFilter(ctx context.Context, query *SearchMetadataQuery, filter func(*Asset) error) error {
 	if query == nil {
-		query = &SearchMetadataQuery{Page: 1, WithExif: true, IsVisible: true, WithDeleted: true}
+		query = &SearchMetadataQuery{Page: 1, WithExif: true, WithDeleted: true}
 	}
 	query.Page = 1
 	return ic.callSearchMetadata(ctx, query, filter)

--- a/immich/upload.go
+++ b/immich/upload.go
@@ -103,6 +103,9 @@ func (ic *ImmichClient) uploadAsset(ctx context.Context, la *assets.Asset, endPo
 		errCall = ic.newServerCall(ctx, EndPointAssetReplace).
 			do(putRequest("/assets/"+replaceID+"/original", setContextValue(callValues), setAcceptJSON(), setImmichChecksum(la), setContentType(m.FormDataContentType()), setBody(body)), responseJSON(&ar))
 	}
+	if ar.Status == "duplicate" && errors.Is(err, io.ErrClosedPipe) {
+		err = nil //immich closes the connection when we upload the x-immich-checksum header and it finds a duplicate
+	}
 	err = errors.Join(err, errCall)
 	return ar, err
 }


### PR DESCRIPTION
The search parameter isVisible filters out some images (such as liveimages), and so we can't find these duplicates.

This fixes https://github.com/simulot/immich-go/issues/842 for images filtered out with the above filter. 

I also fixed the handling or ErrClosedPipe which occurs when we set the x-immich-checksum header and immich closes the connection with a duplicate id. This is expected behaviour (it avoids uploading the duplicate), so we just eat the error in this case and move on. 