### PR TITLE
fix(upload from-google-photos): add --include-failed-videos flag

### DIFF
--- a/adapters/googlePhotos/cmdFromGooglePhotos.go
+++ b/adapters/googlePhotos/cmdFromGooglePhotos.go
@@ -41,6 +41,7 @@ type TakeoutCmd struct {
 	KeepUntitled       bool
 	KeepArchived       bool
 	KeepJSONLess       bool
+	KeepFailedVideos   bool
 	InclusionFlags     cliflags.InclusionFlags
 	BannedFiles        namematcher.List
 	TakeoutTag         bool
@@ -74,6 +75,7 @@ func (toc *TakeoutCmd) RegisterFlags(flags *pflag.FlagSet, cmd *cobra.Command) {
 	flags.StringVar(&toc.PartnerSharedAlbum, "partner-shared-album", "", "Add partner's photo to the specified album name")
 	flags.BoolVarP(&toc.KeepArchived, "include-archived", "a", true, "Import archived Google Photos")
 	flags.BoolVarP(&toc.KeepJSONLess, "include-unmatched", "u", false, "Import photos that do not have a matching JSON file in the takeout")
+	flags.BoolVar(&toc.KeepFailedVideos, "include-failed-videos", false, "Import videos that have been marked by Google Photos as failed")
 	flags.Var(&toc.BannedFiles, "ban-file", "Exclude a file based on a pattern (case-insensitive). Can be specified multiple times.")
 	flags.BoolVar(&toc.TakeoutTag, "takeout-tag", true, "Tag uploaded photos with a tag \"{takeout}/takeout-YYYYMMDDTHHMMSSZ\"")
 	flags.BoolVar(&toc.PeopleTag, "people-tag", true, "Tag uploaded photos with tags \"people/name\" found in the JSON file")

--- a/adapters/googlePhotos/googlephotos.go
+++ b/adapters/googlePhotos/googlephotos.go
@@ -207,12 +207,12 @@ func (toc *TakeoutCmd) passOneFsWalk(ctx context.Context, w fs.FS) error {
 					toc.processor.RecordNonAsset(ctx, fshelper.FSName(w, name), finfo.Size(), fileevent.DiscoveredUnsupported, "reason", "unsupported file type")
 					return nil
 				case filetypes.TypeVideo:
-					if strings.Contains(name, "Failed Videos") {
+					if !toc.KeepFailedVideos && strings.Contains(name, "Failed Videos") {
 						toc.processor.RecordAssetDiscardedImmediately(ctx, fshelper.FSName(w, name), finfo.Size(), fileevent.DiscardedFiltered, "can't upload failed videos")
 						return nil
-					} else {
-						toc.processor.RecordAssetDiscovered(ctx, fshelper.FSName(w, name), finfo.Size(), fileevent.DiscoveredVideo)
 					}
+
+					toc.processor.RecordAssetDiscovered(ctx, fshelper.FSName(w, name), finfo.Size(), fileevent.DiscoveredVideo)
 				case filetypes.TypeImage:
 					toc.processor.RecordAssetDiscovered(ctx, fshelper.FSName(w, name), finfo.Size(), fileevent.DiscoveredImage)
 				}


### PR DESCRIPTION
In some scenarios a user may want to try uploading videos that have been marked by Google Photos as failed, as mentioned in #1242.

This PR adds a flag `--include-failed-videos` that excludes the path check.

I still think the path check can be improved by only checking the path component instead of the whole thing, but this is just the flag addition. 