### PR TITLE
fix(archive): writing files with correct name

### DIFF
--- a/adapters/fromimmich/command.go
+++ b/adapters/fromimmich/command.go
@@ -3,6 +3,7 @@ package fromimmich
 import (
 	"context"
 	"fmt"
+	"path"
 	"slices"
 	"strings"
 	"time"
@@ -400,6 +401,14 @@ func (fic *FromImmichCmd) getAssets(ctx context.Context, grpChan chan *assets.Gr
 		}
 		asset.UseMetadata(asset.FromApplication)
 		asset.File = fshelper.FSName(fic.ifs, a.ID)
+
+		// Set the base filename to the Immich UUID with the proper extension
+		// Use the extension from OriginalFileName if available
+		ext := ""
+		if a.OriginalFileName != "" {
+			ext = path.Ext(a.OriginalFileName)
+		}
+		asset.Base = a.ID + ext
 
 		// Record asset discovery
 		code := fileevent.DiscoveredImage


### PR DESCRIPTION
This resolves https://github.com/simulot/immich-go/issues/1246

Using the following command:

`./immich-go archive from-immich --from-server https://immich.hobbithole.dev -w ~/immich-test --from-api-key $IMMICH_API_KEY`, I would get a list of files like this. The expectation is to get the same UUID that's stored in Immich.

find immich-test/
immich-test/
immich-test/2025
immich-test/2025/2025-10
immich-test/2025/2025-10/2.JSON
immich-test/2025/2025-10/3.JSON
immich-test/2025/2025-10/4.JSON
immich-test/2025/2025-10/2
immich-test/2025/2025-10/5
immich-test/2025/2025-10/5.JSON
immich-test/2025/2025-10/4
immich-test/2025/2025-10/3
immich-test/2025/2025-10/6.JSON
immich-test/2025/2025-10/6
immich-test/2025/2025-10/1
immich-test/2025/2025-10/1.JSON

With my patch, it now downloads and creates files as expected:

/Users/jftheroux/immich-test/2025/2025-12
/Users/jftheroux/immich-test/2025/2025-12/c993e570-3d1a-42b7-b886-0edbc08b2064.mp4
/Users/jftheroux/immich-test/2025/2025-12/c993e570-3d1a-42b7-b886-0edbc08b2064.mp4.JSON
/Users/jftheroux/immich-test/2025/2025-12/869ff097-6a81-4fca-afbd-1fb6bf4ec4d3.jpg
/Users/jftheroux/immich-test/2025/2025-12/4c309510-ae40-410f-945a-4da006def8c0.mp4.JSON
/Users/jftheroux/immich-test/2025/2025-12/198a49aa-fd6a-4084-b0fa-29f6d490ba86.jpg.JSON
/Users/jftheroux/immich-test/2025/2025-12/f3f4051a-c4a4-4695-9781-78aab48b4542.DNG
/Users/jftheroux/immich-test/2025/2025-12/7209372c-5d24-4f91-ba49-7d5bcf89c185.jpg
/Users/jftheroux/immich-test/2025/2025-12/3dbe5982-6f22-4fcc-a442-0198da546cbe.jpg.JSON
/Users/jftheroux/immich-test/2025/2025-12/4c309510-ae40-410f-945a-4da006def8c0.mp4
/Users/jftheroux/immich-test/2025/2025-12/3dbe5982-6f22-4fcc-a442-0198da546cbe.jpg
/Users/jftheroux/immich-test/2025/2025-12/de186c4a-13b5-42e9-8fa6-a2adc8d30144.jpg.JSON
/Users/jftheroux/immich-test/2025/2025-12/45658bbe-1f0b-414d-aeb9-0093d203f14a.jpg
/Users/jftheroux/immich-test/2025/2025-12/f34391ce-686a-4054-805f-59e74a2f2a9e.DNG
/Users/jftheroux/immich-test/2025/2025-12/f34391ce-686a-4054-805f-59e74a2f2a9e.DNG.JSON
/Users/jftheroux/immich-test/2025/2025-12/f3f4051a-c4a4-4695-9781-78aab48b4542.DNG.JSON
/Users/jftheroux/immich-test/2025/2025-12/45658bbe-1f0b-414d-aeb9-0093d203f14a.jpg.JSON
/Users/jftheroux/immich-test/2025/2025-12/198a49aa-fd6a-4084-b0fa-29f6d490ba86.jpg
/Users/jftheroux/immich-test/2025/2025-12/869ff097-6a81-4fca-afbd-1fb6bf4ec4d3.jpg.JSON
/Users/jftheroux/immich-test/2025/2025-12/de186c4a-13b5-42e9-8fa6-a2adc8d30144.jpg
/Users/jftheroux/immich-test/2025/2025-12/7209372c-5d24-4f91-ba49-7d5bcf89c185.jpg.JSON