### PR TITLE
add --sidecar-format flag for XMP sidecar generation

### DIFF
--- a/adapters/folder/run.go
+++ b/adapters/folder/run.go
@@ -364,6 +364,12 @@ func (ifc *ImportFolderCmd) parseDir(ctx context.Context, fsys fs.FS, dir string
 				}
 			}
 
+			// If no JSON but XMP exists, promote XMP metadata to FromApplication for upload
+			// This ensures XMP sidecars created by immich-go archive command can be re-imported
+			if a.FromApplication == nil && a.FromSideCar != nil {
+				a.FromApplication = a.FromSideCar
+			}
+
 			// Read metadata from the file only id needed (date range or take date from filename)
 			if ifc.requiresDateInformation {
 				// try to get date from icloud takeout meta

--- a/adapters/folder/writeFolder.go
+++ b/adapters/folder/writeFolder.go
@@ -6,11 +6,14 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"log/slog"
 	"os"
 	"path"
 
 	"github.com/simulot/immich-go/internal/assets"
+	"github.com/simulot/immich-go/internal/exif/sidecars"
 	"github.com/simulot/immich-go/internal/exif/sidecars/jsonsidecar"
+	"github.com/simulot/immich-go/internal/exif/sidecars/xmpsidecar"
 	"github.com/simulot/immich-go/internal/fshelper"
 	"github.com/simulot/immich-go/internal/fshelper/debugfiles"
 )
@@ -24,17 +27,21 @@ type closer interface {
 	Close() error
 }
 type LocalAssetWriter struct {
-	WriteToFS  fs.FS
-	createdDir map[string]struct{}
+	WriteToFS     fs.FS
+	createdDir    map[string]struct{}
+	SidecarFormat sidecars.SidecarFormat
+	Log           *slog.Logger
 }
 
