### PR TITLE
fix nix flakes command in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -157,7 +157,7 @@ You can try `immich-go` without installing it with the following commands:
 ```bash
 nix-shell -I "nixpkgs=https://github.com/NixOS/nixpkgs/archive/nixos-unstable-small.tar.gz" -p immich-go
 # Or with flakes enabled
-nix run "github:nixos/nixpkgs?ref=nixos-unstable-small#immich-go" -- -help
+nix run "github:nixos/nixpkgs?ref=nixos-unstable-small#immich-go" -- --help
 ```
 
 Or you can add `immich-go` to your `configuration.nix` in the `environment.systemPackages` section.


### PR DESCRIPTION
This pull request fixes the nix flakes command in the readme by adding the missing double dash.

Currently running the readme nix flakes command gives this error
```
$ nix run "github:nixos/nixpkgs?ref=nixos-unstable-small#immich-go" -- -help
Error: unknown shorthand flag: 'e' in -elp
Usage:
  immich-go [command]

Available Commands:
  archive     Archive various sources of photos to a file system
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  stack       Update Immich for stacking related photos
  upload      Upload photos to an Immich server from various sources
  version     Give immich-go version

Flags:
  -h, --help               help for immich-go
  -l, --log-file string    Write log messages into the file
      --log-level string   Log level (DEBUG|INFO|WARN|ERROR), default INFO (default "INFO")
      --log-type string    Log formatted  as text of JSON file (default "text")
  -v, --version            version for immich-go

Use "immich-go [command] --help" for more information about a command.

unknown shorthand flag: 'e' in -elp
```
the correct command is
```
nix run "github:nixos/nixpkgs?ref=nixos-unstable-small#immich-go" -- --help
```