### PR TITLE
Ensures that multiple tags are being honored, instead of just getting the first one

### DIFF
--- a/app/upload/run.go
+++ b/app/upload/run.go
@@ -552,12 +552,8 @@ func (uc *UpCmd) manageAssetTags(ctx context.Context, a *assets.Asset) {
 		return
 	}
 
-	tags := make([]string, len(a.Tags))
-	for i := range a.Tags {
-		tags[i] = a.Tags[i].Name
-	}
 	for _, t := range a.Tags {
-		if uc.tagsCache.AddIDToCollection(t.Name, t, a.ID) {
+		if uc.tagsCache.AddIDToCollection(t.Value, t, a.ID) {
 			// Record tag event
 			uc.app.FileProcessor().Logger().Record(ctx, fileevent.ProcessedTagged, a.File, "tag", t.Value)
 		}

--- a/internal/assets/asset.go
+++ b/internal/assets/asset.go
@@ -164,7 +164,7 @@ func (a *Asset) MergeTags(t2 []Tag) {
 	for _, tag := range t2 {
 		found := false
 		for _, existingTag := range a.Tags {
-			if existingTag.Name == tag.Name {
+			if existingTag.Value == tag.Value {
 				found = true
 				break
 			}


### PR DESCRIPTION
It relates to this issue: #1279

When merging tags, only the name was being used, but when the tags are loaded from the json sidecar file, only the value is expected, having only the name set to `""`. 
Aside from that, the value is also used for manage the asset tags for the same reason. 

A tiny cleanup of a for loop that was initializing a variable that was never used