### PR TITLE
Fix: Ensure `--overwrite` is respected for checksum matches

### DIFF
--- a/app/upload/advice.go
+++ b/app/upload/advice.go
@@ -261,6 +261,9 @@ func (ii *immichIndex) ShouldUpload(la *assets.Asset, upCmd *UpCmd) (*Advice, er
 		if ii.isAlreadyProcessed(checksum) {
 			return ii.adviceAlreadyProcessed(sa), nil
 		}
+		if upCmd.Overwrite {
+			return ii.adviceForceUpload(sa), nil
+		}
 		return ii.adviceSameOnServer(sa), nil
 	}
 


### PR DESCRIPTION
**Problem:**
Previously, if a local asset had the same checksum as a server asset, the upload was immediately skipped as a duplicate (`SameOnServer`). This happened before the `--overwrite` flag was ever checked, preventing users from force-replacing a binary-identical file.

**Solution:**
This PR modifies the `ShouldUpload` logic to check for the `Overwrite` flag within the checksum validation block. The order of checks is now:
1.  Is it an in-session duplicate? (Skip)
2.  Is `--overwrite` enabled? (Force Upload)
3.  Otherwise, it's a server duplicate. (Skip)

This ensures user intent to overwrite is respected while maintaining the efficiency of skipping redundant local uploads.

Resolves issue #1137 