### PR TITLE
fix(ci): prevent E2E workflow failure on push validation

### DIFF
--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -43,6 +43,12 @@ jobs:
           # 2. Is the comment body exactly `/run-e2e`?
           # 3. Is the author a maintainer (MEMBER or OWNER)?
 
+          if [[ "${{ github.event_name }}" != "issue_comment" ]]; then
+            echo "Not triggered by issue comment. Skipping."
+            echo "should_run=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
           if [[ "${{ github.event.issue.pull_request }}" == "" ]]
           then
             echo "This comment is not on a pull request. Skipping."


### PR DESCRIPTION
This PR fixes the E2E Tests (Maintainer Trigger) workflow to prevent failures during GitHub's automatic push validation runs.

## Changes
- Added a check in the `check-trigger` job to verify the event type is `issue_comment` before proceeding
- This prevents the workflow from attempting to access `github.event.comment` properties when triggered by push events
- Ensures the workflow validates successfully on pushes while maintaining its intended behavior for maintainer-triggered E2E tests

## Testing
The workflow will now skip gracefully during push validations and only execute when a maintainer comments `/run-e2e` on a PR.