### PR TITLE
fix: prevent default folder uploads from creating albums when not asked to

### DIFF
--- a/adapters/folder/commands.go
+++ b/adapters/folder/commands.go
@@ -57,7 +57,7 @@ type ImportFolderCmd struct {
 func (ifc *ImportFolderCmd) RegisterFlags(flags *pflag.FlagSet, cmd *cobra.Command) {
 	ifc.Recursive = true
 	ifc.supportedMedia = filetypes.DefaultSupportedMedia
-	ifc.UsePathAsAlbumName = "none"
+	ifc.UsePathAsAlbumName = FolderModeNone
 	ifc.BannedFiles, _ = namematcher.New(shared.DefaultBannedFiles...)
 
 	flags.Var(&ifc.BannedFiles, "ban-file", "Exclude a file based on a pattern (case-insensitive). Can be specified multiple times.")

--- a/adapters/folder/commands_test.go
+++ b/adapters/folder/commands_test.go
@@ -1,0 +1,30 @@
+package folder
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+func TestRegisterFlagsSetsAlbumModeNone(t *testing.T) {
+	var ifc ImportFolderCmd
+	cmd := &cobra.Command{Use: "from-folder"}
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+
+	ifc.RegisterFlags(flags, cmd)
+
+	if ifc.UsePathAsAlbumName != FolderModeNone {
+		t.Fatalf("expected default album mode %q, got %q", FolderModeNone, ifc.UsePathAsAlbumName)
+	}
+}
+
+func TestAlbumFolderModeSetAcceptsNone(t *testing.T) {
+	var mode AlbumFolderMode
+	if err := mode.Set("none"); err != nil {
+		t.Fatalf("unexpected error setting mode: %v", err)
+	}
+	if mode != FolderModeNone {
+		t.Fatalf("expected mode %q, got %q", FolderModeNone, mode)
+	}
+}

--- a/adapters/folder/folderCli.go
+++ b/adapters/folder/folderCli.go
@@ -23,7 +23,7 @@ func (m AlbumFolderMode) String() string {
 func (m *AlbumFolderMode) Set(v string) error {
 	v = strings.TrimSpace(strings.ToUpper(v))
 	switch v {
-	case string(FolderModeFolder), string(FolderModePath):
+	case string(FolderModeFolder), string(FolderModePath), string(FolderModeNone):
 		*m = AlbumFolderMode(v)
 	default:
 		return fmt.Errorf("invalid value for folder mode, expected %s, %s or %s", FolderModeFolder, FolderModePath, FolderModeNone)


### PR DESCRIPTION
## Issue

I'm seeing an album with an empty name created when uploading images, even when no option that indicates an album should be created (like `--folder-as-album` or `--into-album`) is added.

Here's what I see in logs: 

```
{"time":"2025-10-13T09:12:58.989093-07:00","level":"INFO","msg":"added to an album","file":"fixture_metadata:pixel-photo/PXL_20250215_001150100.jpg","album":""}
{"time":"2025-10-13T09:12:58.995687-07:00","level":"INFO","msg":"created album","album":"","assets":2}
```

## Root cause

- In ImportFolderCmd.RegisterFlags the default is assigned as the lowercase string "none" instead of the AlbumFolderMode constant `adapters/folder/commands.go:60` Because the enum values are uppercase ("NONE", "FOLDER", "PATH"), the later check ifc.UsePathAsAlbumName != FolderModeNone evaluates true for the default, so the album-building branch always runs.
- Inside that branch the switch has no matching case, leaving Album as the empty string; nevertheless a.Albums is set to []assets.Album{{Title: ""}}, so every upload is queued for an album whose key/title is "" `adapters/folder/run.go:394-431`.
- The upload pipeline dutifully creates that album, yielding the added to an album and created album log lines with an empty title `app/upload/run.go:533-542`, `app/upload/run.go:499-544`.

## Fix Summary
- ensure the default folder uploader album mode uses the NONE constant
- allow AlbumFolderMode to accept "none" input explicitly
- add regression tests covering the default and parser behavior

## Testing
- GOCACHE=/Volumes/Projects/Software/mio/immich-go/.gocache go test ./adapters/folder -run TestRegisterFlagsSetsAlbumModeNone