-func NewLocalAssetWriter(fsys fs.FS, writeToPath string) (*LocalAssetWriter, error) {
+func NewLocalAssetWriter(fsys fs.FS, writeToPath string, format sidecars.SidecarFormat, log *slog.Logger) (*LocalAssetWriter, error) {
 	if _, ok := fsys.(fshelper.FSCanWrite); !ok {
 		return nil, errors.New("FS does not support writing")
 	}
 	return &LocalAssetWriter{
-		WriteToFS:  fsys,
-		createdDir: make(map[string]struct{}),
+		WriteToFS:     fsys,
+		createdDir:    make(map[string]struct{}),
+		SidecarFormat: format,
+		Log:           log,
 	}, nil
 }
 
@@ -110,28 +117,59 @@ func (w *LocalAssetWriter) WriteAsset(ctx context.Context, a *assets.Asset) erro
 			if err != nil {
 				return err
 			}
-			// XMP?
-			if a.FromSideCar != nil {
-				// Sidecar file is set, copy it
-				var scr fs.File
-				scr, err = a.FromSideCar.File.Open()
-				if err != nil {
-					return err
+
+			// Warn about data loss when using XMP-only format
+			if w.SidecarFormat == sidecars.FormatXMP && a.FromApplication != nil {
+				var lostFields []string
+				if a.FromApplication.Trashed {
+					lostFields = append(lostFields, "Trashed")
 				}
-				debugfiles.TrackOpenFile(scr, a.FromSideCar.File.Name())
-				defer scr.Close()
-				defer debugfiles.TrackCloseFile(scr)
-				var scw fshelper.WFile
-				scw, err = fshelper.OpenFile(w.WriteToFS, path.Join(dir, base+".XMP"), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o644)
-				if err != nil {
-					return err
+				if a.FromApplication.Archived {
+					lostFields = append(lostFields, "Archived")
 				}
-				_, err = io.Copy(scw, scr)
-				scw.Close()
+				if a.FromApplication.FromPartner {
+					lostFields = append(lostFields, "FromPartner")
+				}
+				if len(lostFields) > 0 && w.Log != nil {
+					w.Log.Warn("XMP format cannot preserve some metadata",
+						"file", a.OriginalFileName,
+						"lost_fields", lostFields)
+				}
 			}
 
-			// Having metadata from an Application or immich-go JSON?
-			if a.FromApplication != nil {
+			// Write XMP sidecar if format requires it
+			if w.SidecarFormat.CreatesXMP() {
+				if a.FromSideCar != nil && a.FromSideCar.File.FS() != nil {
+					// Existing XMP sidecar file - copy it
+					var scr fs.File
+					scr, err = a.FromSideCar.File.Open()
+					if err != nil {
+						return err
+					}
+					debugfiles.TrackOpenFile(scr, a.FromSideCar.File.Name())
+					defer scr.Close()
+					defer debugfiles.TrackCloseFile(scr)
+					var scw fshelper.WFile
+					scw, err = fshelper.OpenFile(w.WriteToFS, path.Join(dir, base+".xmp"), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o644)
+					if err != nil {
+						return err
+					}
+					_, err = io.Copy(scw, scr)
+					scw.Close()
+				} else if a.FromApplication != nil {
+					// Generate XMP from FromApplication metadata
+					var scw fshelper.WFile
+					scw, err = fshelper.OpenFile(w.WriteToFS, path.Join(dir, base+".xmp"), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o644)
+					if err != nil {
+						return err
+					}
+					err = xmpsidecar.Write(a.FromApplication, scw)
+					scw.Close()
+				}
+			}
+
+			// Write JSON sidecar if format requires it
+			if w.SidecarFormat.CreatesJSON() && a.FromApplication != nil {
 				var scw fshelper.WFile
 				scw, err = fshelper.OpenFile(w.WriteToFS, path.Join(dir, base+".JSON"), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o644)
 				if err != nil {

--- a/app/archive/archiveCmd.go
+++ b/app/archive/archiveCmd.go
@@ -9,13 +9,15 @@ import (
 	gp "github.com/simulot/immich-go/adapters/googlePhotos"
 	"github.com/simulot/immich-go/app"
 	"github.com/simulot/immich-go/internal/assettracker"
+	"github.com/simulot/immich-go/internal/exif/sidecars"
 	"github.com/simulot/immich-go/internal/fileevent"
 	"github.com/simulot/immich-go/internal/fileprocessor"
 	"github.com/spf13/cobra"
 )
 
 type ArchiveCmd struct {
-	ArchivePath string
+	ArchivePath   string
+	SidecarFormat sidecars.SidecarFormat
 
 	app  *app.Application
 	dest *folder.LocalAssetWriter
@@ -27,11 +29,13 @@ func NewArchiveCommand(ctx context.Context, app *app.Application) *cobra.Command
 		Short: "Archive various sources of photos to a file system",
 	}
 	ac := &ArchiveCmd{
-		app: app,
+		app:           app,
+		SidecarFormat: sidecars.FormatJSON, // Default to JSON for backward compatibility
 	}
 
 	cmd.PersistentFlags().StringVarP(&ac.ArchivePath, "write-to-folder", "w", "", "Path where to write the archive")
 	_ = cmd.MarkPersistentFlagRequired("write-to-folder")
+	cmd.PersistentFlags().Var(&ac.SidecarFormat, "sidecar-format", "Sidecar format: json (default), xmp, or both")
 
 	cmd.AddCommand(folder.NewFromFolderCommand(ctx, cmd, app, ac))
 	cmd.AddCommand(folder.NewFromICloudCommand(ctx, cmd, app, ac))

--- a/app/archive/run.go
+++ b/app/archive/run.go
@@ -34,7 +34,7 @@ func (ac *ArchiveCmd) Run(cmd *cobra.Command, adapter adapters.Reader) error {
 	}
 
 	destFS := osfs.DirFS(p)
-	ac.dest, err = folder.NewLocalAssetWriter(destFS, ".")
+	ac.dest, err = folder.NewLocalAssetWriter(destFS, ".", ac.SidecarFormat, log.Logger)
 	if err != nil {
 		return err
 	}

--- a/docs/commands/archive.md
+++ b/docs/commands/archive.md
@@ -17,10 +17,12 @@ destination-folder/
 ├── 2022/
 │   ├── 2022-01/
 │   │   ├── photo01.jpg
-│   │   └── photo01.jpg.JSON    # Metadata file
+│   │   ├── photo01.jpg.JSON    # Metadata (with --sidecar-format json or both)
+│   │   └── photo01.jpg.xmp     # XMP sidecar (with --sidecar-format xmp or both)
 │   └── 2022-02/
 │       ├── photo02.jpg
-│       └── photo02.jpg.JSON
+│       ├── photo02.jpg.JSON
+│       └── photo02.jpg.xmp
 ├── 2023/
 │   ├── 2023-03/
 │   └── 2023-04/
@@ -31,9 +33,43 @@ destination-folder/
 
 ## Required Options
 
-| Option | Description |
-|--------|-------------|
+| Option              | Description                            |
+|---------------------|----------------------------------------|
 | `--write-to-folder` | Destination folder for archived photos |
+
+## Archive Options
+
+| Option             | Default | Description                              |
+|--------------------|---------|------------------------------------------|
+| `--sidecar-format` | `json`  | Sidecar format: `json`, `xmp`, or `both` |
+
+### Sidecar Format
+
+The `--sidecar-format` option controls which metadata sidecar files are created:
+
+| Format | Description                                                                                                                                                     |
+|--------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `json` | Creates `.JSON` sidecars with full metadata. Best for round-trip with immich-go.                                                                                |
+| `xmp`  | Creates `.xmp` sidecars using standard XMP format. Interoperable with other applications and supported by Immich in external libraries or on immich-cli upload. |
+| `both` | Creates both `.JSON` and `.xmp` sidecars. Maximum compatibility.                                                                                                |
+
+#### XMP Field Mapping
+
+When using `xmp` or `both` format, the following fields are preserved:
+
+| Metadata Field | XMP Path                                  | Notes                                  |
+|----------------|-------------------------------------------|----------------------------------------|
+| DateTaken      | `exif:DateTimeOriginal`                   | ISO-8601 format                        |
+| Description    | `dc:description`, `tiff:ImageDescription` | Both namespaces for compatibility      |
+| Rating         | `xmp:Rating`                              | 0-5 scale                              |
+| Favorited      | `xmp:Rating`                              | Stored as Rating=5 when Favorited=true |
+| Tags           | `digiKam:TagsList`                        | Hierarchical paths                     |
+| Albums         | `digiKam:TagsList`                        | As `Albums/<AlbumName>` prefix         |
+| GPS            | `exif:GPSLatitude`, `exif:GPSLongitude`   | DMS format                             |
+
+**Fields NOT preserved in XMP** (JSON-only): `Trashed`, `Archived`, `FromPartner`, `FileName`
+
+A warning is logged when using `--sidecar-format xmp` for assets with these non-preservable fields.
 
 ## Sub-commands
 
@@ -127,7 +163,22 @@ immich-go archive from-google-photos \
 immich-go archive from-folder \
   --write-to-folder=/organized \
   /messy/photo/folders
+```
 
+### Archive with XMP Sidecars
+```bash
+# Create XMP sidecars for use with other applications
+immich-go archive from-google-photos \
+  --sidecar-format=xmp \
+  --write-to-folder=/organized-photos \
+  /path/to/takeout-*.zip
+
+# Create both JSON and XMP for maximum compatibility
+immich-go archive from-immich \
+  --server=http://localhost:2283 \
+  --api-key=your-key \
+  --sidecar-format=both \
+  --write-to-folder=/backup
 ```
 
 ## Use Cases

--- a/internal/exif/sidecars/format.go
+++ b/internal/exif/sidecars/format.go
@@ -1,0 +1,50 @@
+package sidecars
+
+import (
+	"fmt"
+	"strings"
+)
+
+// SidecarFormat specifies which sidecar format(s) to create during archive operations
+type SidecarFormat string
+
+const (
+	// FormatJSON creates JSON sidecars only (default, supports later upload with immich-go without losing data like `Trashed`, `Archived`, `FromPartner`, `FileName`)
+	FormatJSON SidecarFormat = "json"
+	// FormatXMP creates XMP sidecars only (interoperable with other applications and supported by Immich in external libraries or on immich-cli upload)
+	FormatXMP SidecarFormat = "xmp"
+	// FormatBoth creates both JSON and XMP sidecars
+	FormatBoth SidecarFormat = "both"
+)
+
+// String returns the string representation of the format
+func (f SidecarFormat) String() string {
+	return string(f)
+}
+
+// Set implements pflag.Value interface
+func (f *SidecarFormat) Set(s string) error {
+	s = strings.ToLower(strings.TrimSpace(s))
+	switch s {
+	case "json", "xmp", "both":
+		*f = SidecarFormat(s)
+		return nil
+	default:
+		return fmt.Errorf("invalid sidecar format %q: must be json, xmp, or both", s)
+	}
+}
+
+// Type implements pflag.Value interface
+func (f *SidecarFormat) Type() string {
+	return "string"
+}
+
+// CreatesJSON returns true if this format creates JSON sidecars
+func (f SidecarFormat) CreatesJSON() bool {
+	return f == FormatJSON || f == FormatBoth
+}
+
+// CreatesXMP returns true if this format creates XMP sidecars
+func (f SidecarFormat) CreatesXMP() bool {
+	return f == FormatXMP || f == FormatBoth
+}

--- a/internal/exif/sidecars/xmpsidecar/write.go
+++ b/internal/exif/sidecars/xmpsidecar/write.go
@@ -1,0 +1,134 @@
+package xmpsidecar
+
+import (
+	"html"
+	"io"
+	"text/template"
+
+	"github.com/simulot/immich-go/internal/assets"
+)
+
+// xmpData holds the prepared data for XMP template rendering
+type xmpData struct {
+	Description  string
+	DateTaken    string
+	Rating       int
+	GPSLatitude  string
+	GPSLongitude string
+	TagsList     []string
+}
+
+func Write(md *assets.Metadata, w io.Writer) error {
+	data := prepareXMPData(md)
+	return xmpTemplate.Execute(w, data)
+}
+
+func prepareXMPData(md *assets.Metadata) xmpData {
+	data := xmpData{}
+
+	if md.Description != "" {
+		data.Description = html.EscapeString(md.Description)
+	}
+
+	if !md.DateTaken.IsZero() {
+		data.DateTaken = TimeToString(md.DateTaken)
+	}
+
+	// Rating - if Favorited and no explicit rating, set to 5
+	rating := int(md.Rating)
+	if md.Favorited && rating == 0 {
+		rating = 5
+	}
+	data.Rating = rating
+
+	if md.Latitude != 0 {
+		data.GPSLatitude = GPSFloatToString(md.Latitude, true)
+	}
+	if md.Longitude != 0 {
+		data.GPSLongitude = GPSFloatToString(md.Longitude, false)
+	}
+
+	// Combine tags and albums into TagsList
+	// Tags are stored as-is, albums are prefixed with "Albums/"
+	for _, tag := range md.Tags {
+		if tag.Value != "" {
+			data.TagsList = append(data.TagsList, html.EscapeString(tag.Value))
+		}
+	}
+	for _, album := range md.Albums {
+		if album.Title != "" {
+			data.TagsList = append(data.TagsList, "Albums/"+html.EscapeString(album.Title))
+		}
+	}
+
+	return data
+}
+
+// hasExifBlock returns true if any EXIF fields are present
+func (d xmpData) HasExifBlock() bool {
+	return d.DateTaken != "" || d.GPSLatitude != "" || d.GPSLongitude != ""
+}
+
+// HasTagsList returns true if there are any tags or albums
+func (d xmpData) HasTagsList() bool {
+	return len(d.TagsList) > 0
+}
+
+// HasDescription returns true if description is set
+func (d xmpData) HasDescription() bool {
+	return d.Description != ""
+}
+
+// HasRating returns true if rating is set (> 0)
+func (d xmpData) HasRating() bool {
+	return d.Rating > 0
+}
+
+const xmpTemplateText = `<?xpacket begin='' id='W5M0MpCehiHzreSzNTczkc9d'?>
+<x:xmpmeta xmlns:x='adobe:ns:meta/' x:xmptk='immich-go'>
+<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'>
+{{if .HasDescription}}
+ <rdf:Description rdf:about=''
+  xmlns:dc='http://purl.org/dc/elements/1.1/'>
+  <dc:description>
+   <rdf:Alt>
+    <rdf:li xml:lang='x-default'>{{.Description}}</rdf:li>
+   </rdf:Alt>
+  </dc:description>
+ </rdf:Description>
+
+ <rdf:Description rdf:about=''
+  xmlns:tiff='http://ns.adobe.com/tiff/1.0/'>
+  <tiff:ImageDescription>
+   <rdf:Alt>
+    <rdf:li xml:lang='x-default'>{{.Description}}</rdf:li>
+   </rdf:Alt>
+  </tiff:ImageDescription>
+ </rdf:Description>
+{{end}}{{if .HasTagsList}}
+ <rdf:Description rdf:about=''
+  xmlns:digiKam='http://www.digikam.org/ns/1.0/'>
+  <digiKam:TagsList>
+   <rdf:Seq>
+{{range .TagsList}}    <rdf:li>{{.}}</rdf:li>
+{{end}}   </rdf:Seq>
+  </digiKam:TagsList>
+ </rdf:Description>
+{{end}}{{if .HasExifBlock}}
+ <rdf:Description rdf:about=''
+  xmlns:exif='http://ns.adobe.com/exif/1.0/'>
+{{if .DateTaken}}  <exif:DateTimeOriginal>{{.DateTaken}}</exif:DateTimeOriginal>
+{{end}}{{if .GPSLatitude}}  <exif:GPSLatitude>{{.GPSLatitude}}</exif:GPSLatitude>
+{{end}}{{if .GPSLongitude}}  <exif:GPSLongitude>{{.GPSLongitude}}</exif:GPSLongitude>
+{{end}} </rdf:Description>
+{{end}}{{if .HasRating}}
+ <rdf:Description rdf:about=''
+  xmlns:xmp='http://ns.adobe.com/xap/1.0/'>
+  <xmp:Rating>{{.Rating}}</xmp:Rating>
+ </rdf:Description>
+{{end}}</rdf:RDF>
+</x:xmpmeta>
+<?xpacket end='w'?>
+`
+
+var xmpTemplate = template.Must(template.New("xmp").Parse(xmpTemplateText))

--- a/internal/exif/sidecars/xmpsidecar/write_test.go
+++ b/internal/exif/sidecars/xmpsidecar/write_test.go
@@ -1,0 +1,263 @@
+package xmpsidecar
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/simulot/immich-go/internal/assets"
+)
+
+func TestWrite(t *testing.T) {
+	tc := []struct {
+		name     string
+		metadata assets.Metadata
+		validate func(t *testing.T, output string)
+	}{
+		{
+			name: "basic fields",
+			metadata: assets.Metadata{
+				Description: "Test description",
+				DateTaken:   time.Date(2023, 10, 15, 14, 30, 0, 0, time.UTC),
+				Rating:      4,
+			},
+			validate: func(t *testing.T, output string) {
+				if !strings.Contains(output, "Test description") {
+					t.Error("expected description in output")
+				}
+				if !strings.Contains(output, "2023-10-15T14:30:00Z") {
+					t.Error("expected date in output")
+				}
+				if !strings.Contains(output, "<xmp:Rating>4</xmp:Rating>") {
+					t.Error("expected rating in output")
+				}
+			},
+		},
+		{
+			name: "GPS coordinates",
+			metadata: assets.Metadata{
+				Latitude:  48.8583736,
+				Longitude: 2.291901,
+			},
+			validate: func(t *testing.T, output string) {
+				if !strings.Contains(output, "exif:GPSLatitude") {
+					t.Error("expected GPS latitude in output")
+				}
+				if !strings.Contains(output, "exif:GPSLongitude") {
+					t.Error("expected GPS longitude in output")
+				}
+				// Verify positive latitude has N
+				if !strings.Contains(output, "N") {
+					t.Error("expected N for positive latitude")
+				}
+				// Verify positive longitude has E
+				if !strings.Contains(output, "E") {
+					t.Error("expected E for positive longitude")
+				}
+			},
+		},
+		{
+			name: "negative GPS coordinates",
+			metadata: assets.Metadata{
+				Latitude:  -33.8688,
+				Longitude: -151.2093,
+			},
+			validate: func(t *testing.T, output string) {
+				// Verify negative latitude has S
+				if !strings.Contains(output, "S") {
+					t.Error("expected S for negative latitude")
+				}
+				// Verify negative longitude has W
+				if !strings.Contains(output, "W") {
+					t.Error("expected W for negative longitude")
+				}
+			},
+		},
+		{
+			name: "tags",
+			metadata: assets.Metadata{
+				Tags: []assets.Tag{
+					{Name: "outdoors", Value: "activities/outdoors"},
+					{Name: "travel", Value: "travel"},
+				},
+			},
+			validate: func(t *testing.T, output string) {
+				if !strings.Contains(output, "digiKam:TagsList") {
+					t.Error("expected TagsList in output")
+				}
+				if !strings.Contains(output, "activities/outdoors") {
+					t.Error("expected tag value in output")
+				}
+				if !strings.Contains(output, "travel") {
+					t.Error("expected second tag in output")
+				}
+			},
+		},
+		{
+			name: "albums as tags",
+			metadata: assets.Metadata{
+				Albums: []assets.Album{
+					{Title: "Vacation 2023"},
+					{Title: "Family"},
+				},
+			},
+			validate: func(t *testing.T, output string) {
+				if !strings.Contains(output, "Albums/Vacation 2023") {
+					t.Error("expected album as tag with Albums/ prefix")
+				}
+				if !strings.Contains(output, "Albums/Family") {
+					t.Error("expected second album as tag")
+				}
+			},
+		},
+		{
+			name: "favorited sets rating to 5",
+			metadata: assets.Metadata{
+				Favorited: true,
+				Rating:    0, // No explicit rating
+			},
+			validate: func(t *testing.T, output string) {
+				if !strings.Contains(output, "<xmp:Rating>5</xmp:Rating>") {
+					t.Error("expected rating 5 for favorited item")
+				}
+			},
+		},
+		{
+			name: "favorited does not override explicit rating",
+			metadata: assets.Metadata{
+				Favorited: true,
+				Rating:    3,
+			},
+			validate: func(t *testing.T, output string) {
+				if !strings.Contains(output, "<xmp:Rating>3</xmp:Rating>") {
+					t.Error("expected original rating 3 to be preserved")
+				}
+				if strings.Contains(output, "<xmp:Rating>5</xmp:Rating>") {
+					t.Error("should not override explicit rating with 5")
+				}
+			},
+		},
+		{
+			name: "empty metadata",
+			metadata: assets.Metadata{},
+			validate: func(t *testing.T, output string) {
+				// Should still have XMP header
+				if !strings.Contains(output, "<?xpacket") {
+					t.Error("expected xpacket header")
+				}
+				if !strings.Contains(output, "x:xmpmeta") {
+					t.Error("expected xmpmeta element")
+				}
+				// Should not have any content blocks
+				if strings.Contains(output, "dc:description") {
+					t.Error("should not have description block for empty metadata")
+				}
+				if strings.Contains(output, "digiKam:TagsList") {
+					t.Error("should not have tags block for empty metadata")
+				}
+			},
+		},
+		{
+			name: "special characters in description",
+			metadata: assets.Metadata{
+				Description: "Test with <special> & \"characters\"",
+			},
+			validate: func(t *testing.T, output string) {
+				// Should be XML escaped
+				if strings.Contains(output, "<special>") {
+					t.Error("special characters should be escaped")
+				}
+				if !strings.Contains(output, "&lt;special&gt;") {
+					t.Error("expected < and > to be escaped")
+				}
+				if !strings.Contains(output, "&amp;") {
+					t.Error("expected & to be escaped")
+				}
+			},
+		},
+	}
+
+	for _, c := range tc {
+		t.Run(c.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			err := Write(&c.metadata, &buf)
+			if err != nil {
+				t.Fatalf("Write failed: %v", err)
+			}
+			output := buf.String()
+			c.validate(t, output)
+		})
+	}
+}
+
+func TestWriteReadRoundTrip(t *testing.T) {
+	tc := []struct {
+		name     string
+		metadata assets.Metadata
+	}{
+		{
+			name: "basic roundtrip",
+			metadata: assets.Metadata{
+				Description: "Test description",
+				DateTaken:   time.Date(2023, 10, 15, 14, 30, 0, 0, time.UTC),
+				Rating:      4,
+				Tags: []assets.Tag{
+					{Name: "outdoors", Value: "activities/outdoors"},
+				},
+			},
+		},
+		{
+			name: "GPS roundtrip",
+			metadata: assets.Metadata{
+				Latitude:  48.8583736,
+				Longitude: 2.291901,
+			},
+		},
+		{
+			name: "negative GPS roundtrip",
+			metadata: assets.Metadata{
+				Latitude:  -33.8688,
+				Longitude: -151.2093,
+			},
+		},
+	}
+
+	for _, c := range tc {
+		t.Run(c.name, func(t *testing.T) {
+			// Write
+			var buf bytes.Buffer
+			err := Write(&c.metadata, &buf)
+			if err != nil {
+				t.Fatalf("Write failed: %v", err)
+			}
+
+			// Read back
+			readMd := &assets.Metadata{}
+			err = ReadXMP(bytes.NewReader(buf.Bytes()), readMd)
+			if err != nil {
+				t.Fatalf("ReadXMP failed: %v", err)
+			}
+
+			// Compare
+			if c.metadata.Description != "" && readMd.Description != c.metadata.Description {
+				t.Errorf("description mismatch: expected %q, got %q", c.metadata.Description, readMd.Description)
+			}
+			if !c.metadata.DateTaken.IsZero() && !readMd.DateTaken.Equal(c.metadata.DateTaken) {
+				t.Errorf("date mismatch: expected %v, got %v", c.metadata.DateTaken, readMd.DateTaken)
+			}
+			if c.metadata.Rating != 0 && readMd.Rating != c.metadata.Rating {
+				t.Errorf("rating mismatch: expected %d, got %d", c.metadata.Rating, readMd.Rating)
+			}
+			if c.metadata.Latitude != 0 && !floatIsEqual(readMd.Latitude, c.metadata.Latitude) {
+				t.Errorf("latitude mismatch: expected %f, got %f", c.metadata.Latitude, readMd.Latitude)
+			}
+			if c.metadata.Longitude != 0 && !floatIsEqual(readMd.Longitude, c.metadata.Longitude) {
+				t.Errorf("longitude mismatch: expected %f, got %f", c.metadata.Longitude, readMd.Longitude)
+			}
+			if len(c.metadata.Tags) > 0 && len(readMd.Tags) != len(c.metadata.Tags) {
+				t.Errorf("tags count mismatch: expected %d, got %d", len(c.metadata.Tags), len(readMd.Tags))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add XMP sidecar creation support to the archive command with --sidecar-format json|xmp|both flag. Also fix upload to use XMP metadata when no JSON sidecar exists.

fixes #1273 