### PR TITLE
docs: add no-animal-violence Vale package for inclusive language checking

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -5,10 +5,12 @@ StylesPath = .vale/styles
 
 MinAlertLevel = suggestion
 
+Packages = https://github.com/Open-Paws/vale-no-animal-violence/releases/latest/download/NoAnimalViolence.zip
+
 # Glob patterns for files to check
 [*.md]
 # Microsoft Writing Style Guide
-BasedOnStyles = Microsoft
+BasedOnStyles = Microsoft, NoAnimalViolence
 
 # Custom vocabulary
 Vocab = immich-go
@@ -18,4 +20,4 @@ BlockIgnores = (?s) *```[^`]*?```
 TokenIgnores = (?s)`[^`]*?`
 
 # Ignore common patterns
-IgnorePatterns = (?i)\b(TODO|FIXME|NOTE|XXX)\b
+IgnorePatterns = (?i)(TODO|FIXME|NOTE|XXX)


### PR DESCRIPTION
Adds the [NoAnimalViolence](https://github.com/Open-Paws/vale-no-animal-violence) Vale package alongside the existing Microsoft style. This package flags phrases that normalize violence toward animals and suggests clearer professional alternatives.

## Changes

- `.vale.ini`: add `NoAnimalViolence` package URL to a new `Packages =` line and `NoAnimalViolence` to `BasedOnStyles`

## The package

The [vale-no-animal-violence](https://github.com/Open-Paws/vale-no-animal-violence) package detects phrases like:
- "kill two birds with one stone" → "accomplish two things at once"
- "beat a dead horse" → "belabor the point"
- "guinea pig" → "test subject"
- "cattle vs. pets" → "ephemeral vs. persistent"
- "canary deployment" → "progressive rollout"
- "monkey patch" → "runtime patch"

All rules are at `warning` level — informational, not blocking.

Part of the [Open Paws](https://openpaws.ai) no-animal-violence toolchain for inclusive language.