### PR TITLE
feat: implement `--tag-via-sidecar` when uploading

### DIFF
--- a/app/upload/upload.go
+++ b/app/upload/upload.go
@@ -55,12 +55,14 @@ type UpCmd struct {
 	// Cli flags
 
 	shared.StackOptions
-	client     app.Client
-	NoUI       bool // Disable UI
-	Overwrite  bool // Always overwrite files on the server with local versions
-	Tags       []string
-	SessionTag bool
-	session    string // Session tag value
+	client        app.Client
+	NoUI          bool // Disable UI
+	Overwrite     bool // Always overwrite files on the server with local versions
+	Tags          []string
+	SessionTag    bool
+	TagViaSidecar bool
+	session       string // Session tag value
+	tagSidecarDir string
 
 	// Upload command state
 	// Filters           []filters.Filter
@@ -85,6 +87,7 @@ func (uc *UpCmd) RegisterFlags(flags *pflag.FlagSet) {
 	flags.BoolVar(&uc.Overwrite, "overwrite", false, "Always overwrite files on the server with local versions")
 	flags.StringSliceVar(&uc.Tags, "tag", nil, "Add tags to the imported assets. Can be specified multiple times. Hierarchy is supported using a / separator (e.g. 'tag1/subtag1')")
 	flags.BoolVar(&uc.SessionTag, "session-tag", false, "Tag uploaded photos with a tag \"{immich-go}/YYYY-MM-DD HH-MM-SS\"")
+	flags.BoolVar(&uc.TagViaSidecar, "tag-via-sidecar", false, "Write tags to a temporary XMP sidecar instead of creating tags in Immich")
 
 	uc.StackOptions.RegisterFlags(flags)
 }

--- a/docs/commands/upload.md
+++ b/docs/commands/upload.md
@@ -41,11 +41,12 @@ All upload sub-commands require these connection parameters:
 
 ## Tagging and Organization
 
-| Option          | Default      | Description                                  |
-| --------------- | ------------ | -------------------------------------------- |
-| `--session-tag` | `false`      | Tag with upload session timestamp            |
-| `--tag`         | -            | Add custom tags (can be used multiple times) |
-| `--device-uuid` | `$LOCALHOST` | Set device identifier                        |
+| Option             | Default      | Description                                                                                                                                                  |
+| ------------------ | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `--session-tag`    | `false`      | Tag with upload session timestamp                                                                                                                            |
+| `--tag`            | -            | Add custom tags (can be used multiple times)                                                                                                                 |
+| `--tag-via-sidecar`| `false`      | Write tags into a temporary XMP sidecar instead of using Immich tag APIs (workaround for [Immich #16747](https://github.com/immich-app/immich/issues/16747)) |
+| `--device-uuid`    | `$LOCALHOST` | Set device identifier                                                                                                                                        |
 
 ## User Interface
 

--- a/internal/exif/sidecars/xmpsidecar/read.go
+++ b/internal/exif/sidecars/xmpsidecar/read.go
@@ -42,31 +42,35 @@ func walk(m mxj.Map, md *assets.Metadata, path string) {
 	}
 }
 
-var reDescription = regexp.MustCompile(`/xmpmeta/RDF/Description\[\d+\]/`)
+var (
+	reDescription = regexp.MustCompile(`/xmpmeta/RDF/Description(?:\[\d+\])?/`)
+	reIndex       = regexp.MustCompile(`\[\d+\]`)
+)
 
 func filter(md *assets.Metadata, p string, value string) {
 	p = reDescription.ReplaceAllString(p, "")
+	p = reIndex.ReplaceAllString(p, "")
 	// debug 	fmt.Printf("%s: %s\n", p, value)
 	switch p {
-	case "DateTimeOriginal":
+	case "DateTimeOriginal", "DateTimeOriginal/#text":
 		if d, err := TimeStringToTime(value, time.UTC); err == nil {
 			md.DateTaken = d
 		}
 	case "ImageDescription/Alt/li/#text":
 		md.Description = value
-	case "Rating":
+	case "Rating", "Rating/#text":
 		md.Rating = StringToByte(value)
-	case "TagsList/Seq/li":
+	case "TagsList/Seq/li", "TagsList/Seq/li/#text":
 		md.Tags = append(md.Tags,
 			assets.Tag{
 				Name:  path.Base(value),
 				Value: value,
 			})
-	case "/xmpmeta/RDF/Description/GPSLatitude":
+	case "/xmpmeta/RDF/Description/GPSLatitude", "/xmpmeta/RDF/Description/GPSLatitude/#text", "GPSLatitude", "GPSLatitude/#text":
 		if f, err := GPTStringToFloat(value); err == nil {
 			md.Latitude = f
 		}
-	case "/xmpmeta/RDF/Description/GPSLongitude":
+	case "/xmpmeta/RDF/Description/GPSLongitude", "/xmpmeta/RDF/Description/GPSLongitude/#text", "GPSLongitude", "GPSLongitude/#text":
 		if f, err := GPTStringToFloat(value); err == nil {
 			md.Longitude = f
 		}

--- a/internal/exif/sidecars/xmpsidecar/testdata/C0092.xmp
+++ b/internal/exif/sidecars/xmpsidecar/testdata/C0092.xmp
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:xmp="http://ns.adobe.com/xap/1.0/" xmlns:xmpDM="http://ns.adobe.com/xmp/1.0/DynamicMedia/" xmlns:stDim="http://ns.adobe.com/xap/1.0/sType/Dimensions#" xmlns:tiff="http://ns.adobe.com/tiff/1.0/" xmlns:exif="http://ns.adobe.com/exif/1.0/" xmlns:sonyNRT="https://example.com/ns/sonyNRT/1.0/">
+  <rdf:RDF>
+    <rdf:Description rdf:about="">
+      <xmp:ModifyDate>2025-08-28T23:31:20-07:00</xmp:ModifyDate>
+      <xmp:MetadataDate>2025-08-28T23:31:20-07:00</xmp:MetadataDate>
+      <xmp:CreateDate>2025-08-28T23:30:53-07:00</xmp:CreateDate>
+      <tiff:Make>Sony</tiff:Make>
+      <tiff:Model>ILCE-6700</tiff:Model>
+      <xmpDM:videoCompressor>AVC_1920_1080_HP@L41</xmpDM:videoCompressor>
+      <xmpDM:videoFrameSize rdf:parseType="Resource">
+        <stDim:w>1920</stDim:w>
+        <stDim:h>1080</stDim:h>
+        <stDim:unit>pixel</stDim:unit>
+      </xmpDM:videoFrameSize>
+      <xmpDM:audioChannelType>Stereo</xmpDM:audioChannelType>
+      <xmpDM:audioSampleType>16Int</xmpDM:audioSampleType>
+      <exif:GPSMapDatum>WGS-84</exif:GPSMapDatum>
+      <exif:GPSDifferential>0</exif:GPSDifferential>
+      <exif:GPSVersionID>2.2.0.0</exif:GPSVersionID>
+      <sonyNRT:LastUpdate>2025-08-28T23:31:20-07:00</sonyNRT:LastUpdate>
+      <sonyNRT:CreationDateOriginal>2025-08-28T23:30:53-07:00</sonyNRT:CreationDateOriginal>
+      <sonyNRT:Device rdf:parseType="Resource">
+        <sonyNRT:manufacturer>Sony</sonyNRT:manufacturer>
+        <sonyNRT:modelName>ILCE-6700</sonyNRT:modelName>
+      </sonyNRT:Device>
+      <sonyNRT:DurationFrames>624</sonyNRT:DurationFrames>
+      <sonyNRT:VideoFormat rdf:parseType="Resource">
+        <sonyNRT:VideoRecPort>DIRECT</sonyNRT:VideoRecPort>
+        <sonyNRT:VideoFrame rdf:parseType="Resource">
+          <sonyNRT:videoCodec>AVC_1920_1080_HP@L41</sonyNRT:videoCodec>
+          <sonyNRT:captureFps>23.98p</sonyNRT:captureFps>
+          <sonyNRT:formatFps>23.98p</sonyNRT:formatFps>
+        </sonyNRT:VideoFrame>
+        <sonyNRT:VideoLayout rdf:parseType="Resource">
+          <sonyNRT:pixel>1920</sonyNRT:pixel>
+          <sonyNRT:numOfVerticalLine>1080</sonyNRT:numOfVerticalLine>
+          <sonyNRT:aspectRatio>16:9</sonyNRT:aspectRatio>
+        </sonyNRT:VideoLayout>
+      </sonyNRT:VideoFormat>
+      <sonyNRT:AudioFormat rdf:parseType="Resource">
+        <sonyNRT:numOfChannel>2</sonyNRT:numOfChannel>
+        <sonyNRT:AudioRecPorts>
+          <rdf:Seq>
+            <rdf:li rdf:parseType="Resource">
+              <sonyNRT:port>DIRECT</sonyNRT:port>
+              <sonyNRT:audioCodec>LPCM16</sonyNRT:audioCodec>
+              <sonyNRT:trackDst>CH1</sonyNRT:trackDst>
+            </rdf:li>
+            <rdf:li rdf:parseType="Resource">
+              <sonyNRT:port>DIRECT</sonyNRT:port>
+              <sonyNRT:audioCodec>LPCM16</sonyNRT:audioCodec>
+              <sonyNRT:trackDst>CH2</sonyNRT:trackDst>
+            </rdf:li>
+          </rdf:Seq>
+        </sonyNRT:AudioRecPorts>
+      </sonyNRT:AudioFormat>
+      <sonyNRT:RecordingMode rdf:parseType="Resource">
+        <sonyNRT:type>normal</sonyNRT:type>
+        <sonyNRT:cacheRec>false</sonyNRT:cacheRec>
+      </sonyNRT:RecordingMode>
+      <sonyNRT:LtcChangeTable rdf:parseType="Resource">
+        <sonyNRT:tcFps>24</sonyNRT:tcFps>
+        <sonyNRT:halfStep>false</sonyNRT:halfStep>
+        <sonyNRT:Changes>
+          <rdf:Seq>
+            <rdf:li rdf:parseType="Resource">
+              <sonyNRT:frameCount>0</sonyNRT:frameCount>
+              <sonyNRT:value>12282823</sonyNRT:value>
+              <sonyNRT:status>increment</sonyNRT:status>
+            </rdf:li>
+            <rdf:li rdf:parseType="Resource">
+              <sonyNRT:frameCount>623</sonyNRT:frameCount>
+              <sonyNRT:value>11542823</sonyNRT:value>
+              <sonyNRT:status>end</sonyNRT:status>
+            </rdf:li>
+          </rdf:Seq>
+        </sonyNRT:Changes>
+      </sonyNRT:LtcChangeTable>
+      <sonyNRT:CameraUnit rdf:parseType="Resource">
+        <sonyNRT:CaptureGammaEquation>s-cinetone</sonyNRT:CaptureGammaEquation>
+        <sonyNRT:CaptureColorPrimaries>rec709</sonyNRT:CaptureColorPrimaries>
+        <sonyNRT:CodingEquations>rec709</sonyNRT:CodingEquations>
+      </sonyNRT:CameraUnit>
+      <sonyNRT:ExifGPS rdf:parseType="Resource">
+        <sonyNRT:VersionID>2.2.0.0</sonyNRT:VersionID>
+        <sonyNRT:Status>V</sonyNRT:Status>
+        <sonyNRT:MapDatum>WGS-84</sonyNRT:MapDatum>
+        <sonyNRT:Differential>0</sonyNRT:Differential>
+      </sonyNRT:ExifGPS>
+      <sonyNRT:ChangeTables>
+        <rdf:Seq>
+          <rdf:li rdf:parseType="Resource">
+            <sonyNRT:name>ImagerControlInformation</sonyNRT:name>
+            <sonyNRT:Events>
+              <rdf:Seq>
+                <rdf:li rdf:parseType="Resource">
+                  <sonyNRT:frameCount>0</sonyNRT:frameCount>
+                  <sonyNRT:status>start</sonyNRT:status>
+                </rdf:li>
+              </rdf:Seq>
+            </sonyNRT:Events>
+          </rdf:li>
+          <rdf:li rdf:parseType="Resource">
+            <sonyNRT:name>LensControlInformation</sonyNRT:name>
+            <sonyNRT:Events>
+              <rdf:Seq>
+                <rdf:li rdf:parseType="Resource">
+                  <sonyNRT:frameCount>0</sonyNRT:frameCount>
+                  <sonyNRT:status>start</sonyNRT:status>
+                </rdf:li>
+              </rdf:Seq>
+            </sonyNRT:Events>
+          </rdf:li>
+          <rdf:li rdf:parseType="Resource">
+            <sonyNRT:name>DistortionCorrection</sonyNRT:name>
+            <sonyNRT:Events>
+              <rdf:Seq>
+                <rdf:li rdf:parseType="Resource">
+                  <sonyNRT:frameCount>0</sonyNRT:frameCount>
+                  <sonyNRT:status>start</sonyNRT:status>
+                </rdf:li>
+              </rdf:Seq>
+            </sonyNRT:Events>
+          </rdf:li>
+          <rdf:li rdf:parseType="Resource">
+            <sonyNRT:name>Gyroscope</sonyNRT:name>
+            <sonyNRT:Events>
+              <rdf:Seq>
+                <rdf:li rdf:parseType="Resource">
+                  <sonyNRT:frameCount>0</sonyNRT:frameCount>
+                  <sonyNRT:status>start</sonyNRT:status>
+                </rdf:li>
+              </rdf:Seq>
+            </sonyNRT:Events>
+          </rdf:li>
+          <rdf:li rdf:parseType="Resource">
+            <sonyNRT:name>Accelerometor</sonyNRT:name>
+            <sonyNRT:Events>
+              <rdf:Seq>
+                <rdf:li rdf:parseType="Resource">
+                  <sonyNRT:frameCount>0</sonyNRT:frameCount>
+                  <sonyNRT:status>start</sonyNRT:status>
+                </rdf:li>
+              </rdf:Seq>
+            </sonyNRT:Events>
+          </rdf:li>
+        </rdf:Seq>
+      </sonyNRT:ChangeTables>
+    </rdf:Description>
+  </rdf:RDF>
+</x:xmpmeta>

--- a/internal/exif/sidecars/xmpsidecar/write.go
+++ b/internal/exif/sidecars/xmpsidecar/write.go
@@ -1,0 +1,342 @@
+package xmpsidecar
+
+import (
+	"bytes"
+	"encoding/xml"
+	"errors"
+	"io"
+)
+
+const (
+	namespaceRDF     = "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	namespaceDigiKam = "http://www.digikam.org/ns/1.0/"
+	namespaceX       = "adobe:ns:meta/"
+)
+
+type namespaceDecl struct {
+	uri      string
+	previous string
+	hadPrev  bool
+}
+
+type namespaceState struct {
+	stack       [][]namespaceDecl
+	uriToPrefix map[string]string
+}
+
+func newNamespaceState() *namespaceState {
+	return &namespaceState{
+		stack: nil,
+		uriToPrefix: map[string]string{
+			"http://www.w3.org/XML/1998/namespace": "xml",
+		},
+	}
+}
+
+func (ns *namespaceState) push(start xml.StartElement) {
+	var decls []namespaceDecl
+	for _, attr := range start.Attr {
+		if attr.Name.Space == "xmlns" || (attr.Name.Space == "" && attr.Name.Local == "xmlns") {
+			prefix := attr.Name.Local
+			if attr.Name.Space == "" && attr.Name.Local == "xmlns" {
+				prefix = ""
+			}
+			uri := attr.Value
+			prev, ok := ns.uriToPrefix[uri]
+			decls = append(decls, namespaceDecl{uri: uri, previous: prev, hadPrev: ok})
+			ns.uriToPrefix[uri] = prefix
+		}
+	}
+	ns.stack = append(ns.stack, decls)
+}
+
+func (ns *namespaceState) pop() {
+	if len(ns.stack) == 0 {
+		return
+	}
+	decls := ns.stack[len(ns.stack)-1]
+	ns.stack = ns.stack[:len(ns.stack)-1]
+	for i := len(decls) - 1; i >= 0; i-- {
+		decl := decls[i]
+		if decl.hadPrev {
+			ns.uriToPrefix[decl.uri] = decl.previous
+		} else {
+			delete(ns.uriToPrefix, decl.uri)
+		}
+	}
+}
+
+func (ns *namespaceState) encodeStart(encoder *xml.Encoder, start xml.StartElement) error {
+	ns.push(start)
+	return encoder.EncodeToken(ns.convertStart(start))
+}
+
+func (ns *namespaceState) encodeEnd(encoder *xml.Encoder, end xml.EndElement) error {
+	converted := ns.convertEnd(end)
+	ns.pop()
+	return encoder.EncodeToken(converted)
+}
+
+func (ns *namespaceState) convertStart(start xml.StartElement) xml.StartElement {
+	converted := xml.StartElement{
+		Name: ns.convertName(start.Name),
+		Attr: make([]xml.Attr, len(start.Attr)),
+	}
+	for i, attr := range start.Attr {
+		converted.Attr[i] = ns.convertAttr(attr)
+	}
+	return converted
+}
+
+func (ns *namespaceState) convertEnd(end xml.EndElement) xml.EndElement {
+	return xml.EndElement{Name: ns.convertName(end.Name)}
+}
+
+func (ns *namespaceState) convertAttr(attr xml.Attr) xml.Attr {
+	switch {
+	case attr.Name.Space == "" && attr.Name.Local == "xmlns":
+		return xml.Attr{Name: xml.Name{Local: "xmlns"}, Value: attr.Value}
+	case attr.Name.Space == "xmlns":
+		local := attr.Name.Local
+		if local == "" {
+			return xml.Attr{Name: xml.Name{Local: "xmlns"}, Value: attr.Value}
+		}
+		return xml.Attr{Name: xml.Name{Local: "xmlns:" + local}, Value: attr.Value}
+	default:
+		return xml.Attr{Name: ns.convertName(attr.Name), Value: attr.Value}
+	}
+}
+
+func (ns *namespaceState) convertName(name xml.Name) xml.Name {
+	if name.Local == "" {
+		return xml.Name{}
+	}
+	if name.Space == "" {
+		return xml.Name{Local: name.Local}
+	}
+	if prefix, ok := ns.uriToPrefix[name.Space]; ok {
+		if prefix == "" {
+			return xml.Name{Local: name.Local}
+		}
+		return xml.Name{Local: prefix + ":" + name.Local}
+	}
+	return xml.Name{Local: name.Local}
+}
+
+// UpdateTags returns a copy of the provided XMP document with the TagsList updated to contain the
+// provided tags. When no source is supplied, a minimal XMP document is generated.
+func UpdateTags(source []byte, tags []string) ([]byte, error) {
+	if len(source) == 0 {
+		if len(tags) == 0 {
+			return nil, nil
+		}
+		return buildNewSidecar(tags)
+	}
+
+	updated, err := rewriteTags(source, tags)
+	if err != nil {
+		if len(tags) == 0 {
+			return source, nil
+		}
+		return buildNewSidecar(tags)
+	}
+	return updated, nil
+}
+
+func rewriteTags(source []byte, tags []string) ([]byte, error) {
+	decoder := xml.NewDecoder(bytes.NewReader(source))
+	buffer := &bytes.Buffer{}
+	encoder := xml.NewEncoder(buffer)
+	encoder.Indent("", "  ")
+	ns := newNamespaceState()
+
+	var (
+		insideTagsList bool
+		nestedDepth    int
+		tagsListFound  bool
+	)
+
+	for {
+		token, err := decoder.Token()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		switch tok := token.(type) {
+		case xml.StartElement:
+			if tok.Name.Space == namespaceDigiKam && tok.Name.Local == "TagsList" {
+				insideTagsList = true
+				nestedDepth = 0
+				tagsListFound = true
+				if err = ns.encodeStart(encoder, tok); err != nil {
+					return nil, err
+				}
+				continue
+			}
+			if insideTagsList {
+				ns.push(tok)
+				nestedDepth++
+				continue
+			}
+			if err = ns.encodeStart(encoder, tok); err != nil {
+				return nil, err
+			}
+		case xml.EndElement:
+			if insideTagsList {
+				if nestedDepth > 0 {
+					nestedDepth--
+					ns.pop()
+					continue
+				}
+				if err = writeSeq(encoder, ns, tags); err != nil {
+					return nil, err
+				}
+				if err = ns.encodeEnd(encoder, tok); err != nil {
+					return nil, err
+				}
+				insideTagsList = false
+				continue
+			}
+			if tok.Name.Space == namespaceRDF && tok.Name.Local == "RDF" && !tagsListFound && len(tags) > 0 {
+				if err = writeDescription(encoder, ns, tags); err != nil {
+					return nil, err
+				}
+				tagsListFound = true
+			}
+			if err = ns.encodeEnd(encoder, tok); err != nil {
+				return nil, err
+			}
+		case xml.CharData:
+			if insideTagsList {
+				continue
+			}
+			if err = encoder.EncodeToken(tok); err != nil {
+				return nil, err
+			}
+		case xml.Comment:
+			if insideTagsList {
+				continue
+			}
+			if err = encoder.EncodeToken(tok); err != nil {
+				return nil, err
+			}
+		case xml.Directive, xml.ProcInst:
+			if err = encoder.EncodeToken(tok); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	if insideTagsList {
+		return nil, errors.New("unterminated TagsList element")
+	}
+	if !tagsListFound && len(tags) > 0 {
+		return nil, errors.New("missing RDF Description to attach TagsList")
+	}
+
+	if err := encoder.Flush(); err != nil {
+		return nil, err
+	}
+
+	return buffer.Bytes(), nil
+}
+
+func buildNewSidecar(tags []string) ([]byte, error) {
+	buffer := &bytes.Buffer{}
+	_, _ = buffer.WriteString("<?xpacket begin='\ufeff' id='W5M0MpCehiHzreSzNTczkc9d'?>\n")
+
+	encoder := xml.NewEncoder(buffer)
+	encoder.Indent("", "  ")
+	ns := newNamespaceState()
+
+	xmpStart := xml.StartElement{
+		Name: xml.Name{Space: namespaceX, Local: "xmpmeta"},
+		Attr: []xml.Attr{
+			{Name: xml.Name{Space: "xmlns", Local: "x"}, Value: namespaceX},
+		},
+	}
+	if err := ns.encodeStart(encoder, xmpStart); err != nil {
+		return nil, err
+	}
+
+	rdfStart := xml.StartElement{
+		Name: xml.Name{Space: namespaceRDF, Local: "RDF"},
+		Attr: []xml.Attr{
+			{Name: xml.Name{Space: "xmlns", Local: "rdf"}, Value: namespaceRDF},
+		},
+	}
+	if err := ns.encodeStart(encoder, rdfStart); err != nil {
+		return nil, err
+	}
+
+	if err := writeDescription(encoder, ns, tags); err != nil {
+		return nil, err
+	}
+
+	if err := ns.encodeEnd(encoder, rdfStart.End()); err != nil {
+		return nil, err
+	}
+	if err := ns.encodeEnd(encoder, xmpStart.End()); err != nil {
+		return nil, err
+	}
+
+	if err := encoder.Flush(); err != nil {
+		return nil, err
+	}
+
+	_, _ = buffer.WriteString("\n<?xpacket end='w'?>")
+	return buffer.Bytes(), nil
+}
+
+func writeDescription(encoder *xml.Encoder, ns *namespaceState, tags []string) error {
+	descStart := xml.StartElement{
+		Name: xml.Name{Space: namespaceRDF, Local: "Description"},
+		Attr: []xml.Attr{
+			{Name: xml.Name{Space: namespaceRDF, Local: "about"}, Value: ""},
+			{Name: xml.Name{Space: "xmlns", Local: "digiKam"}, Value: namespaceDigiKam},
+		},
+	}
+	if err := ns.encodeStart(encoder, descStart); err != nil {
+		return err
+	}
+
+	tagsStart := xml.StartElement{Name: xml.Name{Space: namespaceDigiKam, Local: "TagsList"}}
+	if err := ns.encodeStart(encoder, tagsStart); err != nil {
+		return err
+	}
+
+	if err := writeSeq(encoder, ns, tags); err != nil {
+		return err
+	}
+
+	if err := ns.encodeEnd(encoder, tagsStart.End()); err != nil {
+		return err
+	}
+
+	return ns.encodeEnd(encoder, descStart.End())
+}
+
+func writeSeq(encoder *xml.Encoder, ns *namespaceState, tags []string) error {
+	seqStart := xml.StartElement{Name: xml.Name{Space: namespaceRDF, Local: "Seq"}}
+	if err := ns.encodeStart(encoder, seqStart); err != nil {
+		return err
+	}
+
+	for _, tag := range tags {
+		liStart := xml.StartElement{Name: xml.Name{Space: namespaceRDF, Local: "li"}}
+		if err := ns.encodeStart(encoder, liStart); err != nil {
+			return err
+		}
+		if err := encoder.EncodeToken(xml.CharData(tag)); err != nil {
+			return err
+		}
+		if err := ns.encodeEnd(encoder, liStart.End()); err != nil {
+			return err
+		}
+	}
+
+	return ns.encodeEnd(encoder, seqStart.End())
+}

--- a/internal/exif/sidecars/xmpsidecar/write_test.go
+++ b/internal/exif/sidecars/xmpsidecar/write_test.go
@@ -1,0 +1,123 @@
+package xmpsidecar
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/simulot/immich-go/internal/assets"
+)
+
+func TestUpdateTagsWithExistingSidecar(t *testing.T) {
+	source, err := os.ReadFile("DATA/159d9172-2a1e-4d95-aef1-b5133549927b.jpg.xmp")
+	if err != nil {
+		t.Fatalf("read sample sidecar: %v", err)
+	}
+
+	result, err := UpdateTags(source, []string{"activities/outdoors", "Trips/Europe"})
+	if err != nil {
+		t.Fatalf("update tags: %v", err)
+	}
+	if len(result) == 0 {
+		t.Fatal("expected updated sidecar content")
+	}
+
+	md := &assets.Metadata{}
+	if err = ReadXMP(bytes.NewReader(result), md); err != nil {
+		t.Fatalf("parse updated sidecar: %v", err)
+	}
+
+	if len(md.Tags) != 2 {
+		t.Fatalf("expected 2 tags, got %d", len(md.Tags))
+	}
+	expected := map[string]struct{}{
+		"activities/outdoors": {},
+		"Trips/Europe":        {},
+	}
+	for _, tag := range md.Tags {
+		if _, ok := expected[tag.Value]; !ok {
+			t.Fatalf("unexpected tag %q", tag.Value)
+		}
+	}
+	if md.Rating != 4 {
+		t.Fatalf("expected rating preserved, got %d", md.Rating)
+	}
+}
+
+func TestUpdateTagsWithoutSource(t *testing.T) {
+	result, err := UpdateTags(nil, []string{"New/Tag"})
+	if err != nil {
+		t.Fatalf("build new sidecar: %v", err)
+	}
+	if len(result) == 0 {
+		t.Fatal("expected new sidecar content")
+	}
+
+	md := &assets.Metadata{}
+	if err = ReadXMP(bytes.NewReader(result), md); err != nil {
+		t.Fatalf("parse generated sidecar: %v", err)
+	}
+	if len(md.Tags) != 1 || md.Tags[0].Value != "New/Tag" {
+		t.Fatalf("unexpected tags %#v", md.Tags)
+	}
+}
+
+func TestUpdateTagsPreservesNamespaces(t *testing.T) {
+	source, err := os.ReadFile("testdata/C0092.xmp")
+	if err != nil {
+		t.Fatalf("read sample sony sidecar: %v", err)
+	}
+
+	tags := []string{"volume/a6700", "{immich-go}/2025-10-13 00:07:30"}
+	result, err := UpdateTags(source, tags)
+	if err != nil {
+		t.Fatalf("update tags: %v", err)
+	}
+
+	if strings.Contains(string(result), "_xmlns") {
+		t.Fatalf("unexpected namespace mangling in output:\n%s", result)
+	}
+	if !strings.Contains(string(result), "<x:xmpmeta") {
+		t.Fatalf("expected x:xmpmeta element in output:\n%s", result)
+	}
+
+	md := &assets.Metadata{}
+	if err = ReadXMP(bytes.NewReader(result), md); err != nil {
+		t.Fatalf("parse updated sony sidecar: %v", err)
+	}
+	if len(md.Tags) != len(tags) {
+		t.Fatalf("expected %d tags, got %d", len(tags), len(md.Tags))
+	}
+	expected := map[string]struct{}{
+		"volume/a6700":                    {},
+		"{immich-go}/2025-10-13 00:07:30": {},
+	}
+	for _, tag := range md.Tags {
+		if _, ok := expected[tag.Value]; !ok {
+			t.Fatalf("unexpected tag %q", tag.Value)
+		}
+	}
+}
+
+func TestUpdateTagsAddsDigiKamBlock(t *testing.T) {
+	source, err := os.ReadFile("testdata/C0092.xmp")
+	if err != nil {
+		t.Fatalf("read sample sony sidecar: %v", err)
+	}
+
+	tags := []string{"volume/a6700", "{immich-go}/2025-10-13 00:07:30"}
+	result, err := UpdateTags(source, tags)
+	if err != nil {
+		t.Fatalf("update tags: %v", err)
+	}
+
+	resultStr := string(result)
+	expectedBlock := "    <rdf:Description rdf:about=\"\" xmlns:digiKam=\"http://www.digikam.org/ns/1.0/\">\n      <digiKam:TagsList>\n        <rdf:Seq>\n          <rdf:li>volume/a6700</rdf:li>\n          <rdf:li>{immich-go}/2025-10-13 00:07:30</rdf:li>\n        </rdf:Seq>\n      </digiKam:TagsList>\n    </rdf:Description>\n"
+	if !strings.Contains(resultStr, expectedBlock) {
+		t.Fatalf("expected DigiKam block in output, missing:\n%s", expectedBlock)
+	}
+	if strings.Count(resultStr, expectedBlock) != 1 {
+		t.Fatalf("expected DigiKam block exactly once")
+	}
+}


### PR DESCRIPTION
fixes #990 

Write tags into a temporary XMP sidecar before uploading, instead of using Immich tag APIs as a workaround for Immich's race condition in https://github.com/immich-app/immich/issues/16747.
This means tags are attached as part of the initial POST asset upload, in the `sidecarData` multipart, instead of as subsequent calls to Immich's API.
If there's no sidecar, we create one (with just the tags), and if there is one, we losslessly modify its copy, by adding tags to it before sending it to Immich. 

## Changes

- cleans up the generated files after upload
- introduce XMP sidecar tag writer helpers and expand the reader so existing tags, ratings, and namespaces round-trip correctly when merging sidecars
- document the new flag and cover the sidecar writer with unit tests and fixture updates
- adds DEBUG logs for the new functionality
- adds tests