### PR TITLE
feat: add smaller duplicate check to google takeout

### DIFF
--- a/app/upload/ui.go
+++ b/app/upload/ui.go
@@ -270,10 +270,11 @@ func (uc *UpCmd) newUI(ctx context.Context, a *app.Application) *uiPage {
 	ui.addCounter(ui.prepareCounts, 3, "Discarded files", fileevent.DiscoveredDiscarded)
 	ui.addCounter(ui.prepareCounts, 4, "Unsupported files", fileevent.DiscoveredUnsupported)
 	ui.addCounter(ui.prepareCounts, 5, "Duplicates in the input", fileevent.AnalysisLocalDuplicate)
-	ui.addCounter(ui.prepareCounts, 6, "Files with a sidecar", fileevent.AnalysisAssociatedMetadata)
-	ui.addCounter(ui.prepareCounts, 7, "Files without sidecar", fileevent.AnalysisMissingAssociatedMetadata)
+	ui.addCounter(ui.prepareCounts, 6, "Smaller Duplicates", fileevent.AnalysisSmallerLocalDuplicate)
+	ui.addCounter(ui.prepareCounts, 7, "Files with a sidecar", fileevent.AnalysisAssociatedMetadata)
+	ui.addCounter(ui.prepareCounts, 8, "Files without sidecar", fileevent.AnalysisMissingAssociatedMetadata)
 
-	ui.prepareCounts.SetSize(8, 2, 1, 1).SetColumns(30, 10)
+	ui.prepareCounts.SetSize(9, 2, 1, 1).SetColumns(30, 10)
 
 	ui.uploadCounts = tview.NewGrid()
 	ui.uploadCounts.SetBorder(true).SetTitle("Uploading")

--- a/app/upload/upload.go
+++ b/app/upload/upload.go
@@ -132,7 +132,7 @@ func NewUploadCommand(ctx context.Context, app *app.Application) *cobra.Command 
 
 // Run is called back by the actual asset reader
 func (uc *UpCmd) Run(cmd *cobra.Command, adapter adapters.Reader) error {
-	uc.Mode = UpModeFolder // TODO
+	uc.Mode = UpModeGoogleTakeout // TODO
 
 	// ready to run
 	ctx := cmd.Context()

--- a/internal/fileevent/fileevents.go
+++ b/internal/fileevent/fileevents.go
@@ -34,6 +34,7 @@ const (
 	AnalysisAssociatedMetadata
 	AnalysisMissingAssociatedMetadata
 	AnalysisLocalDuplicate
+	AnalysisSmallerLocalDuplicate
 
 	UploadNotSelected
 	UploadUpgraded        // = "Server's asset upgraded"
@@ -70,6 +71,7 @@ var _code = map[Code]string{
 	AnalysisAssociatedMetadata:        "associated metadata file",
 	AnalysisMissingAssociatedMetadata: "missing associated metadata file",
 	AnalysisLocalDuplicate:            "file duplicated in the input",
+	AnalysisSmallerLocalDuplicate:     "smaller duplicate",
 
 	UploadNotSelected:     "file not selected",
 	UploadUpgraded:        "server's asset upgraded with the input",
@@ -100,6 +102,7 @@ var _logLevels = map[Code]slog.Level{
 	AnalysisAssociatedMetadata:        slog.LevelInfo,
 	AnalysisMissingAssociatedMetadata: slog.LevelWarn,
 	AnalysisLocalDuplicate:            slog.LevelWarn,
+	AnalysisSmallerLocalDuplicate:     slog.LevelWarn,
 	UploadNotSelected:                 slog.LevelWarn,
 	UploadUpgraded:                    slog.LevelInfo,
 	UploadServerBetter:                slog.LevelInfo,
@@ -178,6 +181,7 @@ func (r *Recorder) Report() string {
 		DiscoveredDiscarded,
 		DiscoveredUnsupported,
 		AnalysisLocalDuplicate,
+		AnalysisSmallerLocalDuplicate,
 		AnalysisAssociatedMetadata,
 		AnalysisMissingAssociatedMetadata,
 	} {
@@ -195,6 +199,7 @@ func (r *Recorder) Report() string {
 			DiscoveredDiscarded,
 			DiscoveredUnsupported,
 			AnalysisLocalDuplicate,
+			AnalysisSmallerLocalDuplicate,
 			AnalysisAssociatedMetadata,
 			AnalysisMissingAssociatedMetadata,
 		} {
@@ -258,7 +263,8 @@ func (r *Recorder) TotalProcessed(forcedMissingJSON bool) int64 {
 		atomic.LoadInt64(&r.counts[UploadServerDuplicate]) +
 		atomic.LoadInt64(&r.counts[UploadServerBetter]) +
 		atomic.LoadInt64(&r.counts[DiscoveredDiscarded]) +
-		atomic.LoadInt64(&r.counts[AnalysisLocalDuplicate])
+		atomic.LoadInt64(&r.counts[AnalysisLocalDuplicate]) +
+		atomic.LoadInt64(&r.counts[AnalysisSmallerLocalDuplicate])
 	if !forcedMissingJSON {
 		v += atomic.LoadInt64(&r.counts[AnalysisMissingAssociatedMetadata])
 	}

--- a/internal/journal/journal.go
+++ b/internal/journal/journal.go
@@ -14,26 +14,27 @@ type Journal struct {
 type Action string
 
 const (
-	DiscoveredFile     Action = "File"
-	ScannedImage       Action = "Scanned image"
-	ScannedVideo       Action = "Scanned video"
-	Discarded          Action = "Discarded"
-	Uploaded           Action = "Uploaded"
-	Upgraded           Action = "Server's asset upgraded"
-	ERROR              Action = "Error"
-	LocalDuplicate     Action = "Local duplicate"
-	ServerDuplicate    Action = "Server has photo"
-	Stacked            Action = "Stacked"
-	ServerBetter       Action = "Server's asset is better"
-	Album              Action = "Added to an album"
-	LivePhoto          Action = "Live photo"
-	FailedVideo        Action = "Failed video"
-	Unsupported        Action = "File type not supported"
-	Metadata           Action = "Metadata files"
-	AssociatedMetadata Action = "Associated with metadata"
-	INFO               Action = "Info"
-	NotSelected        Action = "Not selected because options"
-	ServerError        Action = "Server error"
+	DiscoveredFile        Action = "File"
+	ScannedImage          Action = "Scanned image"
+	ScannedVideo          Action = "Scanned video"
+	Discarded             Action = "Discarded"
+	Uploaded              Action = "Uploaded"
+	Upgraded              Action = "Server's asset upgraded"
+	ERROR                 Action = "Error"
+	LocalDuplicate        Action = "Local duplicate"
+	SmallerLocalDuplicate Action = "Smaller Local duplicate"
+	ServerDuplicate       Action = "Server has photo"
+	Stacked               Action = "Stacked"
+	ServerBetter          Action = "Server's asset is better"
+	Album                 Action = "Added to an album"
+	LivePhoto             Action = "Live photo"
+	FailedVideo           Action = "Failed video"
+	Unsupported           Action = "File type not supported"
+	Metadata              Action = "Metadata files"
+	AssociatedMetadata    Action = "Associated with metadata"
+	INFO                  Action = "Info"
+	NotSelected           Action = "Not selected because options"
+	ServerError           Action = "Server error"
 )
 
 func NewJournal(log Logger) *Journal {
@@ -71,7 +72,7 @@ func (j *Journal) AddEntry(file string, action Action, comment ...string) {
 
 func (j *Journal) Report() {
 	checkFiles := j.counts[ScannedImage] + j.counts[ScannedVideo] + j.counts[Metadata] + j.counts[Unsupported] + j.counts[FailedVideo] + j.counts[Discarded]
-	handledFiles := j.counts[NotSelected] + j.counts[LocalDuplicate] + j.counts[ServerDuplicate] + j.counts[ServerBetter] + j.counts[Uploaded] + j.counts[Upgraded] + j.counts[ServerError]
+	handledFiles := j.counts[NotSelected] + j.counts[LocalDuplicate] + j.counts[SmallerLocalDuplicate] + j.counts[ServerDuplicate] + j.counts[ServerBetter] + j.counts[Uploaded] + j.counts[Upgraded] + j.counts[ServerError]
 	j.Log.OK("Scan of the sources:")
 	j.Log.OK("%6d files in the input", j.counts[DiscoveredFile])
 	j.Log.OK("--------------------------------------------------------")
@@ -91,6 +92,7 @@ func (j *Journal) Report() {
 	j.Log.OK("%6d files already on the server", j.counts[ServerDuplicate])
 	j.Log.OK("%6d discarded files because of options", j.counts[NotSelected])
 	j.Log.OK("%6d discarded files because duplicated in the input", j.counts[LocalDuplicate])
+	j.Log.OK("%6d discarded files because smaller duplicate", j.counts[SmallerLocalDuplicate])
 	j.Log.OK("%6d discarded files because server has a better image", j.counts[ServerBetter])
 	j.Log.OK("%6d errors when uploading", j.counts[ServerError])
 


### PR DESCRIPTION
Add a filename check that ignores extension so it can find duplicated live/motion photos and videos.

resolves #1142 