### PR TITLE
feat(synology): add Synology Photos adapter for server-to-server migration

### DIFF
--- a/adapters/synology/client.go
+++ b/adapters/synology/client.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -94,8 +93,6 @@ func NewClient(baseURL, account, password string, opts ...ClientOption) (*Client
 		opt(client)
 	}
 
-	fmt.Fprintf(os.Stderr, "[DEBUG] Client created for base URL: %s\n", baseURL)
-
 	return client, nil
 }
 
@@ -141,9 +138,6 @@ func (c *Client) Login(ctx context.Context) error {
 			Path:       "auth.cgi",
 			MaxVersion: 6,
 		}
-		fmt.Fprintf(os.Stderr, "[DEBUG] Using default API info, path=%s, version=%d\n", apiInfo.Path, apiInfo.MaxVersion)
-	} else {
-		fmt.Fprintf(os.Stderr, "[DEBUG] API info: path=%s, maxVersion=%d\n", apiInfo.Path, apiInfo.MaxVersion)
 	}
 
 	// Build login parameters according to DSM API spec
@@ -162,16 +156,11 @@ func (c *Client) Login(ctx context.Context) error {
 
 	var resp LoginResponse
 	if err := c.doRequest(ctx, http.MethodGet, authPath, params, nil, &resp); err != nil {
-		return fmt.Errorf("login request failed: %w", err)
-	}
-
-	if !resp.Success {
-		return fmt.Errorf("login failed: error code %d (%s)", resp.Error.Code, c.getErrorMessage(resp.Error.Code))
+		return fmt.Errorf("login failed: %w", err)
 	}
 
 	c.sid = resp.Data.SID
 	c.did = resp.Data.DID
-	fmt.Fprintf(os.Stderr, "[DEBUG] Login successful!\n")
 	return nil
 }
 
@@ -486,15 +475,12 @@ func (c *Client) doAuthenticatedRequest(ctx context.Context, method, path string
 
 // doRequest performs an HTTP request with retries
 func (c *Client) doRequest(ctx context.Context, method, path string, params url.Values, body io.Reader, result interface{}) error {
-	var lastErr error
-
 	for attempt := 0; attempt < c.maxRetries; attempt++ {
 		if attempt > 0 {
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
 			case <-time.After(c.retryDelay * time.Duration(attempt)):
-				// Exponential backoff
 			}
 		}
 
@@ -503,7 +489,6 @@ func (c *Client) doRequest(ctx context.Context, method, path string, params url.
 			return fmt.Errorf("invalid URL: %w", err)
 		}
 
-		// Add query parameters
 		if len(params) > 0 {
 			reqURL = reqURL + "?" + params.Encode()
 		}
@@ -520,24 +505,28 @@ func (c *Client) doRequest(ctx context.Context, method, path string, params url.
 
 		resp, err := c.httpClient.Do(req)
 		if err != nil {
-			lastErr = err
-			continue // Retry on network error
+			if attempt < c.maxRetries-1 {
+				continue
+			}
+			return fmt.Errorf("http request failed: %w", err)
 		}
 
 		respBody, err := io.ReadAll(resp.Body)
 		resp.Body.Close()
 
 		if err != nil {
-			lastErr = fmt.Errorf("read response: %w", err)
-			continue
+			if attempt < c.maxRetries-1 {
+				continue
+			}
+			return fmt.Errorf("read response: %w", err)
 		}
 
 		if resp.StatusCode != http.StatusOK {
-			lastErr = fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(respBody))
-			continue
+			if attempt < c.maxRetries-1 {
+				continue
+			}
+			return fmt.Errorf("http %d: %s", resp.StatusCode, string(respBody))
 		}
-
-		fmt.Fprintf(os.Stderr, "[DEBUG] Response body: %s\n", string(respBody))
 
 		// Parse response
 		var baseResp struct {
@@ -546,38 +535,42 @@ func (c *Client) doRequest(ctx context.Context, method, path string, params url.
 		}
 
 		if err := json.Unmarshal(respBody, &baseResp); err != nil {
-			lastErr = fmt.Errorf("parse response: %w (body: %s)", err, string(respBody))
+			if attempt < c.maxRetries-1 {
+				continue
+			}
+			return fmt.Errorf("parse response: %w", err)
+		}
+
+		// Handle session expiration - re-login and retry
+		if !baseResp.Success && baseResp.Error != nil && baseResp.Error.Code == 119 {
+			c.sid = ""
+			if err := c.Login(ctx); err != nil {
+				if attempt < c.maxRetries-1 {
+					continue
+				}
+				return fmt.Errorf("re-login after session expired: %w", err)
+			}
+			params.Set("_sid", c.sid)
 			continue
 		}
 
-		// Handle API error response
+		// Handle other API errors
 		if !baseResp.Success {
-			if baseResp.Error != nil && baseResp.Error.Code == 119 {
-				// Session expired - try to re-login
-				c.sid = ""
-				if err := c.Login(ctx); err != nil {
-					lastErr = err
-					continue
-				}
-				// Update params with new session ID
-				params.Set("_sid", c.sid)
-				continue
-			}
-			// Other API error - return immediately
 			if baseResp.Error != nil {
-				return fmt.Errorf("API error: code %d (%s)", baseResp.Error.Code, c.getErrorMessage(baseResp.Error.Code))
+				return fmt.Errorf("synology api error %d: %s", baseResp.Error.Code, c.getErrorMessage(baseResp.Error.Code))
 			}
-			return fmt.Errorf("API error: success=false but no error code")
+			return fmt.Errorf("synology api error: success=false")
 		}
 
+		// Parse result
 		if result != nil {
 			if err := json.Unmarshal(respBody, result); err != nil {
-				return fmt.Errorf("parse result: %w (body: %s)", err, string(respBody))
+				return fmt.Errorf("parse result: %w", err)
 			}
 		}
 
 		return nil
 	}
 
-	return fmt.Errorf("max retries exceeded: %w", lastErr)
+	return fmt.Errorf("max retries exceeded")
 }

--- a/adapters/synology/client.go
+++ b/adapters/synology/client.go
@@ -1,0 +1,462 @@
+package synology
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	defaultTimeout      = 30 * time.Second
+	defaultMaxRetries   = 3
+	defaultRetryDelay   = 1 * time.Second
+	defaultLimit        = 100
+)
+
+// Client is a Synology Photos API client
+type Client struct {
+	baseURL    string
+	account    string
+	password   string
+	sid        string
+	did        string
+	httpClient *http.Client
+	maxRetries int
+	retryDelay time.Duration
+}
+
+// ClientOption is a functional option for the Client
+type ClientOption func(*Client)
+
+// WithHTTPClient sets a custom HTTP client
+func WithHTTPClient(httpClient *http.Client) ClientOption {
+	return func(c *Client) {
+		c.httpClient = httpClient
+	}
+}
+
+// WithInsecureSkipVerify skips SSL certificate verification
+func WithInsecureSkipVerify(skip bool) ClientOption {
+	return func(c *Client) {
+		if transport, ok := c.httpClient.Transport.(*http.Transport); ok {
+			transport.TLSClientConfig.InsecureSkipVerify = skip
+		}
+	}
+}
+
+// WithTimeout sets the HTTP client timeout
+func WithTimeout(timeout time.Duration) ClientOption {
+	return func(c *Client) {
+		c.httpClient.Timeout = timeout
+	}
+}
+
+// WithRetries sets the maximum number of retries
+func WithRetries(maxRetries int) ClientOption {
+	return func(c *Client) {
+		c.maxRetries = maxRetries
+	}
+}
+
+// NewClient creates a new Synology Photos API client
+func NewClient(baseURL, account, password string, opts ...ClientOption) (*Client, error) {
+	// Clean up the base URL
+	baseURL = strings.TrimRight(baseURL, "/")
+
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true, // Default to insecure for self-signed certs
+		},
+		MaxIdleConns:        10,
+		IdleConnTimeout:     90 * time.Second,
+		MaxIdleConnsPerHost: 10,
+	}
+
+	client := &Client{
+		baseURL:    baseURL,
+		account:    account,
+		password:   password,
+		httpClient: &http.Client{Timeout: defaultTimeout, Transport: transport},
+		maxRetries: defaultMaxRetries,
+		retryDelay: defaultRetryDelay,
+	}
+
+	// Apply options
+	for _, opt := range opts {
+		opt(client)
+	}
+
+	return client, nil
+}
+
+// Login authenticates with the Synology server
+func (c *Client) Login(ctx context.Context) error {
+	params := url.Values{
+		"api":     {"SYNO.API.Auth"},
+		"version": {"3"},
+		"method":  {"login"},
+		"account": {c.account},
+		"passwd":  {c.password},
+	}
+
+	var resp LoginResponse
+	if err := c.doRequest(ctx, http.MethodPost, "/webapi/auth.cgi", params, nil, &resp); err != nil {
+		return fmt.Errorf("login failed: %w", err)
+	}
+
+	if !resp.Success {
+		return fmt.Errorf("login failed: error code %d", resp.Error.Code)
+	}
+
+	c.sid = resp.Data.SID
+	c.did = resp.Data.DID
+	return nil
+}
+
+// Logout ends the session
+func (c *Client) Logout(ctx context.Context) error {
+	if c.sid == "" {
+		return nil
+	}
+
+	params := url.Values{
+		"api":     {"SYNO.API.Auth"},
+		"version": {"3"},
+		"method":  {"logout"},
+		"_sid":    {c.sid},
+	}
+
+	var resp APIResponse[struct{ Success bool }]
+	err := c.doRequest(ctx, http.MethodGet, "/webapi/auth.cgi", params, nil, &resp)
+
+	c.sid = ""
+	c.did = ""
+
+	return err
+}
+
+// IsAuthenticated returns true if the client has a valid session
+func (c *Client) IsAuthenticated() bool {
+	return c.sid != ""
+}
+
+// ListAlbums retrieves a list of albums
+func (c *Client) ListAlbums(ctx context.Context, offset, limit int) ([]Album, error) {
+	if limit <= 0 {
+		limit = defaultLimit
+	}
+
+	params := url.Values{
+		"api":     {"SYNO.Foto.Browse.Album"},
+		"version": {"1"},
+		"method":  {"list"},
+		"offset":  {strconv.Itoa(offset)},
+		"limit":   {strconv.Itoa(limit)},
+	}
+
+	var resp APIResponse[AlbumListResponse]
+	if err := c.doAuthenticatedRequest(ctx, http.MethodGet, "/webapi/entry.cgi", params, nil, &resp); err != nil {
+		return nil, err
+	}
+
+	return resp.Data.List, nil
+}
+
+// GetAlbumItems retrieves items in a specific album
+func (c *Client) GetAlbumItems(ctx context.Context, albumID int, offset, limit int, additional []string) ([]Item, error) {
+	if limit <= 0 {
+		limit = defaultLimit
+	}
+
+	params := url.Values{
+		"api":        {"SYNO.Foto.Browse.Item"},
+		"version":    {"1"},
+		"method":     {"list"},
+		"offset":     {strconv.Itoa(offset)},
+		"limit":      {strconv.Itoa(limit)},
+		"album_id":   {strconv.Itoa(albumID)},
+	}
+
+	if len(additional) > 0 {
+		additionalJSON, _ := json.Marshal(additional)
+		params.Set("additional", string(additionalJSON))
+	}
+
+	var resp APIResponse[ItemListResponse]
+	if err := c.doAuthenticatedRequest(ctx, http.MethodGet, "/webapi/entry.cgi", params, nil, &resp); err != nil {
+		return nil, err
+	}
+
+	return resp.Data.List, nil
+}
+
+// ListItems retrieves items from folders in the Personal Space
+func (c *Client) ListItems(ctx context.Context, folderID *int, offset, limit int, additional []string) ([]Item, error) {
+	if limit <= 0 {
+		limit = defaultLimit
+	}
+
+	params := url.Values{
+		"api":     {"SYNO.Foto.Browse.Item"},
+		"version": {"1"},
+		"method":  {"list"},
+		"offset":  {strconv.Itoa(offset)},
+		"limit":   {strconv.Itoa(limit)},
+	}
+
+	if folderID != nil {
+		params.Set("folder_id", strconv.Itoa(*folderID))
+	}
+
+	if len(additional) > 0 {
+		additionalJSON, _ := json.Marshal(additional)
+		params.Set("additional", string(additionalJSON))
+	}
+
+	var resp APIResponse[ItemListResponse]
+	if err := c.doAuthenticatedRequest(ctx, http.MethodGet, "/webapi/entry.cgi", params, nil, &resp); err != nil {
+		return nil, err
+	}
+
+	return resp.Data.List, nil
+}
+
+// ListAllItems retrieves all items (no folder filter)
+func (c *Client) ListAllItems(ctx context.Context, offset, limit int, additional []string) ([]Item, error) {
+	return c.ListItems(ctx, nil, offset, limit, additional)
+}
+
+// GetItemDetails retrieves detailed information about a specific item
+func (c *Client) GetItemDetails(ctx context.Context, itemID int, additional []string) (*Item, error) {
+	params := url.Values{
+		"api":     {"SYNO.Foto.Browse.Item"},
+		"version": {"1"},
+		"method":  {"get"},
+		"id":      {strconv.Itoa(itemID)},
+	}
+
+	if len(additional) > 0 {
+		additionalJSON, _ := json.Marshal(additional)
+		params.Set("additional", string(additionalJSON))
+	}
+
+	var resp APIResponse[Item]
+	if err := c.doAuthenticatedRequest(ctx, http.MethodGet, "/webapi/entry.cgi", params, nil, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp.Data, nil
+}
+
+// ListTags retrieves all general tags
+func (c *Client) ListTags(ctx context.Context, offset, limit int) ([]Tag, error) {
+	if limit <= 0 {
+		limit = defaultLimit
+	}
+
+	params := url.Values{
+		"api":     {"SYNO.Foto.Browse.GeneralTag"},
+		"version": {"1"},
+		"method":  {"list"},
+		"offset":  {strconv.Itoa(offset)},
+		"limit":   {strconv.Itoa(limit)},
+	}
+
+	var resp APIResponse[TagListResponse]
+	if err := c.doAuthenticatedRequest(ctx, http.MethodGet, "/webapi/entry.cgi", params, nil, &resp); err != nil {
+		return nil, err
+	}
+
+	return resp.Data.List, nil
+}
+
+// ListPeople retrieves all people (face recognition)
+func (c *Client) ListPeople(ctx context.Context, offset, limit int) ([]Person, error) {
+	if limit <= 0 {
+		limit = defaultLimit
+	}
+
+	params := url.Values{
+		"api":     {"SYNO.Foto.Browse.Person"},
+		"version": {"1"},
+		"method":  {"list"},
+		"offset":  {strconv.Itoa(offset)},
+		"limit":   {strconv.Itoa(limit)},
+	}
+
+	var resp APIResponse[PersonListResponse]
+	if err := c.doAuthenticatedRequest(ctx, http.MethodGet, "/webapi/entry.cgi", params, nil, &resp); err != nil {
+		return nil, err
+	}
+
+	return resp.Data.List, nil
+}
+
+// DownloadItem downloads the original file
+func (c *Client) DownloadItem(ctx context.Context, itemID int, cacheKey string) (io.ReadCloser, error) {
+	params := url.Values{
+		"api":       {"SYNO.Foto.Download"},
+		"version":   {"1"},
+		"method":    {"download"},
+		"unit_id":   {fmt.Sprintf("[%d]", itemID)},
+		"cache_key": {fmt.Sprintf("\"%s\"", cacheKey)},
+	}
+
+	reqURL, err := url.JoinPath(c.baseURL, "/webapi/entry.cgi")
+	if err != nil {
+		return nil, fmt.Errorf("invalid URL: %w", err)
+	}
+
+	fullURL := reqURL + "?" + params.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fullURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("download request failed: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
+		return nil, fmt.Errorf("download failed with status %d", resp.StatusCode)
+	}
+
+	return resp.Body, nil
+}
+
+// GetThumbnailURL returns the URL for a thumbnail
+func (c *Client) GetThumbnailURL(itemID int, cacheKey string, size string) string {
+	if size == "" {
+		size = "xl" // default size
+	}
+
+	params := url.Values{
+		"api":       {"SYNO.Foto.Thumbnail"},
+		"version":   {"1"},
+		"method":    {"get"},
+		"id":        {strconv.Itoa(itemID)},
+		"cache_key": {cacheKey},
+		"type":      {"unit"},
+		"size":      {size},
+	}
+
+	if c.sid != "" {
+		params.Set("_sid", c.sid)
+	}
+
+	return c.baseURL + "/webapi/entry.cgi?" + params.Encode()
+}
+
+// doAuthenticatedRequest makes an authenticated API request
+func (c *Client) doAuthenticatedRequest(ctx context.Context, method, path string, params url.Values, body io.Reader, result interface{}) error {
+	// Ensure we're authenticated
+	if !c.IsAuthenticated() {
+		if err := c.Login(ctx); err != nil {
+			return err
+		}
+	}
+
+	// Add session ID to params
+	params.Set("_sid", c.sid)
+
+	return c.doRequest(ctx, method, path, params, body, result)
+}
+
+// doRequest performs an HTTP request with retries
+func (c *Client) doRequest(ctx context.Context, method, path string, params url.Values, body io.Reader, result interface{}) error {
+	var lastErr error
+
+	for attempt := 0; attempt < c.maxRetries; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(c.retryDelay * time.Duration(attempt)):
+				// Exponential backoff
+			}
+		}
+
+		reqURL, err := url.JoinPath(c.baseURL, path)
+		if err != nil {
+			return fmt.Errorf("invalid URL: %w", err)
+		}
+
+		// Add query parameters
+		if len(params) > 0 {
+			reqURL = reqURL + "?" + params.Encode()
+		}
+
+		req, err := http.NewRequestWithContext(ctx, method, reqURL, body)
+		if err != nil {
+			return fmt.Errorf("create request: %w", err)
+		}
+
+		req.Header.Set("Accept", "application/json")
+		if body != nil {
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		}
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			lastErr = err
+			continue // Retry on network error
+		}
+
+		respBody, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+
+		if err != nil {
+			lastErr = fmt.Errorf("read response: %w", err)
+			continue
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			lastErr = fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(respBody))
+			continue
+		}
+
+		// Parse response
+		var baseResp struct {
+			Success bool   `json:"success"`
+			Error   *Error `json:"error,omitempty"`
+		}
+
+		if err := json.Unmarshal(respBody, &baseResp); err != nil {
+			lastErr = fmt.Errorf("parse response: %w", err)
+			continue
+		}
+
+		// Handle authentication error - try to re-login
+		if !baseResp.Success && baseResp.Error != nil && baseResp.Error.Code == 119 {
+			// Session expired
+			c.sid = ""
+			if err := c.Login(ctx); err != nil {
+				lastErr = err
+				continue
+			}
+			// Update params with new session ID
+			params.Set("_sid", c.sid)
+			continue
+		}
+
+		if result != nil {
+			if err := json.Unmarshal(respBody, result); err != nil {
+				return fmt.Errorf("parse result: %w", err)
+			}
+		}
+
+		return nil
+	}
+
+	return fmt.Errorf("max retries exceeded: %w", lastErr)
+}

--- a/adapters/synology/client.go
+++ b/adapters/synology/client.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	defaultTimeout    = 30 * time.Second
+	defaultTimeout    = 300 * time.Second
 	defaultMaxRetries = 3
 	defaultRetryDelay = 1 * time.Second
 	defaultLimit      = 100
@@ -383,7 +383,7 @@ func (c *Client) ListTags(ctx context.Context, offset, limit int) ([]Tag, error)
 
 	params := url.Values{
 		"api":     {"SYNO.Foto.Browse.GeneralTag"},
-		"version": {"4"},
+		"version": {"1"},
 		"method":  {"list"},
 		"offset":  {strconv.Itoa(offset)},
 		"limit":   {strconv.Itoa(limit)},
@@ -428,7 +428,7 @@ func (c *Client) DownloadItem(ctx context.Context, itemID int, cacheKey string) 
 		"unit_id":   {fmt.Sprintf("[%d]", itemID)},
 		"cache_key": {cacheKey},
 	}
-
+	c.logger.Debug("start download item", "itemID", itemID, "cacheKey", cacheKey)
 	// Build request URL
 	reqURL, err := url.JoinPath(c.baseURL, "/webapi/entry.cgi")
 	if err != nil {
@@ -440,6 +440,7 @@ func (c *Client) DownloadItem(ctx context.Context, itemID int, cacheKey string) 
 		if attempt > 0 {
 			select {
 			case <-ctx.Done():
+				c.logger.Debug("context done error", "err", err)
 				return nil, ctx.Err()
 			case <-time.After(c.retryDelay * time.Duration(attempt)):
 			}
@@ -463,6 +464,7 @@ func (c *Client) DownloadItem(ctx context.Context, itemID int, cacheKey string) 
 
 		resp, err := c.httpClient.Do(req)
 		if err != nil {
+			c.logger.Debug("http error", "err", err)
 			lastErr = err
 			continue
 		}
@@ -505,7 +507,7 @@ func (c *Client) DownloadItem(ctx context.Context, itemID int, cacheKey string) 
 // DownloadLivePhoto downloads a live photo using the source download API.
 // Returns the response body, content-type, and whether it's a ZIP file (based on Content-Disposition).
 // Note: Synology may return either a ZIP (containing both image and video) or just the image file.
-func (c *Client) DownloadLivePhoto(ctx context.Context, itemID int, filename string, logger *slog.Logger) (io.ReadCloser, string, bool, error) {
+func (c *Client) DownloadLivePhoto(ctx context.Context, itemID int, filename string) (io.ReadCloser, string, bool, error) {
 	params := url.Values{
 		"api":            {"SYNO.Foto.Download"},
 		"version":        {"2"},
@@ -514,7 +516,6 @@ func (c *Client) DownloadLivePhoto(ctx context.Context, itemID int, filename str
 		"download_type":  {"source"},
 		"force_download": {"true"},
 	}
-
 	// Build request URL with filename in path (like browser does)
 	reqURL, err := url.JoinPath(c.baseURL, "/webapi/entry.cgi", filename)
 	if err != nil {
@@ -555,7 +556,7 @@ func (c *Client) DownloadLivePhoto(ctx context.Context, itemID int, filename str
 		resp, err := c.httpClient.Do(req)
 		if err != nil {
 			lastErr = err
-			logger.Error("Download failed, retrying", "attempt", attempt, "error", err, "item", itemID, "filename", filename)
+			c.logger.Error("Download failed, retrying", "attempt", attempt, "error", err, "item", itemID, "filename", filename)
 			continue
 		}
 

--- a/adapters/synology/client.go
+++ b/adapters/synology/client.go
@@ -100,24 +100,64 @@ func NewClient(baseURL, account, password string, opts ...ClientOption) (*Client
 func (c *Client) Login(ctx context.Context) error {
 	params := url.Values{
 		"api":     {"SYNO.API.Auth"},
-		"version": {"3"},
+		"version": {"6"},
 		"method":  {"login"},
 		"account": {c.account},
 		"passwd":  {c.password},
+		"session": {"Foto"},
+		"enable_syno_token": {"yes"},
 	}
 
 	var resp LoginResponse
 	if err := c.doRequest(ctx, http.MethodPost, "/webapi/auth.cgi", params, nil, &resp); err != nil {
-		return fmt.Errorf("login failed: %w", err)
+		return fmt.Errorf("login request failed: %w", err)
 	}
 
 	if !resp.Success {
-		return fmt.Errorf("login failed: error code %d", resp.Error.Code)
+		return fmt.Errorf("login failed: error code %d (%s), check your username and password", resp.Error.Code, c.getErrorMessage(resp.Error.Code))
 	}
 
 	c.sid = resp.Data.SID
 	c.did = resp.Data.DID
 	return nil
+}
+
+// getErrorMessage returns a human-readable error message for Synology API error codes
+func (c *Client) getErrorMessage(code int) string {
+	switch code {
+	case 100:
+		return "Unknown error"
+	case 101:
+		return "Invalid parameters - check URL, username and password"
+	case 102:
+		return "The requested method does not exist"
+	case 103:
+		return "The requested method does not support the requested version"
+	case 119:
+		return "Session timeout - session ID not found"
+	case 400:
+		return "Invalid credentials - wrong account or password"
+	case 401:
+		return "Guest account disabled"
+	case 402:
+		return "Account disabled"
+	case 403:
+		return "Permission denied"
+	case 404:
+		return "OTP code required (two-factor authentication)"
+	case 405:
+		return "Failed to authenticate with OTP"
+	case 407:
+		return "Max TOTP retries reached"
+	case 408:
+		return "Password change required"
+	case 409:
+		return "Strong password required"
+	case 410:
+		return "Strong password required for admin"
+	default:
+		return fmt.Sprintf("Unknown error code %d", code)
+	}
 }
 
 // Logout ends the session
@@ -432,7 +472,7 @@ func (c *Client) doRequest(ctx context.Context, method, path string, params url.
 		}
 
 		if err := json.Unmarshal(respBody, &baseResp); err != nil {
-			lastErr = fmt.Errorf("parse response: %w", err)
+			lastErr = fmt.Errorf("parse response: %w (body: %s)", err, string(respBody))
 			continue
 		}
 
@@ -451,7 +491,7 @@ func (c *Client) doRequest(ctx context.Context, method, path string, params url.
 
 		if result != nil {
 			if err := json.Unmarshal(respBody, result); err != nil {
-				return fmt.Errorf("parse result: %w", err)
+				return fmt.Errorf("parse result: %w (body: %s)", err, string(respBody))
 			}
 		}
 

--- a/adapters/synology/client.go
+++ b/adapters/synology/client.go
@@ -15,10 +15,10 @@ import (
 )
 
 const (
-	defaultTimeout      = 30 * time.Second
-	defaultMaxRetries   = 3
-	defaultRetryDelay   = 1 * time.Second
-	defaultLimit        = 100
+	defaultTimeout    = 30 * time.Second
+	defaultMaxRetries = 3
+	defaultRetryDelay = 1 * time.Second
+	defaultLimit      = 100
 )
 
 // Client is a Synology Photos API client
@@ -131,7 +131,7 @@ func (c *Client) QueryAPIInfo(ctx context.Context, apiName string) (*APIInfo, er
 	if !resp.Success {
 		return nil, fmt.Errorf("query API info failed: error %d", resp.Error.Code)
 	}
-
+	c.logger.Debug("API info query successful", "apiName", apiName, "data", resp.Data)
 	if apiInfo, ok := resp.Data[apiName]; ok {
 		return &apiInfo, nil
 	}
@@ -176,6 +176,13 @@ func (c *Client) Login(ctx context.Context) error {
 	if c.did == "" {
 		c.did = resp.Data.DeviceID // Fallback to device_id if did is empty
 	}
+	mask := func(s string) string {
+		if len(s) <= 6 {
+			return "***"
+		}
+		return s[:3] + "***" + s[len(s)-3:]
+	}
+	c.logger.Info("Synology login successful", "sid", mask(c.sid), "did", mask(c.did), "synotoken", mask(c.synotoken))
 	return nil
 }
 
@@ -229,13 +236,6 @@ func (c *Client) getErrorMessage(code int) string {
 	}
 }
 
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 // Logout ends the session
 func (c *Client) Logout(ctx context.Context) error {
 	if c.sid == "" {
@@ -254,7 +254,7 @@ func (c *Client) Logout(ctx context.Context) error {
 
 	c.sid = ""
 	c.did = ""
-
+	c.logger.Info("Synology session logged out")
 	return err
 }
 
@@ -296,12 +296,12 @@ func (c *Client) GetAlbumItems(ctx context.Context, albumID int, offset, limit i
 	}
 
 	params := url.Values{
-		"api":        {"SYNO.Foto.Browse.Item"},
-		"version":    {"4"},
-		"method":     {"list"},
-		"offset":     {strconv.Itoa(offset)},
-		"limit":      {strconv.Itoa(limit)},
-		"album_id":   {strconv.Itoa(albumID)},
+		"api":      {"SYNO.Foto.Browse.Item"},
+		"version":  {"4"},
+		"method":   {"list"},
+		"offset":   {strconv.Itoa(offset)},
+		"limit":    {strconv.Itoa(limit)},
+		"album_id": {strconv.Itoa(albumID)},
 	}
 
 	if len(additional) > 0 {
@@ -603,29 +603,6 @@ func (c *Client) DownloadLivePhoto(ctx context.Context, itemID int, filename str
 	return nil, "", false, fmt.Errorf("download failed after retries: %w", lastErr)
 }
 
-// GetThumbnailURL returns the URL for a thumbnail
-func (c *Client) GetThumbnailURL(itemID int, cacheKey string, size string) string {
-	if size == "" {
-		size = "xl" // default size
-	}
-
-	params := url.Values{
-		"api":       {"SYNO.Foto.Thumbnail"},
-		"version":   {"1"},
-		"method":    {"get"},
-		"id":        {strconv.Itoa(itemID)},
-		"cache_key": {cacheKey},
-		"type":      {"unit"},
-		"size":      {size},
-	}
-
-	if c.sid != "" {
-		params.Set("_sid", c.sid)
-	}
-
-	return c.baseURL + "/webapi/entry.cgi?" + params.Encode()
-}
-
 // doRequestNoAuth performs an HTTP request without authentication (used for login and API info)
 func (c *Client) doRequestNoAuth(ctx context.Context, method, path string, params url.Values, result interface{}) error {
 	reqURL, err := url.JoinPath(c.baseURL, path)
@@ -724,7 +701,7 @@ func (c *Client) doRequestWithAuth(ctx context.Context, method, path string, par
 			req.Header.Set("Content-Type", contentType)
 		}
 
-			// Add X-SYNO-TOKEN header for CSRF protection
+		// Add X-SYNO-TOKEN header for CSRF protection
 		if c.synotoken != "" {
 			req.Header.Set("X-SYNO-TOKEN", c.synotoken)
 		}
@@ -809,4 +786,3 @@ func (c *Client) doRequestWithAuth(ctx context.Context, method, path string, par
 
 	return fmt.Errorf("max retries exceeded")
 }
-

--- a/adapters/synology/client.go
+++ b/adapters/synology/client.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -27,9 +28,11 @@ type Client struct {
 	password   string
 	sid        string
 	did        string
+	synotoken  string // Required for some APIs
 	httpClient *http.Client
 	maxRetries int
 	retryDelay time.Duration
+	logger     *slog.Logger // Optional logger for debugging
 }
 
 // ClientOption is a functional option for the Client
@@ -65,12 +68,20 @@ func WithRetries(maxRetries int) ClientOption {
 	}
 }
 
+// WithLogger sets a logger for debugging
+func WithLogger(logger *slog.Logger) ClientOption {
+	return func(c *Client) {
+		c.logger = logger
+	}
+}
+
 // NewClient creates a new Synology Photos API client
 func NewClient(baseURL, account, password string, opts ...ClientOption) (*Client, error) {
 	// Clean up the base URL
 	baseURL = strings.TrimRight(baseURL, "/")
 
 	transport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment, // Enable HTTP_PROXY/HTTPS_PROXY support
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true, // Default to insecure for self-signed certs
 		},
@@ -113,7 +124,7 @@ func (c *Client) QueryAPIInfo(ctx context.Context, apiName string) (*APIInfo, er
 	}
 
 	var resp APIResponse[map[string]APIInfo]
-	if err := c.doRequest(ctx, http.MethodGet, "/webapi/query.cgi", params, nil, &resp); err != nil {
+	if err := c.doRequestNoAuth(ctx, http.MethodGet, "/webapi/query.cgi", params, &resp); err != nil {
 		return nil, fmt.Errorf("query API info failed: %w", err)
 	}
 
@@ -155,12 +166,16 @@ func (c *Client) Login(ctx context.Context) error {
 	authPath := "/webapi/" + apiInfo.Path
 
 	var resp LoginResponse
-	if err := c.doRequest(ctx, http.MethodGet, authPath, params, nil, &resp); err != nil {
+	if err := c.doRequestNoAuth(ctx, http.MethodGet, authPath, params, &resp); err != nil {
 		return fmt.Errorf("login failed: %w", err)
 	}
 
 	c.sid = resp.Data.SID
 	c.did = resp.Data.DID
+	c.synotoken = resp.Data.SynoToken
+	if c.did == "" {
+		c.did = resp.Data.DeviceID // Fallback to device_id if did is empty
+	}
 	return nil
 }
 
@@ -235,7 +250,7 @@ func (c *Client) Logout(ctx context.Context) error {
 	}
 
 	var resp APIResponse[struct{ Success bool }]
-	err := c.doRequest(ctx, http.MethodGet, "/webapi/auth.cgi", params, nil, &resp)
+	err := c.doRequestNoAuth(ctx, http.MethodGet, "/webapi/auth.cgi", params, &resp)
 
 	c.sid = ""
 	c.did = ""
@@ -249,11 +264,13 @@ func (c *Client) IsAuthenticated() bool {
 }
 
 // ListAlbums retrieves a list of albums
+// Note: SYNO.Foto.Browse.Album may not be available in all DSM versions
 func (c *Client) ListAlbums(ctx context.Context, offset, limit int) ([]Album, error) {
 	if limit <= 0 {
 		limit = defaultLimit
 	}
 
+	// Try SYNO.Foto.Browse.Album first (version 1)
 	params := url.Values{
 		"api":     {"SYNO.Foto.Browse.Album"},
 		"version": {"1"},
@@ -263,8 +280,10 @@ func (c *Client) ListAlbums(ctx context.Context, offset, limit int) ([]Album, er
 	}
 
 	var resp APIResponse[AlbumListResponse]
-	if err := c.doAuthenticatedRequest(ctx, http.MethodGet, "/webapi/entry.cgi", params, nil, &resp); err != nil {
-		return nil, err
+	err := c.doAuthenticatedRequest(ctx, http.MethodPost, "/webapi/entry.cgi", params, nil, &resp)
+	if err != nil {
+		// If Album API fails, try getting items from timeline instead
+		return nil, fmt.Errorf("album API not available: %w", err)
 	}
 
 	return resp.Data.List, nil
@@ -278,7 +297,7 @@ func (c *Client) GetAlbumItems(ctx context.Context, albumID int, offset, limit i
 
 	params := url.Values{
 		"api":        {"SYNO.Foto.Browse.Item"},
-		"version":    {"1"},
+		"version":    {"4"},
 		"method":     {"list"},
 		"offset":     {strconv.Itoa(offset)},
 		"limit":      {strconv.Itoa(limit)},
@@ -291,7 +310,7 @@ func (c *Client) GetAlbumItems(ctx context.Context, albumID int, offset, limit i
 	}
 
 	var resp APIResponse[ItemListResponse]
-	if err := c.doAuthenticatedRequest(ctx, http.MethodGet, "/webapi/entry.cgi", params, nil, &resp); err != nil {
+	if err := c.doAuthenticatedRequest(ctx, http.MethodPost, "/webapi/entry.cgi", params, nil, &resp); err != nil {
 		return nil, err
 	}
 
@@ -306,7 +325,7 @@ func (c *Client) ListItems(ctx context.Context, folderID *int, offset, limit int
 
 	params := url.Values{
 		"api":     {"SYNO.Foto.Browse.Item"},
-		"version": {"1"},
+		"version": {"4"},
 		"method":  {"list"},
 		"offset":  {strconv.Itoa(offset)},
 		"limit":   {strconv.Itoa(limit)},
@@ -322,7 +341,7 @@ func (c *Client) ListItems(ctx context.Context, folderID *int, offset, limit int
 	}
 
 	var resp APIResponse[ItemListResponse]
-	if err := c.doAuthenticatedRequest(ctx, http.MethodGet, "/webapi/entry.cgi", params, nil, &resp); err != nil {
+	if err := c.doAuthenticatedRequest(ctx, http.MethodPost, "/webapi/entry.cgi", params, nil, &resp); err != nil {
 		return nil, err
 	}
 
@@ -364,14 +383,14 @@ func (c *Client) ListTags(ctx context.Context, offset, limit int) ([]Tag, error)
 
 	params := url.Values{
 		"api":     {"SYNO.Foto.Browse.GeneralTag"},
-		"version": {"1"},
+		"version": {"4"},
 		"method":  {"list"},
 		"offset":  {strconv.Itoa(offset)},
 		"limit":   {strconv.Itoa(limit)},
 	}
 
 	var resp APIResponse[TagListResponse]
-	if err := c.doAuthenticatedRequest(ctx, http.MethodGet, "/webapi/entry.cgi", params, nil, &resp); err != nil {
+	if err := c.doAuthenticatedRequest(ctx, http.MethodPost, "/webapi/entry.cgi", params, nil, &resp); err != nil {
 		return nil, err
 	}
 
@@ -407,24 +426,47 @@ func (c *Client) DownloadItem(ctx context.Context, itemID int, cacheKey string) 
 		"version":   {"1"},
 		"method":    {"download"},
 		"unit_id":   {fmt.Sprintf("[%d]", itemID)},
-		"cache_key": {fmt.Sprintf("\"%s\"", cacheKey)},
+		"cache_key": {cacheKey},
 	}
 
+	// Build request URL with auth params
 	reqURL, err := url.JoinPath(c.baseURL, "/webapi/entry.cgi")
 	if err != nil {
 		return nil, fmt.Errorf("invalid URL: %w", err)
 	}
 
-	fullURL := reqURL + "?" + params.Encode()
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fullURL, nil)
+	// Create POST request with params in body
+	reqBody := strings.NewReader(params.Encode())
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, reqBody)
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)
 	}
 
+	// Set required headers
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8")
+	req.Header.Set("Accept", "*/*")
+	req.Header.Set("X-SYNO-TOKEN", c.synotoken)
+	req.Header.Set("Cookie", fmt.Sprintf("id=%s", c.sid))
+
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("download request failed: %w", err)
+	}
+
+	// Check if response is JSON error (Synology returns JSON for API errors even on download)
+	contentType := resp.Header.Get("Content-Type")
+	if strings.Contains(contentType, "application/json") {
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		// Try to parse error
+		var errResp struct {
+			Success bool   `json:"success"`
+			Error   *Error `json:"error,omitempty"`
+		}
+		if json.Unmarshal(body, &errResp) == nil && !errResp.Success && errResp.Error != nil {
+			return nil, fmt.Errorf("download API error %d: %s", errResp.Error.Code, c.getErrorMessage(errResp.Error.Code))
+		}
+		return nil, fmt.Errorf("download failed: %s", string(body))
 	}
 
 	if resp.StatusCode != http.StatusOK {
@@ -458,6 +500,48 @@ func (c *Client) GetThumbnailURL(itemID int, cacheKey string, size string) strin
 	return c.baseURL + "/webapi/entry.cgi?" + params.Encode()
 }
 
+// doRequestNoAuth performs an HTTP request without authentication (used for login and API info)
+func (c *Client) doRequestNoAuth(ctx context.Context, method, path string, params url.Values, result interface{}) error {
+	reqURL, err := url.JoinPath(c.baseURL, path)
+	if err != nil {
+		return fmt.Errorf("invalid URL: %w", err)
+	}
+
+	if len(params) > 0 {
+		reqURL = reqURL + "?" + params.Encode()
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, reqURL, nil)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("http request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("http %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	if result != nil {
+		if err := json.Unmarshal(respBody, result); err != nil {
+			return fmt.Errorf("parse result: %w", err)
+		}
+	}
+
+	return nil
+}
+
 // doAuthenticatedRequest makes an authenticated API request
 func (c *Client) doAuthenticatedRequest(ctx context.Context, method, path string, params url.Values, body io.Reader, result interface{}) error {
 	// Ensure we're authenticated
@@ -467,14 +551,11 @@ func (c *Client) doAuthenticatedRequest(ctx context.Context, method, path string
 		}
 	}
 
-	// Add session ID to params
-	params.Set("_sid", c.sid)
-
-	return c.doRequest(ctx, method, path, params, body, result)
+	return c.doRequestWithAuth(ctx, method, path, params, body, result)
 }
 
-// doRequest performs an HTTP request with retries
-func (c *Client) doRequest(ctx context.Context, method, path string, params url.Values, body io.Reader, result interface{}) error {
+// doRequestWithAuth makes a request with authentication headers
+func (c *Client) doRequestWithAuth(ctx context.Context, method, path string, params url.Values, body io.Reader, result interface{}) error {
 	for attempt := 0; attempt < c.maxRetries; attempt++ {
 		if attempt > 0 {
 			select {
@@ -489,18 +570,42 @@ func (c *Client) doRequest(ctx context.Context, method, path string, params url.
 			return fmt.Errorf("invalid URL: %w", err)
 		}
 
-		if len(params) > 0 {
-			reqURL = reqURL + "?" + params.Encode()
+		// Clone params and add auth
+		reqParams := url.Values{}
+		for k, v := range params {
+			reqParams[k] = v
 		}
 
-		req, err := http.NewRequestWithContext(ctx, method, reqURL, body)
+		// For POST requests, put params in body; for GET, put in URL
+		var reqBody io.Reader
+		var contentType string
+		if method == http.MethodPost {
+			reqBody = strings.NewReader(reqParams.Encode())
+			contentType = "application/x-www-form-urlencoded; charset=UTF-8"
+		} else {
+			if len(reqParams) > 0 {
+				reqURL = reqURL + "?" + reqParams.Encode()
+			}
+		}
+
+		req, err := http.NewRequestWithContext(ctx, method, reqURL, reqBody)
 		if err != nil {
 			return fmt.Errorf("create request: %w", err)
 		}
 
 		req.Header.Set("Accept", "application/json")
-		if body != nil {
-			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		if contentType != "" {
+			req.Header.Set("Content-Type", contentType)
+		}
+
+			// Add X-SYNO-TOKEN header for CSRF protection
+		if c.synotoken != "" {
+			req.Header.Set("X-SYNO-TOKEN", c.synotoken)
+		}
+
+		// Add Cookie with session ID (required for some APIs)
+		if c.sid != "" {
+			req.Header.Set("Cookie", fmt.Sprintf("id=%s", c.sid))
 		}
 
 		resp, err := c.httpClient.Do(req)
@@ -528,6 +633,11 @@ func (c *Client) doRequest(ctx context.Context, method, path string, params url.
 			return fmt.Errorf("http %d: %s", resp.StatusCode, string(respBody))
 		}
 
+		// Debug logging
+		if c.logger != nil {
+			c.logger.Debug("synology api call", "method", method, "url", reqURL, "response", string(respBody))
+		}
+
 		// Parse response
 		var baseResp struct {
 			Success bool   `json:"success"`
@@ -550,7 +660,6 @@ func (c *Client) doRequest(ctx context.Context, method, path string, params url.
 				}
 				return fmt.Errorf("re-login after session expired: %w", err)
 			}
-			params.Set("_sid", c.sid)
 			continue
 		}
 
@@ -574,3 +683,4 @@ func (c *Client) doRequest(ctx context.Context, method, path string, params url.
 
 	return fmt.Errorf("max retries exceeded")
 }
+

--- a/adapters/synology/client.go
+++ b/adapters/synology/client.go
@@ -429,52 +429,77 @@ func (c *Client) DownloadItem(ctx context.Context, itemID int, cacheKey string) 
 		"cache_key": {cacheKey},
 	}
 
-	// Build request URL with auth params
+	// Build request URL
 	reqURL, err := url.JoinPath(c.baseURL, "/webapi/entry.cgi")
 	if err != nil {
 		return nil, fmt.Errorf("invalid URL: %w", err)
 	}
 
-	// Create POST request with params in body
-	reqBody := strings.NewReader(params.Encode())
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, reqBody)
-	if err != nil {
-		return nil, fmt.Errorf("create request: %w", err)
-	}
-
-	// Set required headers
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8")
-	req.Header.Set("Accept", "*/*")
-	req.Header.Set("X-SYNO-TOKEN", c.synotoken)
-	req.Header.Set("Cookie", fmt.Sprintf("id=%s", c.sid))
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("download request failed: %w", err)
-	}
-
-	// Check if response is JSON error (Synology returns JSON for API errors even on download)
-	contentType := resp.Header.Get("Content-Type")
-	if strings.Contains(contentType, "application/json") {
-		body, _ := io.ReadAll(resp.Body)
-		resp.Body.Close()
-		// Try to parse error
-		var errResp struct {
-			Success bool   `json:"success"`
-			Error   *Error `json:"error,omitempty"`
+	var lastErr error
+	for attempt := 0; attempt < c.maxRetries; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(c.retryDelay * time.Duration(attempt)):
+			}
 		}
-		if json.Unmarshal(body, &errResp) == nil && !errResp.Success && errResp.Error != nil {
-			return nil, fmt.Errorf("download API error %d: %s", errResp.Error.Code, c.getErrorMessage(errResp.Error.Code))
+
+		reqBody := strings.NewReader(params.Encode())
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, reqBody)
+		if err != nil {
+			return nil, fmt.Errorf("create request: %w", err)
 		}
-		return nil, fmt.Errorf("download failed: %s", string(body))
+
+		// Set required headers
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8")
+		req.Header.Set("Accept", "*/*")
+		if c.synotoken != "" {
+			req.Header.Set("X-SYNO-TOKEN", c.synotoken)
+		}
+		if c.sid != "" {
+			req.Header.Set("Cookie", fmt.Sprintf("id=%s", c.sid))
+		}
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+
+		// Check if response is JSON error
+		contentType := resp.Header.Get("Content-Type")
+		if strings.Contains(contentType, "application/json") {
+			body, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			var errResp struct {
+				Success bool   `json:"success"`
+				Error   *Error `json:"error,omitempty"`
+			}
+			if json.Unmarshal(body, &errResp) == nil && !errResp.Success && errResp.Error != nil {
+				if errResp.Error.Code == 119 && attempt < c.maxRetries-1 {
+					// Session expired, re-login and retry
+					if err := c.Login(ctx); err != nil {
+						lastErr = fmt.Errorf("re-login failed: %w", err)
+						continue
+					}
+					continue
+				}
+				return nil, fmt.Errorf("download API error %d: %s", errResp.Error.Code, c.getErrorMessage(errResp.Error.Code))
+			}
+			return nil, fmt.Errorf("download failed: %s", string(body))
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			resp.Body.Close()
+			lastErr = fmt.Errorf("http %d", resp.StatusCode)
+			continue
+		}
+
+		return resp.Body, nil
 	}
 
-	if resp.StatusCode != http.StatusOK {
-		resp.Body.Close()
-		return nil, fmt.Errorf("download failed with status %d", resp.StatusCode)
-	}
-
-	return resp.Body, nil
+	return nil, fmt.Errorf("download failed after retries: %w", lastErr)
 }
 
 // GetThumbnailURL returns the URL for a thumbnail

--- a/adapters/synology/client.go
+++ b/adapters/synology/client.go
@@ -485,7 +485,7 @@ func (c *Client) DownloadItem(ctx context.Context, itemID int, cacheKey string) 
 					}
 					continue
 				}
-				return nil, fmt.Errorf("download API error %d: %s", errResp.Error.Code, c.getErrorMessage(errResp.Error.Code))
+				return nil, fmt.Errorf("download API error %d: %s, raw: %s", errResp.Error.Code, c.getErrorMessage(errResp.Error.Code), string(body))
 			}
 			return nil, fmt.Errorf("download failed: %s", string(body))
 		}
@@ -555,6 +555,7 @@ func (c *Client) DownloadLivePhoto(ctx context.Context, itemID int, filename str
 		resp, err := c.httpClient.Do(req)
 		if err != nil {
 			lastErr = err
+			logger.Error("Download failed, retrying", "attempt", attempt, "error", err, "item", itemID, "filename", filename)
 			continue
 		}
 
@@ -576,7 +577,7 @@ func (c *Client) DownloadLivePhoto(ctx context.Context, itemID int, filename str
 					}
 					continue
 				}
-				return nil, "", false, fmt.Errorf("download API error %d: %s", errResp.Error.Code, c.getErrorMessage(errResp.Error.Code))
+				return nil, "", false, fmt.Errorf("download API error %d: %s, raw: %s", errResp.Error.Code, c.getErrorMessage(errResp.Error.Code), string(body))
 			}
 			return nil, "", false, fmt.Errorf("download failed: %s", string(body))
 		}

--- a/adapters/synology/client.go
+++ b/adapters/synology/client.go
@@ -502,22 +502,23 @@ func (c *Client) DownloadItem(ctx context.Context, itemID int, cacheKey string) 
 	return nil, fmt.Errorf("download failed after retries: %w", lastErr)
 }
 
-// DownloadLivePhotoZip downloads a live photo as a ZIP file containing both HEIC and MOV
-// Uses the SYNO.Foto.Download API with download_type=source which returns a ZIP
-func (c *Client) DownloadLivePhotoZip(ctx context.Context, itemID int, filename string, logger *slog.Logger) (io.ReadCloser, string, error) {
+// DownloadLivePhoto downloads a live photo using the source download API.
+// Returns the response body, content-type, and whether it's a ZIP file (based on Content-Disposition).
+// Note: Synology may return either a ZIP (containing both image and video) or just the image file.
+func (c *Client) DownloadLivePhoto(ctx context.Context, itemID int, filename string, logger *slog.Logger) (io.ReadCloser, string, bool, error) {
 	params := url.Values{
-		"api":           {"SYNO.Foto.Download"},
-		"version":       {"2"},
-		"method":        {"download"},
-		"item_id":       {fmt.Sprintf("[%d]", itemID)},
-		"download_type": {"source"},
+		"api":            {"SYNO.Foto.Download"},
+		"version":        {"2"},
+		"method":         {"download"},
+		"item_id":        {fmt.Sprintf("[%d]", itemID)},
+		"download_type":  {"source"},
 		"force_download": {"true"},
 	}
 
 	// Build request URL with filename in path (like browser does)
 	reqURL, err := url.JoinPath(c.baseURL, "/webapi/entry.cgi", filename)
 	if err != nil {
-		return nil, "", fmt.Errorf("invalid URL: %w", err)
+		return nil, "", false, fmt.Errorf("invalid URL: %w", err)
 	}
 
 	// Add synotoken as query param if available
@@ -530,7 +531,7 @@ func (c *Client) DownloadLivePhotoZip(ctx context.Context, itemID int, filename 
 		if attempt > 0 {
 			select {
 			case <-ctx.Done():
-				return nil, "", ctx.Err()
+				return nil, "", false, ctx.Err()
 			case <-time.After(c.retryDelay * time.Duration(attempt)):
 			}
 		}
@@ -538,7 +539,7 @@ func (c *Client) DownloadLivePhotoZip(ctx context.Context, itemID int, filename 
 		reqBody := strings.NewReader(params.Encode())
 		req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, reqBody)
 		if err != nil {
-			return nil, "", fmt.Errorf("create request: %w", err)
+			return nil, "", false, fmt.Errorf("create request: %w", err)
 		}
 
 		// Set required headers
@@ -575,9 +576,9 @@ func (c *Client) DownloadLivePhotoZip(ctx context.Context, itemID int, filename 
 					}
 					continue
 				}
-				return nil, "", fmt.Errorf("download API error %d: %s", errResp.Error.Code, c.getErrorMessage(errResp.Error.Code))
+				return nil, "", false, fmt.Errorf("download API error %d: %s", errResp.Error.Code, c.getErrorMessage(errResp.Error.Code))
 			}
-			return nil, "", fmt.Errorf("download failed: %s", string(body))
+			return nil, "", false, fmt.Errorf("download failed: %s", string(body))
 		}
 
 		if resp.StatusCode != http.StatusOK {
@@ -586,13 +587,20 @@ func (c *Client) DownloadLivePhotoZip(ctx context.Context, itemID int, filename 
 			continue
 		}
 
+		// Check if response is a ZIP by looking at Content-Disposition header
+		contentDisposition := resp.Header.Get("Content-Disposition")
+		isZip := strings.HasSuffix(strings.ToLower(contentDisposition), ".zip") ||
+			strings.Contains(strings.ToLower(contentDisposition), "filename=\"download.zip\"") ||
+			strings.Contains(strings.ToLower(contentDisposition), "filename*=utf-8''download.zip")
+
 		if c.logger != nil {
-			c.logger.Debug("Downloaded live photo", "item_id", itemID, "content_type", contentType, "content_length", resp.Header.Get("Content-Length"))
+			c.logger.Debug("Downloaded live photo", "item_id", itemID, "content_type", contentType,
+				"content_disposition", contentDisposition, "is_zip", isZip, "content_length", resp.Header.Get("Content-Length"))
 		}
-		return resp.Body, contentType, nil
+		return resp.Body, contentType, isZip, nil
 	}
 
-	return nil, "", fmt.Errorf("download failed after retries: %w", lastErr)
+	return nil, "", false, fmt.Errorf("download failed after retries: %w", lastErr)
 }
 
 // GetThumbnailURL returns the URL for a thumbnail

--- a/adapters/synology/client.go
+++ b/adapters/synology/client.go
@@ -550,17 +550,24 @@ func (c *Client) doRequest(ctx context.Context, method, path string, params url.
 			continue
 		}
 
-		// Handle authentication error - try to re-login
-		if !baseResp.Success && baseResp.Error != nil && baseResp.Error.Code == 119 {
-			// Session expired
-			c.sid = ""
-			if err := c.Login(ctx); err != nil {
-				lastErr = err
+		// Handle API error response
+		if !baseResp.Success {
+			if baseResp.Error != nil && baseResp.Error.Code == 119 {
+				// Session expired - try to re-login
+				c.sid = ""
+				if err := c.Login(ctx); err != nil {
+					lastErr = err
+					continue
+				}
+				// Update params with new session ID
+				params.Set("_sid", c.sid)
 				continue
 			}
-			// Update params with new session ID
-			params.Set("_sid", c.sid)
-			continue
+			// Other API error - return immediately
+			if baseResp.Error != nil {
+				return fmt.Errorf("API error: code %d (%s)", baseResp.Error.Code, c.getErrorMessage(baseResp.Error.Code))
+			}
+			return fmt.Errorf("API error: success=false but no error code")
 		}
 
 		if result != nil {

--- a/adapters/synology/client.go
+++ b/adapters/synology/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -93,32 +94,84 @@ func NewClient(baseURL, account, password string, opts ...ClientOption) (*Client
 		opt(client)
 	}
 
+	fmt.Fprintf(os.Stderr, "[DEBUG] Client created for base URL: %s\n", baseURL)
+
 	return client, nil
+}
+
+// APIInfo represents the SYNO.API.Info response
+type APIInfo struct {
+	Path       string `json:"path"`
+	MinVersion int    `json:"minVersion"`
+	MaxVersion int    `json:"maxVersion"`
+}
+
+// QueryAPIInfo queries available APIs and returns API paths and versions
+func (c *Client) QueryAPIInfo(ctx context.Context, apiName string) (*APIInfo, error) {
+	params := url.Values{
+		"api":     {"SYNO.API.Info"},
+		"version": {"1"},
+		"method":  {"query"},
+		"query":   {apiName},
+	}
+
+	var resp APIResponse[map[string]APIInfo]
+	if err := c.doRequest(ctx, http.MethodGet, "/webapi/query.cgi", params, nil, &resp); err != nil {
+		return nil, fmt.Errorf("query API info failed: %w", err)
+	}
+
+	if !resp.Success {
+		return nil, fmt.Errorf("query API info failed: error %d", resp.Error.Code)
+	}
+
+	if apiInfo, ok := resp.Data[apiName]; ok {
+		return &apiInfo, nil
+	}
+
+	return nil, fmt.Errorf("API %s not found", apiName)
 }
 
 // Login authenticates with the Synology server
 func (c *Client) Login(ctx context.Context) error {
+	// First, query API info to get the correct path and version
+	apiInfo, err := c.QueryAPIInfo(ctx, "SYNO.API.Auth")
+	if err != nil {
+		// Fallback to default values
+		apiInfo = &APIInfo{
+			Path:       "auth.cgi",
+			MaxVersion: 6,
+		}
+		fmt.Fprintf(os.Stderr, "[DEBUG] Using default API info, path=%s, version=%d\n", apiInfo.Path, apiInfo.MaxVersion)
+	} else {
+		fmt.Fprintf(os.Stderr, "[DEBUG] API info: path=%s, maxVersion=%d\n", apiInfo.Path, apiInfo.MaxVersion)
+	}
+
+	// Build login parameters according to DSM API spec
 	params := url.Values{
-		"api":     {"SYNO.API.Auth"},
-		"version": {"6"},
-		"method":  {"login"},
-		"account": {c.account},
-		"passwd":  {c.password},
-		"session": {"Foto"},
+		"api":               {"SYNO.API.Auth"},
+		"version":           {strconv.Itoa(apiInfo.MaxVersion)},
+		"method":            {"login"},
+		"account":           {c.account},
+		"passwd":            {c.password},
+		"format":            {"sid"},
 		"enable_syno_token": {"yes"},
 	}
 
+	// Use the correct API path from API info
+	authPath := "/webapi/" + apiInfo.Path
+
 	var resp LoginResponse
-	if err := c.doRequest(ctx, http.MethodPost, "/webapi/auth.cgi", params, nil, &resp); err != nil {
+	if err := c.doRequest(ctx, http.MethodGet, authPath, params, nil, &resp); err != nil {
 		return fmt.Errorf("login request failed: %w", err)
 	}
 
 	if !resp.Success {
-		return fmt.Errorf("login failed: error code %d (%s), check your username and password", resp.Error.Code, c.getErrorMessage(resp.Error.Code))
+		return fmt.Errorf("login failed: error code %d (%s)", resp.Error.Code, c.getErrorMessage(resp.Error.Code))
 	}
 
 	c.sid = resp.Data.SID
 	c.did = resp.Data.DID
+	fmt.Fprintf(os.Stderr, "[DEBUG] Login successful!\n")
 	return nil
 }
 
@@ -128,15 +181,35 @@ func (c *Client) getErrorMessage(code int) string {
 	case 100:
 		return "Unknown error"
 	case 101:
-		return "Invalid parameters - check URL, username and password"
+		return "Invalid parameters - wrong API, method, or version"
 	case 102:
 		return "The requested method does not exist"
 	case 103:
 		return "The requested method does not support the requested version"
+	case 104:
+		return "Version not supported"
+	case 105:
+		return "Session ID not found (need to login again)"
+	case 106:
+		return "Incorrect account or password"
+	case 107:
+		return "Permission denied"
+	case 108:
+		return "OTP code required (two-factor authentication)"
+	case 109:
+		return "Failed to authenticate with OTP"
+	case 110:
+		return "Max TOTP retries reached"
+	case 111:
+		return "Password change required"
+	case 112:
+		return "Strong password required"
+	case 113:
+		return "Strong password required for admin"
 	case 119:
-		return "Session timeout - session ID not found"
+		return "SID not found or session timeout"
 	case 400:
-		return "Invalid credentials - wrong account or password"
+		return "Invalid credentials in request"
 	case 401:
 		return "Guest account disabled"
 	case 402:
@@ -144,20 +217,19 @@ func (c *Client) getErrorMessage(code int) string {
 	case 403:
 		return "Permission denied"
 	case 404:
-		return "OTP code required (two-factor authentication)"
+		return "OTP code required"
 	case 405:
-		return "Failed to authenticate with OTP"
-	case 407:
-		return "Max TOTP retries reached"
-	case 408:
-		return "Password change required"
-	case 409:
-		return "Strong password required"
-	case 410:
-		return "Strong password required for admin"
+		return "OTP authenticate failed"
 	default:
 		return fmt.Sprintf("Unknown error code %d", code)
 	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
 }
 
 // Logout ends the session
@@ -464,6 +536,8 @@ func (c *Client) doRequest(ctx context.Context, method, path string, params url.
 			lastErr = fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(respBody))
 			continue
 		}
+
+		fmt.Fprintf(os.Stderr, "[DEBUG] Response body: %s\n", string(respBody))
 
 		// Parse response
 		var baseResp struct {

--- a/adapters/synology/client.go
+++ b/adapters/synology/client.go
@@ -502,6 +502,96 @@ func (c *Client) DownloadItem(ctx context.Context, itemID int, cacheKey string) 
 	return nil, fmt.Errorf("download failed after retries: %w", lastErr)
 }
 
+// DownloadLivePhotoZip downloads a live photo as a ZIP file containing both HEIC and MOV
+// Uses the SYNO.Foto.Download API with download_type=source which returns a ZIP
+func (c *Client) DownloadLivePhotoZip(ctx context.Context, itemID int, filename string) (io.ReadCloser, error) {
+	params := url.Values{
+		"api":           {"SYNO.Foto.Download"},
+		"version":       {"2"},
+		"method":        {"download"},
+		"item_id":       {fmt.Sprintf("[%d]", itemID)},
+		"download_type": {"source"},
+		"force_download": {"true"},
+	}
+
+	// Build request URL with filename in path (like browser does)
+	reqURL, err := url.JoinPath(c.baseURL, "/webapi/entry.cgi", filename)
+	if err != nil {
+		return nil, fmt.Errorf("invalid URL: %w", err)
+	}
+
+	// Add synotoken as query param if available
+	if c.synotoken != "" {
+		reqURL = reqURL + "?SynoToken=" + url.QueryEscape(c.synotoken)
+	}
+
+	var lastErr error
+	for attempt := 0; attempt < c.maxRetries; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(c.retryDelay * time.Duration(attempt)):
+			}
+		}
+
+		reqBody := strings.NewReader(params.Encode())
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, reqBody)
+		if err != nil {
+			return nil, fmt.Errorf("create request: %w", err)
+		}
+
+		// Set required headers
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8")
+		req.Header.Set("Accept", "*/*")
+		if c.synotoken != "" {
+			req.Header.Set("X-SYNO-TOKEN", c.synotoken)
+		}
+		if c.sid != "" {
+			req.Header.Set("Cookie", fmt.Sprintf("id=%s", c.sid))
+		}
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+
+		// Check if response is JSON error
+		contentType := resp.Header.Get("Content-Type")
+		if strings.Contains(contentType, "application/json") {
+			body, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			var errResp struct {
+				Success bool   `json:"success"`
+				Error   *Error `json:"error,omitempty"`
+			}
+			if json.Unmarshal(body, &errResp) == nil && !errResp.Success && errResp.Error != nil {
+				if errResp.Error.Code == 119 && attempt < c.maxRetries-1 {
+					// Session expired, re-login and retry
+					if err := c.Login(ctx); err != nil {
+						lastErr = fmt.Errorf("re-login failed: %w", err)
+						continue
+					}
+					continue
+				}
+				return nil, fmt.Errorf("download API error %d: %s", errResp.Error.Code, c.getErrorMessage(errResp.Error.Code))
+			}
+			return nil, fmt.Errorf("download failed: %s", string(body))
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			resp.Body.Close()
+			lastErr = fmt.Errorf("http %d", resp.StatusCode)
+			continue
+		}
+
+		return resp.Body, nil
+	}
+
+	return nil, fmt.Errorf("download failed after retries: %w", lastErr)
+}
+
 // GetThumbnailURL returns the URL for a thumbnail
 func (c *Client) GetThumbnailURL(itemID int, cacheKey string, size string) string {
 	if size == "" {

--- a/adapters/synology/client.go
+++ b/adapters/synology/client.go
@@ -504,7 +504,7 @@ func (c *Client) DownloadItem(ctx context.Context, itemID int, cacheKey string) 
 
 // DownloadLivePhotoZip downloads a live photo as a ZIP file containing both HEIC and MOV
 // Uses the SYNO.Foto.Download API with download_type=source which returns a ZIP
-func (c *Client) DownloadLivePhotoZip(ctx context.Context, itemID int, filename string) (io.ReadCloser, error) {
+func (c *Client) DownloadLivePhotoZip(ctx context.Context, itemID int, filename string, logger *slog.Logger) (io.ReadCloser, string, error) {
 	params := url.Values{
 		"api":           {"SYNO.Foto.Download"},
 		"version":       {"2"},
@@ -517,7 +517,7 @@ func (c *Client) DownloadLivePhotoZip(ctx context.Context, itemID int, filename 
 	// Build request URL with filename in path (like browser does)
 	reqURL, err := url.JoinPath(c.baseURL, "/webapi/entry.cgi", filename)
 	if err != nil {
-		return nil, fmt.Errorf("invalid URL: %w", err)
+		return nil, "", fmt.Errorf("invalid URL: %w", err)
 	}
 
 	// Add synotoken as query param if available
@@ -530,7 +530,7 @@ func (c *Client) DownloadLivePhotoZip(ctx context.Context, itemID int, filename 
 		if attempt > 0 {
 			select {
 			case <-ctx.Done():
-				return nil, ctx.Err()
+				return nil, "", ctx.Err()
 			case <-time.After(c.retryDelay * time.Duration(attempt)):
 			}
 		}
@@ -538,7 +538,7 @@ func (c *Client) DownloadLivePhotoZip(ctx context.Context, itemID int, filename 
 		reqBody := strings.NewReader(params.Encode())
 		req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, reqBody)
 		if err != nil {
-			return nil, fmt.Errorf("create request: %w", err)
+			return nil, "", fmt.Errorf("create request: %w", err)
 		}
 
 		// Set required headers
@@ -575,9 +575,9 @@ func (c *Client) DownloadLivePhotoZip(ctx context.Context, itemID int, filename 
 					}
 					continue
 				}
-				return nil, fmt.Errorf("download API error %d: %s", errResp.Error.Code, c.getErrorMessage(errResp.Error.Code))
+				return nil, "", fmt.Errorf("download API error %d: %s", errResp.Error.Code, c.getErrorMessage(errResp.Error.Code))
 			}
-			return nil, fmt.Errorf("download failed: %s", string(body))
+			return nil, "", fmt.Errorf("download failed: %s", string(body))
 		}
 
 		if resp.StatusCode != http.StatusOK {
@@ -586,10 +586,13 @@ func (c *Client) DownloadLivePhotoZip(ctx context.Context, itemID int, filename 
 			continue
 		}
 
-		return resp.Body, nil
+		if c.logger != nil {
+			c.logger.Debug("Downloaded live photo", "item_id", itemID, "content_type", contentType, "content_length", resp.Header.Get("Content-Length"))
+		}
+		return resp.Body, contentType, nil
 	}
 
-	return nil, fmt.Errorf("download failed after retries: %w", lastErr)
+	return nil, "", fmt.Errorf("download failed after retries: %w", lastErr)
 }
 
 // GetThumbnailURL returns the URL for a thumbnail

--- a/adapters/synology/cmd.go
+++ b/adapters/synology/cmd.go
@@ -120,8 +120,9 @@ func (fsc *FromSynologyCmd) Run(ctx context.Context, cmd *cobra.Command, app *ap
 	fsc.adapter = adapter
 
 	// Open connection to Synology
-	app.Log().Info("Connecting to Synology Photos", "url", fsc.SynologyURL)
+	app.Log().Info("Connecting to Synology Photos", "url", fsc.SynologyURL, "user", fsc.SynologyUser)
 	if err := adapter.Open(ctx); err != nil {
+		app.Log().Error("Connection failed. Common causes:", "reason", "1) Wrong URL format - use https://nas:5001 (admin port) or https://nas/photo (Photo alias). 2) Wrong username/password. 3) Account lacks permission. 4) 2FA is enabled (not supported yet)")
 		return fmt.Errorf("failed to connect to Synology Photos: %w", err)
 	}
 	defer adapter.Close(ctx)

--- a/adapters/synology/cmd.go
+++ b/adapters/synology/cmd.go
@@ -1,0 +1,133 @@
+package synology
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/simulot/immich-go/adapters"
+	"github.com/simulot/immich-go/app"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// FromSynologyCmd holds the configuration for the from-synology command
+type FromSynologyCmd struct {
+	// Synology connection settings
+	SynologyURL    string
+	SynologyUser   string
+	SynologyPass   string
+	IncludeShared  bool
+	InsecureSSL    bool
+
+	// Filters
+	Albums        []string
+	Tags          []string
+	People        []string
+	SkipFaceData  bool
+
+	// Internal
+	app       *app.Application
+	adapter   *Adapter
+}
+
+// RegisterFlags registers CLI flags for the command
+func (cmd *FromSynologyCmd) RegisterFlags(flags *pflag.FlagSet) {
+	// Connection flags
+	flags.StringVar(&cmd.SynologyURL, "synology-url", "", "Synology Photos URL (e.g., https://nas:5001 or https://nas/photo)")
+	flags.StringVar(&cmd.SynologyUser, "synology-user", "", "Synology username")
+	flags.StringVar(&cmd.SynologyPass, "synology-pass", "", "Synology password")
+	flags.BoolVar(&cmd.IncludeShared, "include-shared-space", false, "Include shared space (FotoTeam)")
+	flags.BoolVar(&cmd.InsecureSSL, "insecure-ssl", true, "Skip SSL certificate verification")
+
+	// Filter flags
+	flags.StringSliceVar(&cmd.Albums, "from-albums", nil, "Import only from these albums (comma-separated)")
+	flags.StringSliceVar(&cmd.Tags, "from-tags", nil, "Import only items with these tags (comma-separated)")
+	flags.StringSliceVar(&cmd.People, "from-people", nil, "Import only items with these people (comma-separated)")
+	flags.BoolVar(&cmd.SkipFaceData, "skip-face-data", false, "Skip face recognition data")
+}
+
+// NewFromSynologyCommand creates a new Cobra command for importing from Synology Photos
+func NewFromSynologyCommand(ctx context.Context, parent *cobra.Command, app *app.Application, runner adapters.Runner) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "from-synology [flags]",
+		Short: "Import photos from Synology Photos",
+		Long: `Import photos, videos, albums, and tags from a Synology Photos server.
+
+This command connects to a Synology NAS running Synology Photos and imports
+your media library into Immich. It supports:
+
+- Photos and videos from Personal Space
+- Albums (normal albums, not conditional albums)
+- Tags/labels
+- Face recognition data (stored as tags)
+- GPS coordinates and descriptions
+
+Examples:
+  # Import all photos from Synology
+  immich-go upload from-synology --server=http://immich:2283 --api-key=xxx \\
+    --synology-url=https://nas:5001 --synology-user=admin --synology-pass=secret
+
+  # Import specific albums only
+  immich-go upload from-synology --server=http://immich:2283 --api-key=xxx \\
+    --synology-url=https://nas:5001 --synology-user=admin --synology-pass=secret \\
+    --from-albums="Vacation 2023,Birthday Party"
+
+  # Import items with specific tags
+  immich-go upload from-synology --server=http://immich:2283 --api-key=xxx \\
+    --synology-url=https://nas:5001 --synology-user=admin --synology-pass=secret \\
+    --from-tags="family,vacation"
+
+  # Import without face recognition data
+  immich-go upload from-synology --server=http://immich:2283 --api-key=xxx \\
+    --synology-url=https://nas:5001 --synology-user=admin --synology-pass=secret \\
+    --skip-face-data`,
+		Args: cobra.NoArgs,
+	}
+
+	cmd.SetContext(ctx)
+	fsc := &FromSynologyCmd{}
+	fsc.RegisterFlags(cmd.Flags())
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		return fsc.Run(ctx, cmd, app, runner)
+	}
+
+	return cmd
+}
+
+// Run executes the from-synology command
+func (fsc *FromSynologyCmd) Run(ctx context.Context, cmd *cobra.Command, app *app.Application, runner adapters.Runner) error {
+	// Validate required flags
+	if fsc.SynologyURL == "" {
+		return fmt.Errorf("--synology-url is required")
+	}
+	if fsc.SynologyUser == "" {
+		return fmt.Errorf("--synology-user is required")
+	}
+	if fsc.SynologyPass == "" {
+		return fmt.Errorf("--synology-pass is required")
+	}
+
+	fsc.app = app
+
+	// Create and configure the adapter
+	adapter := NewAdapter(app, fsc.SynologyURL, fsc.SynologyUser, fsc.SynologyPass)
+	adapter.IncludeShared = fsc.IncludeShared
+	adapter.Albums = fsc.Albums
+	adapter.Tags = fsc.Tags
+	adapter.People = fsc.People
+	adapter.SkipFaceData = fsc.SkipFaceData
+	fsc.adapter = adapter
+
+	// Open connection to Synology
+	app.Log().Info("Connecting to Synology Photos", "url", fsc.SynologyURL)
+	if err := adapter.Open(ctx); err != nil {
+		return fmt.Errorf("failed to connect to Synology Photos: %w", err)
+	}
+	defer adapter.Close(ctx)
+
+	app.Log().Info("Successfully connected to Synology Photos")
+
+	// Run the import
+	return runner.Run(cmd, adapter)
+}

--- a/adapters/synology/models.go
+++ b/adapters/synology/models.go
@@ -210,20 +210,6 @@ type FolderListResponse struct {
 	List []Folder `json:"list"`
 }
 
-// CaptureTime returns the capture time as a time.Time
-// Note: Synology stores time as local timezone seconds since epoch, not UTC.
-// We need to interpret it as local time and convert to UTC for Immich.
-func (i Item) CaptureTime() time.Time {
-	// Create a time value treating the timestamp as local time
-	// then convert to UTC for proper timezone handling
-	localTime := time.Unix(i.Time, 0)
-	// Get year/month/day/hour/min/sec in local timezone
-	year, month, day := localTime.Date()
-	hour, min, sec := localTime.Clock()
-	// Create a new time with these values in local timezone, then convert to UTC
-	return time.Date(year, month, day, hour, min, sec, 0, time.Local).UTC()
-}
-
 // IndexedTime returns the indexing time as a time.Time
 func (i Item) IndexedAt() time.Time {
 	// Indexed time is in milliseconds

--- a/adapters/synology/models.go
+++ b/adapters/synology/models.go
@@ -8,10 +8,10 @@ import (
 
 // LoginData represents the login response data
 type LoginData struct {
-	DID        string `json:"did"`        // Device ID
-	SID        string `json:"sid"`        // Session ID
-	SynoToken  string `json:"synotoken"`  // CSRF token for some APIs
-	DeviceID   string `json:"device_id"`  // Device ID (alternative field)
+	DID       string `json:"did"`       // Device ID
+	SID       string `json:"sid"`       // Session ID
+	SynoToken string `json:"synotoken"` // CSRF token for some APIs
+	DeviceID  string `json:"device_id"` // Device ID (alternative field)
 }
 
 // LoginResponse represents the response from SYNO.API.Auth login
@@ -35,23 +35,23 @@ type Error struct {
 
 // Album represents a Synology Photos album
 type Album struct {
-	ID                   int           `json:"id"`
-	Name                 string        `json:"name"`
-	ItemCount            int           `json:"item_count"`
-	OwnerUserID          int           `json:"owner_user_id"`
-	CreateTime           int64         `json:"create_time"` // Unix timestamp
-	EndTime              int64         `json:"end_time"`
-	StartTime            int64         `json:"start_time"`
-	Passphrase           string        `json:"passphrase"`
-	Shared               bool          `json:"shared"`
-	TemporaryShared      bool          `json:"temporary_shared"`
-	FreezeAlbum          bool          `json:"freeze_album"`
-	SortBy               string        `json:"sort_by"`
-	SortDirection        string        `json:"sort_direction"`
-	Type                 string        `json:"type"` // "normal" or "condition"
-	Version              int           `json:"version"`
-	Condition            Condition     `json:"condition,omitempty"`
-	CantMigrateCondition interface{}   `json:"cant_migrate_condition,omitempty"`
+	ID                   int         `json:"id"`
+	Name                 string      `json:"name"`
+	ItemCount            int         `json:"item_count"`
+	OwnerUserID          int         `json:"owner_user_id"`
+	CreateTime           int64       `json:"create_time"` // Unix timestamp
+	EndTime              int64       `json:"end_time"`
+	StartTime            int64       `json:"start_time"`
+	Passphrase           string      `json:"passphrase"`
+	Shared               bool        `json:"shared"`
+	TemporaryShared      bool        `json:"temporary_shared"`
+	FreezeAlbum          bool        `json:"freeze_album"`
+	SortBy               string      `json:"sort_by"`
+	SortDirection        string      `json:"sort_direction"`
+	Type                 string      `json:"type"` // "normal" or "condition"
+	Version              int         `json:"version"`
+	Condition            Condition   `json:"condition,omitempty"`
+	CantMigrateCondition interface{} `json:"cant_migrate_condition,omitempty"`
 }
 
 // Condition represents album filter conditions for conditional albums
@@ -67,44 +67,44 @@ type AlbumListResponse struct {
 
 // Item represents a photo or video in Synology Photos
 type Item struct {
-	ID            int        `json:"id"`
-	Filename      string     `json:"filename"`
-	Filesize      int64      `json:"filesize"`
-	FolderID      int        `json:"folder_id"`
-	Time          int64      `json:"time"` // Unix timestamp of capture time
-	IndexedTime   int64      `json:"indexed_time"`
-	Type          string     `json:"type"` // "photo", "video", or "live"
-	LiveType      string     `json:"live_type,omitempty"` // "photo" for live photos
-	OwnerUserID   int        `json:"owner_user_id"`
-	Additional    Additional `json:"additional,omitempty"`
+	ID          int        `json:"id"`
+	Filename    string     `json:"filename"`
+	Filesize    int64      `json:"filesize"`
+	FolderID    int        `json:"folder_id"`
+	Time        int64      `json:"time"` // Local timestamp of capture time
+	IndexedTime int64      `json:"indexed_time"`
+	Type        string     `json:"type"`                // "photo", "video", or "live"
+	LiveType    string     `json:"live_type,omitempty"` // "photo" for live photos
+	OwnerUserID int        `json:"owner_user_id"`
+	Additional  Additional `json:"additional,omitempty"`
 }
 
 // Additional contains extra metadata for items
 type Additional struct {
-	Thumbnail          ThumbnailInfo   `json:"thumbnail,omitempty"`
-	Resolution         ResolutionInfo  `json:"resolution,omitempty"`
-	Orientation        int             `json:"orientation,omitempty"`
+	Thumbnail           ThumbnailInfo  `json:"thumbnail,omitempty"`
+	Resolution          ResolutionInfo `json:"resolution,omitempty"`
+	Orientation         int            `json:"orientation,omitempty"`
 	OrientationOriginal int            `json:"orientation_original,omitempty"`
-	Exif               ExifInfo        `json:"exif,omitempty"`
-	Tag                []TagInfo       `json:"tag,omitempty"`
-	Description        string          `json:"description,omitempty"`
-	GPS                GPSInfo         `json:"gps,omitempty"`
-	GeocodingID        int             `json:"geocoding_id,omitempty"`
-	Address            AddressInfo     `json:"address,omitempty"`
-	Person             []PersonInfo    `json:"person,omitempty"`
-	VideoConvert       interface{}     `json:"video_convert,omitempty"`
-	VideoMeta          interface{}     `json:"video_meta,omitempty"`
-	ProviderUserID     int             `json:"provider_user_id,omitempty"`
+	Exif                ExifInfo       `json:"exif,omitempty"`
+	Tag                 []TagInfo      `json:"tag,omitempty"`
+	Description         string         `json:"description,omitempty"`
+	GPS                 GPSInfo        `json:"gps,omitempty"`
+	GeocodingID         int            `json:"geocoding_id,omitempty"`
+	Address             AddressInfo    `json:"address,omitempty"`
+	Person              []PersonInfo   `json:"person,omitempty"`
+	VideoConvert        interface{}    `json:"video_convert,omitempty"`
+	VideoMeta           interface{}    `json:"video_meta,omitempty"`
+	ProviderUserID      int            `json:"provider_user_id,omitempty"`
 }
 
 // ThumbnailInfo contains thumbnail availability information
 type ThumbnailInfo struct {
 	CacheKey string `json:"cache_key"`
 	UnitID   int    `json:"unit_id"`
-	SM       string `json:"sm"`       // "ready" or "broken"
-	M        string `json:"m"`        // "ready" or "broken"
-	XL       string `json:"xl"`       // "ready" or "broken"
-	Preview  string `json:"preview"`  // "ready" or "broken"
+	SM       string `json:"sm"`      // "ready" or "broken"
+	M        string `json:"m"`       // "ready" or "broken"
+	XL       string `json:"xl"`      // "ready" or "broken"
+	Preview  string `json:"preview"` // "ready" or "broken"
 }
 
 // ResolutionInfo contains image/video resolution
@@ -115,12 +115,12 @@ type ResolutionInfo struct {
 
 // ExifInfo contains EXIF metadata
 type ExifInfo struct {
-	Aperture     string  `json:"aperture,omitempty"`
-	Camera       string  `json:"camera,omitempty"`
-	ExposureTime string  `json:"exposure_time,omitempty"`
-	FocalLength  string  `json:"focal_length,omitempty"`
-	ISO          int     `json:"iso,omitempty"`
-	Lens         string  `json:"lens,omitempty"`
+	Aperture     string `json:"aperture,omitempty"`
+	Camera       string `json:"camera,omitempty"`
+	ExposureTime string `json:"exposure_time,omitempty"`
+	FocalLength  string `json:"focal_length,omitempty"`
+	ISO          int    `json:"iso,omitempty"`
+	Lens         string `json:"lens,omitempty"`
 }
 
 // TagInfo represents a tag assigned to an item
@@ -137,24 +137,24 @@ type GPSInfo struct {
 
 // AddressInfo contains reverse geocoding address
 type AddressInfo struct {
-	City      string `json:"city,omitempty"`
-	CityID    int    `json:"city_id,omitempty"`
-	Country   string `json:"country,omitempty"`
-	CountryID int    `json:"country_id,omitempty"`
-	County    string `json:"county,omitempty"`
-	CountyID  int    `json:"county_id,omitempty"`
-	District  string `json:"district,omitempty"`
-	DistrictID int   `json:"district_id,omitempty"`
-	Landmark  string `json:"landmark,omitempty"`
-	LandmarkID int  `json:"landmark_id,omitempty"`
-	Route     string `json:"route,omitempty"`
-	RouteID   int    `json:"route_id,omitempty"`
-	State     string `json:"state,omitempty"`
-	StateID   int    `json:"state_id,omitempty"`
-	Town      string `json:"town,omitempty"`
-	TownID    int    `json:"town_id,omitempty"`
-	Village   string `json:"village,omitempty"`
-	VillageID int    `json:"village_id,omitempty"`
+	City       string `json:"city,omitempty"`
+	CityID     int    `json:"city_id,omitempty"`
+	Country    string `json:"country,omitempty"`
+	CountryID  int    `json:"country_id,omitempty"`
+	County     string `json:"county,omitempty"`
+	CountyID   int    `json:"county_id,omitempty"`
+	District   string `json:"district,omitempty"`
+	DistrictID int    `json:"district_id,omitempty"`
+	Landmark   string `json:"landmark,omitempty"`
+	LandmarkID int    `json:"landmark_id,omitempty"`
+	Route      string `json:"route,omitempty"`
+	RouteID    int    `json:"route_id,omitempty"`
+	State      string `json:"state,omitempty"`
+	StateID    int    `json:"state_id,omitempty"`
+	Town       string `json:"town,omitempty"`
+	TownID     int    `json:"town_id,omitempty"`
+	Village    string `json:"village,omitempty"`
+	VillageID  int    `json:"village_id,omitempty"`
 }
 
 // PersonInfo represents a recognized person in Synology Photos
@@ -182,10 +182,10 @@ type TagListResponse struct {
 
 // Person represents a person in the face recognition system
 type Person struct {
-	ID            int    `json:"id"`
-	Name          string `json:"name"`
-	ItemCount     int    `json:"item_count,omitempty"`
-	CoverItemID   int    `json:"cover_item_id,omitempty"`
+	ID          int    `json:"id"`
+	Name        string `json:"name"`
+	ItemCount   int    `json:"item_count,omitempty"`
+	CoverItemID int    `json:"cover_item_id,omitempty"`
 }
 
 // PersonListResponse represents the response from Browse.Person list method

--- a/adapters/synology/models.go
+++ b/adapters/synology/models.go
@@ -6,8 +6,10 @@ import (
 
 // LoginData represents the login response data
 type LoginData struct {
-	DID string `json:"did"` // Device ID
-	SID string `json:"sid"` // Session ID
+	DID        string `json:"did"`        // Device ID
+	SID        string `json:"sid"`        // Session ID
+	SynoToken  string `json:"synotoken"`  // CSRF token for some APIs
+	DeviceID   string `json:"device_id"`  // Device ID (alternative field)
 }
 
 // LoginResponse represents the response from SYNO.API.Auth login

--- a/adapters/synology/models.go
+++ b/adapters/synology/models.go
@@ -1,0 +1,238 @@
+package synology
+
+import (
+	"time"
+)
+
+// LoginData represents the login response data
+type LoginData struct {
+	DID string `json:"did"` // Device ID
+	SID string `json:"sid"` // Session ID
+}
+
+// LoginResponse represents the response from SYNO.API.Auth login
+type LoginResponse struct {
+	Data    LoginData `json:"data"`
+	Success bool      `json:"success"`
+	Error   *Error    `json:"error,omitempty"`
+}
+
+// APIResponse is the base response structure for most Synology APIs
+type APIResponse[T any] struct {
+	Data    T      `json:"data"`
+	Success bool   `json:"success"`
+	Error   *Error `json:"error,omitempty"`
+}
+
+// Error represents a Synology API error
+type Error struct {
+	Code int `json:"code"`
+}
+
+// Album represents a Synology Photos album
+type Album struct {
+	ID                   int           `json:"id"`
+	Name                 string        `json:"name"`
+	ItemCount            int           `json:"item_count"`
+	OwnerUserID          int           `json:"owner_user_id"`
+	CreateTime           int64         `json:"create_time"` // Unix timestamp
+	EndTime              int64         `json:"end_time"`
+	StartTime            int64         `json:"start_time"`
+	Passphrase           string        `json:"passphrase"`
+	Shared               bool          `json:"shared"`
+	TemporaryShared      bool          `json:"temporary_shared"`
+	FreezeAlbum          bool          `json:"freeze_album"`
+	SortBy               string        `json:"sort_by"`
+	SortDirection        string        `json:"sort_direction"`
+	Type                 string        `json:"type"` // "normal" or "condition"
+	Version              int           `json:"version"`
+	Condition            Condition     `json:"condition,omitempty"`
+	CantMigrateCondition interface{}   `json:"cant_migrate_condition,omitempty"`
+}
+
+// Condition represents album filter conditions for conditional albums
+type Condition struct {
+	FolderFilter []int `json:"folder_filter,omitempty"`
+	UserID       int   `json:"user_id,omitempty"`
+}
+
+// AlbumListResponse represents the response from Browse.Album list method
+type AlbumListResponse struct {
+	List []Album `json:"list"`
+}
+
+// Item represents a photo or video in Synology Photos
+type Item struct {
+	ID            int        `json:"id"`
+	Filename      string     `json:"filename"`
+	Filesize      int64      `json:"filesize"`
+	FolderID      int        `json:"folder_id"`
+	Time          int64      `json:"time"` // Unix timestamp of capture time
+	IndexedTime   int64      `json:"indexed_time"`
+	Type          string     `json:"type"` // "photo", "video", or "live"
+	LiveType      string     `json:"live_type,omitempty"` // "photo" for live photos
+	OwnerUserID   int        `json:"owner_user_id"`
+	Additional    Additional `json:"additional,omitempty"`
+}
+
+// Additional contains extra metadata for items
+type Additional struct {
+	Thumbnail          ThumbnailInfo   `json:"thumbnail,omitempty"`
+	Resolution         ResolutionInfo  `json:"resolution,omitempty"`
+	Orientation        int             `json:"orientation,omitempty"`
+	OrientationOriginal int            `json:"orientation_original,omitempty"`
+	Exif               ExifInfo        `json:"exif,omitempty"`
+	Tag                []TagInfo       `json:"tag,omitempty"`
+	Description        string          `json:"description,omitempty"`
+	GPS                GPSInfo         `json:"gps,omitempty"`
+	GeocodingID        int             `json:"geocoding_id,omitempty"`
+	Address            AddressInfo     `json:"address,omitempty"`
+	Person             []PersonInfo    `json:"person,omitempty"`
+	VideoConvert       interface{}     `json:"video_convert,omitempty"`
+	VideoMeta          interface{}     `json:"video_meta,omitempty"`
+	ProviderUserID     int             `json:"provider_user_id,omitempty"`
+}
+
+// ThumbnailInfo contains thumbnail availability information
+type ThumbnailInfo struct {
+	CacheKey string `json:"cache_key"`
+	UnitID   int    `json:"unit_id"`
+	SM       string `json:"sm"`       // "ready" or "broken"
+	M        string `json:"m"`        // "ready" or "broken"
+	XL       string `json:"xl"`       // "ready" or "broken"
+	Preview  string `json:"preview"`  // "ready" or "broken"
+}
+
+// ResolutionInfo contains image/video resolution
+type ResolutionInfo struct {
+	Height int `json:"height"`
+	Width  int `json:"width"`
+}
+
+// ExifInfo contains EXIF metadata
+type ExifInfo struct {
+	Aperture     string  `json:"aperture,omitempty"`
+	Camera       string  `json:"camera,omitempty"`
+	ExposureTime string  `json:"exposure_time,omitempty"`
+	FocalLength  string  `json:"focal_length,omitempty"`
+	ISO          int     `json:"iso,omitempty"`
+	Lens         string  `json:"lens,omitempty"`
+}
+
+// TagInfo represents a tag assigned to an item
+type TagInfo struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+// GPSInfo contains GPS coordinates
+type GPSInfo struct {
+	Latitude  float64 `json:"latitude"`
+	Longitude float64 `json:"longitude"`
+}
+
+// AddressInfo contains reverse geocoding address
+type AddressInfo struct {
+	City      string `json:"city,omitempty"`
+	CityID    int    `json:"city_id,omitempty"`
+	Country   string `json:"country,omitempty"`
+	CountryID int    `json:"country_id,omitempty"`
+	County    string `json:"county,omitempty"`
+	CountyID  int    `json:"county_id,omitempty"`
+	District  string `json:"district,omitempty"`
+	DistrictID int   `json:"district_id,omitempty"`
+	Landmark  string `json:"landmark,omitempty"`
+	LandmarkID int  `json:"landmark_id,omitempty"`
+	Route     string `json:"route,omitempty"`
+	RouteID   int    `json:"route_id,omitempty"`
+	State     string `json:"state,omitempty"`
+	StateID   int    `json:"state_id,omitempty"`
+	Town      string `json:"town,omitempty"`
+	TownID    int    `json:"town_id,omitempty"`
+	Village   string `json:"village,omitempty"`
+	VillageID int    `json:"village_id,omitempty"`
+}
+
+// PersonInfo represents a recognized person in Synology Photos
+type PersonInfo struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+// ItemListResponse represents the response from Browse.Item list method
+type ItemListResponse struct {
+	List []Item `json:"list"`
+}
+
+// Tag represents a general tag in Synology Photos
+type Tag struct {
+	ID        int    `json:"id"`
+	Name      string `json:"name"`
+	ItemCount int    `json:"item_count,omitempty"`
+}
+
+// TagListResponse represents the response from Browse.GeneralTag list method
+type TagListResponse struct {
+	List []Tag `json:"list"`
+}
+
+// Person represents a person in the face recognition system
+type Person struct {
+	ID            int    `json:"id"`
+	Name          string `json:"name"`
+	ItemCount     int    `json:"item_count,omitempty"`
+	CoverItemID   int    `json:"cover_item_id,omitempty"`
+}
+
+// PersonListResponse represents the response from Browse.Person list method
+type PersonListResponse struct {
+	List []Person `json:"list"`
+}
+
+// Folder represents a folder in the Personal Space
+type Folder struct {
+	ID            int    `json:"id"`
+	Name          string `json:"name"`
+	Parent        int    `json:"parent"`
+	OwnerUserID   int    `json:"owner_user_id"`
+	Passphrase    string `json:"passphrase"`
+	Shared        bool   `json:"shared"`
+	SortBy        string `json:"sort_by"`
+	SortDirection string `json:"sort_direction"`
+}
+
+// FolderListResponse represents the response from Browse.Folder list method
+type FolderListResponse struct {
+	List []Folder `json:"list"`
+}
+
+// CaptureTime returns the capture time as a time.Time
+func (i Item) CaptureTime() time.Time {
+	return time.Unix(i.Time, 0)
+}
+
+// IndexedTime returns the indexing time as a time.Time
+func (i Item) IndexedAt() time.Time {
+	// Indexed time is in milliseconds
+	return time.Unix(0, i.IndexedTime*int64(time.Millisecond))
+}
+
+// IsPhoto returns true if the item is a photo
+func (i Item) IsPhoto() bool {
+	return i.Type == "photo"
+}
+
+// IsVideo returns true if the item is a video
+func (i Item) IsVideo() bool {
+	return i.Type == "video"
+}
+
+// IsLivePhoto returns true if the item is a live photo
+func (i Item) IsLivePhoto() bool {
+	return i.Type == "live"
+}
+
+// CreateTime returns the album creation time as time.Time
+func (a Album) CreateAt() time.Time {
+	return time.Unix(a.CreateTime, 0)
+}

--- a/adapters/synology/models.go
+++ b/adapters/synology/models.go
@@ -211,8 +211,10 @@ type FolderListResponse struct {
 }
 
 // CaptureTime returns the capture time as a time.Time
+// Note: Synology stores Unix timestamp in local timezone, not UTC.
+// We convert to local time to preserve the original capture time.
 func (i Item) CaptureTime() time.Time {
-	return time.Unix(i.Time, 0)
+	return time.Unix(i.Time, 0).In(time.Local)
 }
 
 // IndexedTime returns the indexing time as a time.Time

--- a/adapters/synology/models.go
+++ b/adapters/synology/models.go
@@ -1,6 +1,8 @@
 package synology
 
 import (
+	"path"
+	"strings"
 	"time"
 )
 
@@ -232,6 +234,32 @@ func (i Item) IsVideo() bool {
 // IsLivePhoto returns true if the item is a live photo
 func (i Item) IsLivePhoto() bool {
 	return i.Type == "live"
+}
+
+// LivePhotoVideoFilename returns the inferred video filename for a live photo
+// Live photos have two files: image (e.g., .HEIC) and video (e.g., .MOV)
+// with the same basename
+func (i Item) LivePhotoVideoFilename() string {
+	if !i.IsLivePhoto() {
+		return ""
+	}
+	ext := strings.ToLower(path.Ext(i.Filename))
+	basename := i.Filename[:len(i.Filename)-len(ext)]
+
+	// Map of image extensions to video extensions (common for live photos)
+	videoExts := map[string]string{
+		".heic": ".mov",
+		".jpg":  ".mov",
+		".jpeg": ".mov",
+		".png":  ".mov",
+	}
+
+	if videoExt, ok := videoExts[ext]; ok {
+		return basename + videoExt
+	}
+
+	// Default to .mov if extension not recognized
+	return basename + ".mov"
 }
 
 // CreateTime returns the album creation time as time.Time

--- a/adapters/synology/models.go
+++ b/adapters/synology/models.go
@@ -211,10 +211,17 @@ type FolderListResponse struct {
 }
 
 // CaptureTime returns the capture time as a time.Time
-// Note: Synology stores Unix timestamp in local timezone, not UTC.
-// We convert to local time to preserve the original capture time.
+// Note: Synology stores time as local timezone seconds since epoch, not UTC.
+// We need to interpret it as local time and convert to UTC for Immich.
 func (i Item) CaptureTime() time.Time {
-	return time.Unix(i.Time, 0).In(time.Local)
+	// Create a time value treating the timestamp as local time
+	// then convert to UTC for proper timezone handling
+	localTime := time.Unix(i.Time, 0)
+	// Get year/month/day/hour/min/sec in local timezone
+	year, month, day := localTime.Date()
+	hour, min, sec := localTime.Clock()
+	// Create a new time with these values in local timezone, then convert to UTC
+	return time.Date(year, month, day, hour, min, sec, 0, time.Local).UTC()
 }
 
 // IndexedTime returns the indexing time as a time.Time

--- a/adapters/synology/synology.go
+++ b/adapters/synology/synology.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"io/fs"
 	"log/slog"
-	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -21,6 +20,8 @@ import (
 	"github.com/simulot/immich-go/internal/fileevent"
 	"github.com/simulot/immich-go/internal/fileprocessor"
 	"github.com/simulot/immich-go/internal/fshelper"
+
+	mapset "github.com/deckarep/golang-set/v2"
 )
 
 // Adapter implements the adapters.Reader interface for Synology Photos
@@ -36,25 +37,27 @@ type Adapter struct {
 	SkipFaceData  bool     // Skip face recognition data
 
 	// Internal
-	client      *Client
-	app         *app.Application
-	processor   *fileprocessor.FileProcessor
-	albumCache  map[string]Album // album name -> album
-	tagCache    map[string]int   // tag name -> tag id
-	peopleCache map[string]int   // person name -> person id
+	client          *Client
+	app             *app.Application
+	processor       *fileprocessor.FileProcessor
+	albumCache      map[string]Album           // album name -> album
+	tagCache        map[string]int             // tag name -> tag id
+	peopleCache     map[string]int             // person name -> person id
+	albumImageCache map[string]mapset.Set[int] //album name -> set of image ids
 }
 
 // NewAdapter creates a new Synology Photos adapter
 func NewAdapter(app *app.Application, serverURL, account, password string) *Adapter {
 	return &Adapter{
-		ServerURL:   serverURL,
-		Account:     account,
-		Password:    password,
-		app:         app,
-		processor:   app.FileProcessor(),
-		albumCache:  make(map[string]Album),
-		tagCache:    make(map[string]int),
-		peopleCache: make(map[string]int),
+		ServerURL:       serverURL,
+		Account:         account,
+		Password:        password,
+		app:             app,
+		processor:       app.FileProcessor(),
+		albumCache:      make(map[string]Album),
+		tagCache:        make(map[string]int),
+		peopleCache:     make(map[string]int),
+		albumImageCache: make(map[string]mapset.Set[int]),
 	}
 }
 
@@ -109,24 +112,18 @@ func (sa *Adapter) Browse(ctx context.Context) chan *assets.Group {
 			return
 		}
 
-		// Process albums or all items
-		// If user specified specific albums, process only those
-		// Otherwise process ALL items (including those not in any album)
-		if len(sa.Albums) > 0 && len(albumsToProcess) > 0 {
-			// User requested specific albums, process only items in those albums
-			for _, album := range albumsToProcess {
-				if err := sa.processAlbum(ctx, album, gOut); err != nil {
-					sa.app.Log().Error("Failed to process album", "album", album.Name, "error", err)
-					continue
-				}
+		// list all image of albums
+		for _, album := range albumsToProcess {
+			if err := sa.fetchAlbumImages(ctx, album); err != nil {
+				sa.app.Log().Error("Failed to fetch album images", "album", album.Name, "error", err)
+				continue
 			}
-		} else {
-			// No specific albums requested - process ALL items
-			// This includes both album items and non-album items
-			if err := sa.processAllItems(ctx, gOut); err != nil {
-				sa.app.Log().Error("Failed to process items", "error", err)
-				return
-			}
+		}
+		// No specific albums requested - process ALL items
+		// This includes both album items and non-album items
+		if err := sa.processAllItems(ctx, gOut); err != nil {
+			sa.app.Log().Error("Failed to process items", "error", err)
+			return
 		}
 	}()
 
@@ -218,38 +215,25 @@ func (sa *Adapter) getAlbumsToProcess(ctx context.Context) ([]Album, error) {
 	return allAlbums, nil
 }
 
-// processAlbum processes items from a specific album
-func (sa *Adapter) processAlbum(ctx context.Context, album Album, gOut chan *assets.Group) error {
-	// Clean up album name (trim whitespace)
-	album.Name = strings.TrimSpace(album.Name)
-	if album.Name == "" {
-		sa.app.Log().Warn("Skipping album with empty name", "id", album.ID)
-		return nil
-	}
-	sa.app.Log().Info("Processing album", "name", album.Name, "item_count", album.ItemCount)
-
-	additional := sa.getAdditionalFields()
+func (sa *Adapter) fetchAlbumImages(ctx context.Context, album Album) error {
 	offset := 0
 	limit := 100
-
 	for {
-		items, err := sa.client.GetAlbumItems(ctx, album.ID, offset, limit, additional)
+		items, err := sa.client.GetAlbumItems(ctx, album.ID, offset, limit, nil)
 		if err != nil {
 			return fmt.Errorf("get album items: %w", err)
 		}
-
-		for _, item := range items {
-			if err := sa.processItem(ctx, &item, &album, gOut); err != nil {
-				sa.app.Log().Error("Failed to process item", "filename", item.Filename, "error", err)
-			}
+		if sa.albumImageCache[album.Name] == nil {
+			sa.albumImageCache[album.Name] = mapset.NewSet[int]()
 		}
-
+		for _, item := range items {
+			sa.albumImageCache[album.Name].Add(item.ID)
+		}
 		if len(items) < limit {
 			break
 		}
 		offset += limit
 	}
-
 	return nil
 }
 
@@ -268,7 +252,7 @@ func (sa *Adapter) processAllItems(ctx context.Context, gOut chan *assets.Group)
 		}
 
 		for _, item := range items {
-			if err := sa.processItem(ctx, &item, nil, gOut); err != nil {
+			if err := sa.processItem(ctx, &item, gOut); err != nil {
 				sa.app.Log().Error("Failed to process item", "filename", item.Filename, "error", err)
 			}
 		}
@@ -301,7 +285,7 @@ func (sa *Adapter) getAdditionalFields() []string {
 
 // processItem processes a single item and sends it to the output channel
 // For live photos, this creates both the image and video assets
-func (sa *Adapter) processItem(ctx context.Context, item *Item, album *Album, gOut chan *assets.Group) error {
+func (sa *Adapter) processItem(ctx context.Context, item *Item, gOut chan *assets.Group) error {
 	// Check tag filter
 	if len(sa.Tags) > 0 && !sa.matchesTagFilter(item) {
 		return nil
@@ -314,17 +298,17 @@ func (sa *Adapter) processItem(ctx context.Context, item *Item, album *Album, gO
 
 	// For live photos, we need to create two assets: image and video
 	if item.IsLivePhoto() {
-		return sa.processLivePhoto(ctx, item, album, gOut)
+		return sa.processLivePhoto(ctx, item, gOut)
 	}
 
 	// Regular single asset
-	return sa.processSingleItem(ctx, item, album, gOut)
+	return sa.processSingleItem(ctx, item, gOut)
 }
 
 // processLivePhoto handles live photos by creating both image and video assets
 // Uses Synology's ZIP download API with proper synchronization
 // Note: Synology may return either a ZIP (with both image and video) or just the image file
-func (sa *Adapter) processLivePhoto(ctx context.Context, item *Item, album *Album, gOut chan *assets.Group) error {
+func (sa *Adapter) processLivePhoto(ctx context.Context, item *Item, gOut chan *assets.Group) error {
 	sa.app.Log().Debug("Processing live photo", "filename", item.Filename, "item_id", item.ID)
 
 	// Create a shared FS for the live photo bundle
@@ -343,7 +327,7 @@ func (sa *Adapter) processLivePhoto(ctx context.Context, item *Item, album *Albu
 	}
 
 	// Step 1: Process the image part (HEIC/JPG)
-	imageAsset := sa.mapToAssetForLiveImage(item, album, liveFS)
+	imageAsset := sa.mapToAssetForLiveImage(item, liveFS)
 	if imageAsset != nil {
 		sa.processor.RecordAssetDiscovered(ctx, imageAsset.File, int64(imageAsset.FileSize), fileevent.DiscoveredImage)
 		group := assets.NewGroup(assets.GroupByNone, imageAsset)
@@ -359,7 +343,7 @@ func (sa *Adapter) processLivePhoto(ctx context.Context, item *Item, album *Albu
 	// Non-ZIP responses only contain the image, no video
 	videoFilename := item.LivePhotoVideoFilename()
 	if videoFilename != "" && liveFS.hasVideo() {
-		videoAsset := sa.mapToAssetForLiveVideo(item, album, liveFS, videoFilename)
+		videoAsset := sa.mapToAssetForLiveVideo(item, liveFS, videoFilename)
 		if videoAsset != nil {
 			sa.processor.RecordAssetDiscovered(ctx, videoAsset.File, int64(videoAsset.FileSize), fileevent.DiscoveredVideo)
 			group := assets.NewGroup(assets.GroupByNone, videoAsset)
@@ -381,9 +365,9 @@ func (sa *Adapter) processLivePhoto(ctx context.Context, item *Item, album *Albu
 }
 
 // processSingleItem processes a regular (non-live) photo or video
-func (sa *Adapter) processSingleItem(ctx context.Context, item *Item, album *Album, gOut chan *assets.Group) error {
+func (sa *Adapter) processSingleItem(ctx context.Context, item *Item, gOut chan *assets.Group) error {
 	// Map to asset
-	asset := sa.mapToAsset(item, album)
+	asset := sa.mapToAsset(item)
 
 	// Record discovery
 	code := fileevent.DiscoveredImage
@@ -445,28 +429,25 @@ func (sa *Adapter) matchesPeopleFilter(item *Item) bool {
 
 // mapToAssetForLiveImage creates an Asset for the image part of a live photo
 // Uses the shared liveFS which handles concurrent access safely
-func (sa *Adapter) mapToAssetForLiveImage(item *Item, album *Album, liveFS *synologyLivePhotoFS) *assets.Asset {
+func (sa *Adapter) mapToAssetForLiveImage(item *Item, liveFS *synologyLivePhotoFS) *assets.Asset {
 	sa.app.Log().Debug("Creating live photo image asset", "filename", item.Filename, "item_id", item.ID)
 
+	captureDate := time.Unix(sa.correctTimestamp(item.Time, sa.app.GetTZ()), 0).In(sa.app.GetTZ())
 	imageAsset := &assets.Asset{
 		File:             fshelper.FSName(liveFS, item.Filename),
 		FileSize:         int(item.Filesize), // Approximate size from API
 		OriginalFileName: item.Filename,
 		FileDate:         item.IndexedAt(),
 		Description:      item.Additional.Description,
-		// Don't set CaptureDate, Latitude, Longitude - let Immich read from EXIF
-		// Synology's metadata may have timezone/format issues
+		CaptureDate:      captureDate,
 	}
 
 	// Add album if specified
-	if album != nil {
-		albumName := strings.TrimSpace(album.Name)
-		if albumName != "" {
-			imageAsset.Albums = []assets.Album{
-				{
-					Title: albumName,
-				},
-			}
+	for albumName, images := range sa.albumImageCache {
+		if images.Contains(item.ID) {
+			imageAsset.Albums = append(imageAsset.Albums, assets.Album{
+				Title: albumName,
+			})
 		}
 	}
 
@@ -493,47 +474,32 @@ func (sa *Adapter) mapToAssetForLiveImage(item *Item, album *Album, liveFS *syno
 		}
 	}
 
-	// Store original metadata
-	// Don't set DateTaken, Latitude, Longitude - let Immich read from EXIF
-	imageAsset.FromApplication = &assets.Metadata{
-		FileName:    item.Filename,
-		Description: item.Additional.Description,
-	}
-
-	// Copy tags to metadata
-	for _, tag := range imageAsset.Tags {
-		imageAsset.FromApplication.Tags = append(imageAsset.FromApplication.Tags, tag)
-	}
-
 	return imageAsset
 }
 
 // mapToAssetForLiveVideo creates an Asset for the video part of a live photo
 // Uses the shared liveFS which handles concurrent access safely
-func (sa *Adapter) mapToAssetForLiveVideo(item *Item, album *Album, liveFS *synologyLivePhotoFS, videoFilename string) *assets.Asset {
+func (sa *Adapter) mapToAssetForLiveVideo(item *Item, liveFS *synologyLivePhotoFS, videoFilename string) *assets.Asset {
 	sa.app.Log().Debug("Creating live photo video asset", "filename", videoFilename, "item_id", item.ID)
 
+	captureDate := time.Unix(sa.correctTimestamp(item.Time, sa.app.GetTZ()), 0).In(sa.app.GetTZ())
 	videoAsset := &assets.Asset{
 		File:             fshelper.FSName(liveFS, videoFilename),
 		FileSize:         int(item.Filesize), // Approximate size
 		OriginalFileName: videoFilename,
 		FileDate:         item.IndexedAt(),
 		Description:      item.Additional.Description,
-		// Don't set CaptureDate, Latitude, Longitude - let Immich read from EXIF
+		CaptureDate:      captureDate,
 	}
 
 	// Add album if specified
-	if album != nil {
-		albumName := strings.TrimSpace(album.Name)
-		if albumName != "" {
-			videoAsset.Albums = []assets.Album{
-				{
-					Title: albumName,
-				},
-			}
+	for albumName, images := range sa.albumImageCache {
+		if images.Contains(item.ID) {
+			videoAsset.Albums = append(videoAsset.Albums, assets.Album{
+				Title: albumName,
+			})
 		}
 	}
-
 	// Store original metadata
 	// Don't set DateTaken, Latitude, Longitude - let Immich read from EXIF
 	videoAsset.FromApplication = &assets.Metadata{
@@ -545,7 +511,7 @@ func (sa *Adapter) mapToAssetForLiveVideo(item *Item, album *Album, liveFS *syno
 }
 
 // mapToAsset converts a Synology Item to an immich-go Asset
-func (sa *Adapter) mapToAsset(item *Item, album *Album) *assets.Asset {
+func (sa *Adapter) mapToAsset(item *Item) *assets.Asset {
 	// Determine file type
 	ext := strings.ToLower(path.Ext(item.Filename))
 	if ext == "" {
@@ -567,7 +533,7 @@ func (sa *Adapter) mapToAsset(item *Item, album *Album) *assets.Asset {
 		size:     int(item.Filesize),
 		logger:   sa.app.Log().Logger,
 	}
-captureDate := time.Unix(sa.correctTimestamp(item.Time, sa.app.GetTZ()), 0).In(sa.app.GetTZ())
+	captureDate := time.Unix(sa.correctTimestamp(item.Time, sa.app.GetTZ()), 0).In(sa.app.GetTZ())
 	asset := &assets.Asset{
 		File:             fshelper.FSName(synFS, item.Filename),
 		FileSize:         int(item.Filesize),
@@ -577,15 +543,12 @@ captureDate := time.Unix(sa.correctTimestamp(item.Time, sa.app.GetTZ()), 0).In(s
 		CaptureDate:      captureDate,
 	}
 
-	// Add album if specified (with cleaned up name)
-	if album != nil {
-		albumName := strings.TrimSpace(album.Name)
-		if albumName != "" {
-			asset.Albums = []assets.Album{
-				{
-					Title: albumName,
-				},
-			}
+	// Add album if specified
+	for albumName, images := range sa.albumImageCache {
+		if images.Contains(item.ID) {
+			asset.Albums = append(asset.Albums, assets.Album{
+				Title: albumName,
+			})
 		}
 	}
 
@@ -644,9 +607,7 @@ func (s *synologyFS) Open(name string) (fs.File, error) {
 		return nil, fmt.Errorf("file not found: %s", name)
 	}
 
-	if s.logger != nil {
-		s.logger.Debug("Downloading Synology file", "filename", s.filename, "item_id", s.itemID, "cache_key", s.cacheKey)
-	}
+	s.logger.Debug("Downloading Synology file", "filename", s.filename, "item_id", s.itemID, "cache_key", s.cacheKey)
 
 	ctx := context.Background()
 
@@ -672,10 +633,7 @@ func (s *synologyFS) Open(name string) (fs.File, error) {
 		os.Remove(tempFile.Name())
 		return nil, fmt.Errorf("download to temp: %w", err)
 	}
-
-	if s.logger != nil {
-		s.logger.Debug("Downloaded Synology file", "filename", s.filename, "size", n)
-	}
+	s.logger.Debug("Downloaded Synology file", "filename", s.filename, "size", n)
 
 	// Seek to beginning for reading
 	_, err = tempFile.Seek(0, 0)
@@ -738,6 +696,7 @@ func (f *synologyFile) Close() error {
 		os.Remove(path)
 	}(f.tempPath)
 
+	os.Remove(f.tempPath)
 	return err
 }
 
@@ -878,7 +837,6 @@ func (s *synologyLivePhotoFS) handleZipDownload(reader io.ReadCloser, tempDir st
 
 	// Verify ZIP by checking file header (magic number)
 	if err := verifyZipFile(zipPath); err != nil {
-		s.printDebugCurlCommand()
 		return fmt.Errorf("verify zip: %w", err)
 	}
 
@@ -1058,47 +1016,6 @@ func (s *synologyLivePhotoFS) cleanup() {
 		s.zipFiles = nil
 		s.downloaded = false
 	}
-}
-
-// printDebugCurlCommand prints a curl command for manual debugging
-func (s *synologyLivePhotoFS) printDebugCurlCommand() {
-	if s.logger == nil {
-		return
-	}
-
-	client := s.client
-	baseURL := client.baseURL
-
-	// Build curl command
-	var cmd strings.Builder
-	cmd.WriteString("curl -v ")
-
-	// Headers
-	cmd.WriteString(`-H "Content-Type: application/x-www-form-urlencoded" `)
-	if client.synotoken != "" {
-		cmd.WriteString(fmt.Sprintf(`-H "X-SYNO-TOKEN: %s" `, client.synotoken))
-	}
-	if client.sid != "" {
-		cmd.WriteString(fmt.Sprintf(`-H "Cookie: id=%s" `, client.sid))
-	}
-
-	// POST data
-	params := fmt.Sprintf("force_download=true&item_id=%s&download_type=source&api=SYNO.Foto.Download&method=download&version=2",
-		url.QueryEscape(fmt.Sprintf("[%d]", s.itemID)))
-	cmd.WriteString(fmt.Sprintf(`--data "%s" `, params))
-
-	// URL
-	filename := url.QueryEscape(s.filename)
-	reqURL := fmt.Sprintf("%s/webapi/entry.cgi/%s", baseURL, filename)
-	if client.synotoken != "" {
-		reqURL = fmt.Sprintf("%s?SynoToken=%s", reqURL, url.QueryEscape(client.synotoken))
-	}
-	cmd.WriteString(fmt.Sprintf(`"%s" `, reqURL))
-
-	// Output to file
-	cmd.WriteString(`-o /tmp/debug_livephoto.zip`)
-
-	s.logger.Error("Live photo ZIP download returned non-ZIP content. Debug with:", "curl", cmd.String())
 }
 
 // verifyZipFile checks if the file is a valid ZIP by reading its magic number

--- a/adapters/synology/synology.go
+++ b/adapters/synology/synology.go
@@ -11,6 +11,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/simulot/immich-go/adapters"
@@ -326,34 +327,43 @@ func (sa *Adapter) processItem(ctx context.Context, item *Item, album *Album, gO
 }
 
 // processLivePhoto handles live photos by creating both image and video assets
-// Uses Synology's ZIP download API to get both files in one request
+// Uses Synology's ZIP download API with proper synchronization
 func (sa *Adapter) processLivePhoto(ctx context.Context, item *Item, album *Album, gOut chan *assets.Group) error {
 	sa.app.Log().Debug("Processing live photo", "filename", item.Filename, "item_id", item.ID)
 
+	// Create a shared FS for the live photo ZIP bundle
+	// The FS uses mutex to prevent concurrent downloads
+	liveFS := &synologyLivePhotoFS{
+		client:   sa.client,
+		itemID:   item.ID,
+		filename: item.Filename,
+		logger:   sa.app.Log().Logger,
+	}
+
 	// Step 1: Process the image part (HEIC/JPG)
-	// Each asset has its own FS instance to avoid lifecycle issues with shared temp directories
-	imageAsset := sa.mapToAssetForLiveImage(item, album)
+	imageAsset := sa.mapToAssetForLiveImage(item, album, liveFS)
 	if imageAsset != nil {
 		sa.processor.RecordAssetDiscovered(ctx, imageAsset.File, int64(imageAsset.FileSize), fileevent.DiscoveredImage)
 		group := assets.NewGroup(assets.GroupByNone, imageAsset)
 		select {
 		case gOut <- group:
 		case <-ctx.Done():
+			liveFS.cleanup()
 			return ctx.Err()
 		}
 	}
 
 	// Step 2: Process the video part (MOV)
-	// Each asset has its own FS instance - ZIP will be downloaded again but avoids cleanup races
 	videoFilename := item.LivePhotoVideoFilename()
 	if videoFilename != "" {
-		videoAsset := sa.mapToAssetForLiveVideo(item, album, videoFilename)
+		videoAsset := sa.mapToAssetForLiveVideo(item, album, liveFS, videoFilename)
 		if videoAsset != nil {
 			sa.processor.RecordAssetDiscovered(ctx, videoAsset.File, int64(videoAsset.FileSize), fileevent.DiscoveredVideo)
 			group := assets.NewGroup(assets.GroupByNone, videoAsset)
 			select {
 			case gOut <- group:
 			case <-ctx.Done():
+				liveFS.cleanup()
 				return ctx.Err()
 			}
 		}
@@ -361,9 +371,7 @@ func (sa *Adapter) processLivePhoto(ctx context.Context, item *Item, album *Albu
 		sa.app.Log().Warn("Live photo has no video filename", "filename", item.Filename)
 	}
 
-	// Note: Cleanup happens when files are closed after upload
-	// We can't cleanup here because the files haven't been read yet
-
+	// Note: Cleanup happens when the last file is closed
 	return nil
 }
 
@@ -431,17 +439,9 @@ func (sa *Adapter) matchesPeopleFilter(item *Item) bool {
 }
 
 // mapToAssetForLiveImage creates an Asset for the image part of a live photo
-// Each live photo asset gets its own FS instance to avoid lifecycle issues
-func (sa *Adapter) mapToAssetForLiveImage(item *Item, album *Album) *assets.Asset {
+// Uses the shared liveFS which handles concurrent access safely
+func (sa *Adapter) mapToAssetForLiveImage(item *Item, album *Album, liveFS *synologyLivePhotoFS) *assets.Asset {
 	sa.app.Log().Debug("Creating live photo image asset", "filename", item.Filename, "item_id", item.ID)
-
-	// Create a dedicated FS for this image asset
-	liveFS := &synologyLivePhotoFS{
-		client:   sa.client,
-		itemID:   item.ID,
-		filename: item.Filename,
-		logger:   sa.app.Log().Logger,
-	}
 
 	imageAsset := &assets.Asset{
 		File:             fshelper.FSName(liveFS, item.Filename),
@@ -507,18 +507,9 @@ func (sa *Adapter) mapToAssetForLiveImage(item *Item, album *Album) *assets.Asse
 }
 
 // mapToAssetForLiveVideo creates an Asset for the video part of a live photo
-// Each live photo asset gets its own FS instance to avoid lifecycle issues
-func (sa *Adapter) mapToAssetForLiveVideo(item *Item, album *Album, videoFilename string) *assets.Asset {
+// Uses the shared liveFS which handles concurrent access safely
+func (sa *Adapter) mapToAssetForLiveVideo(item *Item, album *Album, liveFS *synologyLivePhotoFS, videoFilename string) *assets.Asset {
 	sa.app.Log().Debug("Creating live photo video asset", "filename", videoFilename, "item_id", item.ID)
-
-	// Create a dedicated FS for this video asset
-	// The ZIP will be downloaded again, but this avoids complex lifecycle management
-	liveFS := &synologyLivePhotoFS{
-		client:   sa.client,
-		itemID:   item.ID,
-		filename: item.Filename, // Original filename (HEIC) for the API
-		logger:   sa.app.Log().Logger,
-	}
 
 	videoAsset := &assets.Asset{
 		File:             fshelper.FSName(liveFS, videoFilename),
@@ -750,13 +741,15 @@ func (fi *synologyFileInfo) Sys() interface{}   { return nil }
 // synologyLivePhotoFS implements fs.FS for live photos (ZIP bundle)
 // Downloads a ZIP containing both HEIC and MOV files, extracts on demand
 type synologyLivePhotoFS struct {
-	client     *Client
-	itemID     int
-	filename   string            // e.g., "IMG_9948.HEIC"
-	zipFiles   map[string]string // filename -> temp path
-	tempDir    string
-	logger     *slog.Logger
-	downloaded bool
+	client       *Client
+	itemID       int
+	filename     string            // e.g., "IMG_9948.HEIC"
+	zipFiles     map[string]string // filename -> temp path
+	tempDir      string
+	logger       *slog.Logger
+	downloaded   bool
+	mu           sync.Mutex // protects download operation
+	refCount     int        // number of open files using this FS
 }
 
 // Open implements fs.FS - downloads ZIP on first call, returns requested file
@@ -768,6 +761,10 @@ func (s *synologyLivePhotoFS) Open(name string) (fs.File, error) {
 	}
 
 	ctx := context.Background()
+
+	// Use mutex to prevent concurrent downloads in the same FS
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	// Download and extract ZIP on first access
 	if !s.downloaded {
@@ -800,14 +797,25 @@ func (s *synologyLivePhotoFS) Open(name string) (fs.File, error) {
 			return nil, fmt.Errorf("create zip temp file: %w", err)
 		}
 
-		_, err = io.Copy(zipFile, reader)
+		written, err := io.Copy(zipFile, reader)
 		reader.Close()
 		zipFile.Close()
+
+		if s.logger != nil {
+			s.logger.Debug("Downloaded ZIP to temp file", "filename", s.filename, "bytes", written)
+		}
 
 		if err != nil {
 			os.RemoveAll(s.tempDir)
 			s.tempDir = ""
 			return nil, fmt.Errorf("save zip: %w", err)
+		}
+
+		// Verify ZIP by checking file header (magic number)
+		if err := verifyZipFile(zipPath); err != nil {
+			os.RemoveAll(s.tempDir)
+			s.tempDir = ""
+			return nil, fmt.Errorf("verify zip: %w", err)
 		}
 
 		// Extract ZIP
@@ -883,7 +891,8 @@ func (s *synologyLivePhotoFS) Open(name string) (fs.File, error) {
 				return nil, err
 			}
 
-			return &synologyLivePhotoFile{
+			s.refCount++
+		return &synologyLivePhotoFile{
 				File:     f,
 				name:     fname,
 				size:     info.Size(),
@@ -898,12 +907,49 @@ func (s *synologyLivePhotoFS) Open(name string) (fs.File, error) {
 
 // cleanup removes the temp directory and all extracted files
 func (s *synologyLivePhotoFS) cleanup() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	if s.tempDir != "" {
 		os.RemoveAll(s.tempDir)
 		s.tempDir = ""
 		s.zipFiles = nil
 		s.downloaded = false
 	}
+}
+
+// verifyZipFile checks if the file is a valid ZIP by reading its magic number
+func verifyZipFile(path string) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("open file: %w", err)
+	}
+	defer file.Close()
+
+	// ZIP files start with PK\x03\x04 or PK\x05\x06
+	magic := make([]byte, 4)
+	_, err = file.Read(magic)
+	if err != nil {
+		return fmt.Errorf("read magic: %w", err)
+	}
+
+	// Check for ZIP local file header (PK\x03\x04) or empty archive (PK\x05\x06)
+	if magic[0] != 'P' || magic[1] != 'K' {
+		return fmt.Errorf("invalid ZIP magic bytes: %02x %02x %02x %02x", magic[0], magic[1], magic[2], magic[3])
+	}
+
+	// Check valid ZIP signatures
+	if magic[2] == 0x03 && magic[3] == 0x04 {
+		return nil // Local file header
+	}
+	if magic[2] == 0x05 && magic[3] == 0x06 {
+		return nil // Empty archive
+	}
+	if magic[2] == 0x07 && magic[3] == 0x08 {
+		return nil // Spanned archive
+	}
+
+	return fmt.Errorf("invalid ZIP signature: %02x %02x", magic[2], magic[3])
 }
 
 // synologyLivePhotoFile implements fs.File for live photo extracted files
@@ -924,10 +970,16 @@ func (f *synologyLivePhotoFile) Stat() (fs.FileInfo, error) {
 
 func (f *synologyLivePhotoFile) Close() error {
 	err := f.File.Close()
-	// Cleanup the temp directory when the file is closed
-	// Each asset has its own FS, so cleanup is safe
+	// Decrement ref count and cleanup when zero
 	if f.fs != nil {
-		f.fs.cleanup()
+		f.fs.mu.Lock()
+		f.fs.refCount--
+		shouldCleanup := f.fs.refCount <= 0
+		f.fs.mu.Unlock()
+
+		if shouldCleanup {
+			f.fs.cleanup()
+		}
 	}
 	return err
 }

--- a/adapters/synology/synology.go
+++ b/adapters/synology/synology.go
@@ -567,14 +567,14 @@ func (sa *Adapter) mapToAsset(item *Item, album *Album) *assets.Asset {
 		size:     int(item.Filesize),
 		logger:   sa.app.Log().Logger,
 	}
-
+captureDate := time.Unix(sa.correctTimestamp(item.Time, sa.app.GetTZ()), 0).In(sa.app.GetTZ())
 	asset := &assets.Asset{
 		File:             fshelper.FSName(synFS, item.Filename),
 		FileSize:         int(item.Filesize),
 		OriginalFileName: item.Filename,
 		FileDate:         item.IndexedAt(),
 		Description:      item.Additional.Description,
-		// Don't set CaptureDate, Latitude, Longitude - let Immich read from EXIF
+		CaptureDate:      captureDate,
 	}
 
 	// Add album if specified (with cleaned up name)
@@ -613,19 +613,15 @@ func (sa *Adapter) mapToAsset(item *Item, album *Album) *assets.Asset {
 		}
 	}
 
-	// Store original metadata
-	// Don't set DateTaken, Latitude, Longitude - let Immich read from EXIF
-	asset.FromApplication = &assets.Metadata{
-		FileName:    item.Filename,
-		Description: item.Additional.Description,
-	}
-
-	// Copy tags to metadata
-	for _, tag := range asset.Tags {
-		asset.FromApplication.Tags = append(asset.FromApplication.Tags, tag)
-	}
-
 	return asset
+}
+func (sa *Adapter) correctTimestamp(wrong int64, loc *time.Location) int64 {
+	t := time.Unix(wrong, 0).UTC()
+	for i := 0; i < 2; i++ { // to fix the daylight saving time, twice is enough
+		_, offset := t.In(loc).Zone()
+		t = time.Unix(wrong-int64(offset), 0).UTC()
+	}
+	return t.Unix()
 }
 
 // Ensure Adapter implements adapters.Reader

--- a/adapters/synology/synology.go
+++ b/adapters/synology/synology.go
@@ -1,10 +1,12 @@
 package synology
 
 import (
+	"archive/zip"
 	"context"
 	"fmt"
 	"io"
 	"io/fs"
+	"log/slog"
 	"os"
 	"path"
 	"path/filepath"
@@ -324,35 +326,51 @@ func (sa *Adapter) processItem(ctx context.Context, item *Item, album *Album, gO
 }
 
 // processLivePhoto handles live photos by creating both image and video assets
+// Uses Synology's ZIP download API to get both files in one request
 func (sa *Adapter) processLivePhoto(ctx context.Context, item *Item, album *Album, gOut chan *assets.Group) error {
-	// Live photos have two files with the same basename:
-	// - Image: e.g., IMG_9948.HEIC
-	// - Video: e.g., IMG_9948.MOV
+	sa.app.Log().Debug("Processing live photo", "filename", item.Filename, "item_id", item.ID)
 
-	// Process the image part first
-	imageAsset := sa.mapToAsset(item, album)
-
-	// Send image
-	sa.processor.RecordAssetDiscovered(ctx, imageAsset.File, int64(imageAsset.FileSize), fileevent.DiscoveredImage)
-	group := assets.NewGroup(assets.GroupByNone, imageAsset)
-	select {
-	case gOut <- group:
-	case <-ctx.Done():
-		return ctx.Err()
+	// Create a shared FS for the live photo ZIP bundle
+	liveFS := &synologyLivePhotoFS{
+		client:   sa.client,
+		itemID:   item.ID,
+		filename: item.Filename,
+		logger:   sa.app.Log().Logger,
 	}
 
-	// Infer video filename from image filename
-	// SYNO.Foto.Download API should handle this based on item ID
-	videoAsset := sa.mapToAssetForLiveVideo(item, album)
-	if videoAsset != nil {
-		sa.processor.RecordAssetDiscovered(ctx, videoAsset.File, int64(videoAsset.FileSize), fileevent.DiscoveredVideo)
-		group := assets.NewGroup(assets.GroupByNone, videoAsset)
+	// Step 1: Process the image part (HEIC/JPG)
+	imageAsset := sa.mapToAssetForLiveImage(item, album, liveFS)
+	if imageAsset != nil {
+		sa.processor.RecordAssetDiscovered(ctx, imageAsset.File, int64(imageAsset.FileSize), fileevent.DiscoveredImage)
+		group := assets.NewGroup(assets.GroupByNone, imageAsset)
 		select {
 		case gOut <- group:
 		case <-ctx.Done():
+			liveFS.cleanup()
 			return ctx.Err()
 		}
 	}
+
+	// Step 2: Process the video part (MOV)
+	videoFilename := item.LivePhotoVideoFilename()
+	if videoFilename != "" {
+		videoAsset := sa.mapToAssetForLiveVideo(item, album, liveFS, videoFilename)
+		if videoAsset != nil {
+			sa.processor.RecordAssetDiscovered(ctx, videoAsset.File, int64(videoAsset.FileSize), fileevent.DiscoveredVideo)
+			group := assets.NewGroup(assets.GroupByNone, videoAsset)
+			select {
+			case gOut <- group:
+			case <-ctx.Done():
+				liveFS.cleanup()
+				return ctx.Err()
+			}
+		}
+	} else {
+		sa.app.Log().Warn("Live photo has no video filename", "filename", item.Filename)
+	}
+
+	// Note: Cleanup happens when files are closed after upload
+	// We can't cleanup here because the files haven't been read yet
 
 	return nil
 }
@@ -420,34 +438,86 @@ func (sa *Adapter) matchesPeopleFilter(item *Item) bool {
 	return false
 }
 
+// mapToAssetForLiveImage creates an Asset for the image part of a live photo
+// Uses the shared liveFS which downloads and extracts the ZIP bundle
+func (sa *Adapter) mapToAssetForLiveImage(item *Item, album *Album, liveFS *synologyLivePhotoFS) *assets.Asset {
+	sa.app.Log().Debug("Creating live photo image asset", "filename", item.Filename, "item_id", item.ID)
+
+	// Use the shared live photo FS (ZIP bundle)
+	// FileSize will be determined when the file is opened
+	imageAsset := &assets.Asset{
+		File:             fshelper.FSName(liveFS, item.Filename),
+		FileSize:         int(item.Filesize), // Approximate size from API
+		OriginalFileName: item.Filename,
+		FileDate:         item.IndexedAt(),
+		CaptureDate:      item.CaptureTime(),
+		Description:      item.Additional.Description,
+		Latitude:         item.Additional.GPS.Latitude,
+		Longitude:        item.Additional.GPS.Longitude,
+	}
+
+	// Add album if specified
+	if album != nil {
+		albumName := strings.TrimSpace(album.Name)
+		if albumName != "" {
+			imageAsset.Albums = []assets.Album{
+				{
+					Title: albumName,
+				},
+			}
+		}
+	}
+
+	// Add tags
+	for _, tag := range item.Additional.Tag {
+		if tag.Name != "" {
+			imageAsset.Tags = append(imageAsset.Tags, assets.Tag{
+				Name:  tag.Name,
+				Value: tag.Name,
+			})
+		}
+	}
+
+	// Add people as tags
+	if !sa.SkipFaceData {
+		for _, person := range item.Additional.Person {
+			if person.Name != "" {
+				personTag := fmt.Sprintf("Person: %s", person.Name)
+				imageAsset.Tags = append(imageAsset.Tags, assets.Tag{
+					Name:  personTag,
+					Value: personTag,
+				})
+			}
+		}
+	}
+
+	// Store original metadata
+	imageAsset.FromApplication = &assets.Metadata{
+		FileName:    item.Filename,
+		DateTaken:   item.CaptureTime(),
+		Description: item.Additional.Description,
+		Latitude:    item.Additional.GPS.Latitude,
+		Longitude:   item.Additional.GPS.Longitude,
+	}
+
+	// Copy tags to metadata
+	for _, tag := range imageAsset.Tags {
+		imageAsset.FromApplication.Tags = append(imageAsset.FromApplication.Tags, tag)
+	}
+
+	return imageAsset
+}
+
 // mapToAssetForLiveVideo creates an Asset for the video part of a live photo
-// For live photos, we create a separate video Asset with the inferred video filename
-func (sa *Adapter) mapToAssetForLiveVideo(item *Item, album *Album) *assets.Asset {
-	videoFilename := item.LivePhotoVideoFilename()
-	if videoFilename == "" {
-		return nil
-	}
+// Uses the shared liveFS which contains both HEIC and MOV from the ZIP bundle
+func (sa *Adapter) mapToAssetForLiveVideo(item *Item, album *Album, liveFS *synologyLivePhotoFS, videoFilename string) *assets.Asset {
+	sa.app.Log().Debug("Creating live photo video asset", "filename", videoFilename, "item_id", item.ID)
 
-	// For the video part, use thumbnail's unit_id if different from main item
-	// This handles cases where photo and video have different IDs
-	videoItemID := item.ID
-	videoCacheKey := item.Additional.Thumbnail.CacheKey
-	if item.Additional.Thumbnail.UnitID > 0 && item.Additional.Thumbnail.UnitID != item.ID {
-		videoItemID = item.Additional.Thumbnail.UnitID
-	}
-
-	// Create a custom FS for the video file
-	synFS := &synologyFS{
-		client:   sa.client,
-		itemID:   videoItemID,
-		cacheKey: videoCacheKey,
-		filename: videoFilename,
-		size:     int(item.Filesize), // Approximate, may not be accurate for video
-	}
-
+	// Use the shared live photo FS (ZIP bundle)
+	// FileSize is approximate - actual size comes from extracted file
 	videoAsset := &assets.Asset{
-		File:             fshelper.FSName(synFS, videoFilename),
-		FileSize:         int(item.Filesize), // May need adjustment
+		File:             fshelper.FSName(liveFS, videoFilename),
+		FileSize:         int(item.Filesize), // Approximate size
 		OriginalFileName: videoFilename,
 		FileDate:         item.IndexedAt(),
 		CaptureDate:      item.CaptureTime(),
@@ -501,6 +571,7 @@ func (sa *Adapter) mapToAsset(item *Item, album *Album) *assets.Asset {
 		cacheKey: item.Additional.Thumbnail.CacheKey,
 		filename: item.Filename,
 		size:     int(item.Filesize),
+		logger:   sa.app.Log().Logger,
 	}
 
 	asset := &assets.Asset{
@@ -577,7 +648,7 @@ type synologyFS struct {
 	cacheKey string
 	filename string
 	size     int
-	app      *app.Application // For temp file management
+	logger   *slog.Logger // Optional logger for debugging
 }
 
 // Open implements fs.FS
@@ -585,6 +656,10 @@ type synologyFS struct {
 func (s *synologyFS) Open(name string) (fs.File, error) {
 	if name != s.filename {
 		return nil, fmt.Errorf("file not found: %s", name)
+	}
+
+	if s.logger != nil {
+		s.logger.Debug("Downloading Synology file", "filename", s.filename, "item_id", s.itemID, "cache_key", s.cacheKey)
 	}
 
 	ctx := context.Background()
@@ -603,13 +678,17 @@ func (s *synologyFS) Open(name string) (fs.File, error) {
 		return nil, err
 	}
 
-	_, err = io.Copy(tempFile, reader)
+	n, err := io.Copy(tempFile, reader)
 	reader.Close()
 
 	if err != nil {
 		tempFile.Close()
 		os.Remove(tempFile.Name())
 		return nil, fmt.Errorf("download to temp: %w", err)
+	}
+
+	if s.logger != nil {
+		s.logger.Debug("Downloaded Synology file", "filename", s.filename, "size", n)
 	}
 
 	// Seek to beginning for reading
@@ -662,3 +741,192 @@ func (fi *synologyFileInfo) Mode() fs.FileMode  { return 0444 } // Read-only
 func (fi *synologyFileInfo) ModTime() time.Time { return time.Now() }
 func (fi *synologyFileInfo) IsDir() bool        { return false }
 func (fi *synologyFileInfo) Sys() interface{}   { return nil }
+
+// synologyLivePhotoFS implements fs.FS for live photos (ZIP bundle)
+// Downloads a ZIP containing both HEIC and MOV files, extracts on demand
+type synologyLivePhotoFS struct {
+	client     *Client
+	itemID     int
+	filename   string            // e.g., "IMG_9948.HEIC"
+	zipFiles   map[string]string // filename -> temp path
+	tempDir    string
+	logger     *slog.Logger
+	downloaded bool
+	refCount   int // Number of open files
+}
+
+// Open implements fs.FS - downloads ZIP on first call, returns requested file
+func (s *synologyLivePhotoFS) Open(name string) (fs.File, error) {
+	// Only allow opening the main file (HEIC) or its corresponding video (MOV)
+	expectedVideo := s.filename[:len(s.filename)-len(filepath.Ext(s.filename))] + ".mov"
+	if name != s.filename && strings.ToLower(name) != strings.ToLower(expectedVideo) {
+		return nil, fmt.Errorf("file not found: %s", name)
+	}
+
+	ctx := context.Background()
+
+	// Download and extract ZIP on first access
+	if !s.downloaded {
+		if s.logger != nil {
+			s.logger.Debug("Downloading live photo ZIP", "filename", s.filename, "item_id", s.itemID)
+		}
+
+		// Create temp directory
+		tempDir, err := os.MkdirTemp("", "synology-livephoto-*")
+		if err != nil {
+			return nil, fmt.Errorf("create temp dir: %w", err)
+		}
+		s.tempDir = tempDir
+
+		// Download ZIP
+		reader, err := s.client.DownloadLivePhotoZip(ctx, s.itemID, s.filename)
+		if err != nil {
+			os.RemoveAll(s.tempDir)
+			s.tempDir = ""
+			return nil, fmt.Errorf("download live photo ZIP: %w", err)
+		}
+
+		// Save ZIP to temp file
+		zipPath := filepath.Join(tempDir, "livephoto.zip")
+		zipFile, err := os.Create(zipPath)
+		if err != nil {
+			reader.Close()
+			os.RemoveAll(s.tempDir)
+			s.tempDir = ""
+			return nil, fmt.Errorf("create zip temp file: %w", err)
+		}
+
+		_, err = io.Copy(zipFile, reader)
+		reader.Close()
+		zipFile.Close()
+
+		if err != nil {
+			os.RemoveAll(s.tempDir)
+			s.tempDir = ""
+			return nil, fmt.Errorf("save zip: %w", err)
+		}
+
+		// Extract ZIP
+		zipReader, err := zip.OpenReader(zipPath)
+		if err != nil {
+			os.RemoveAll(s.tempDir)
+			s.tempDir = ""
+			return nil, fmt.Errorf("open zip: %w", err)
+		}
+
+		s.zipFiles = make(map[string]string)
+		for _, zf := range zipReader.File {
+			// Extract each file
+			extractPath := filepath.Join(tempDir, filepath.Base(zf.Name))
+			rc, err := zf.Open()
+			if err != nil {
+				zipReader.Close()
+				os.RemoveAll(s.tempDir)
+				s.tempDir = ""
+				return nil, fmt.Errorf("extract %s: %w", zf.Name, err)
+			}
+
+			extractFile, err := os.Create(extractPath)
+			if err != nil {
+				rc.Close()
+				zipReader.Close()
+				os.RemoveAll(s.tempDir)
+				s.tempDir = ""
+				return nil, fmt.Errorf("create extract file: %w", err)
+			}
+
+			_, err = io.Copy(extractFile, rc)
+			rc.Close()
+			extractFile.Close()
+
+			if err != nil {
+				zipReader.Close()
+				os.RemoveAll(s.tempDir)
+				s.tempDir = ""
+				return nil, fmt.Errorf("extract %s: %w", zf.Name, err)
+			}
+
+			s.zipFiles[filepath.Base(zf.Name)] = extractPath
+			if s.logger != nil {
+				s.logger.Debug("Extracted live photo file", "name", zf.Name, "size", zf.UncompressedSize64)
+			}
+		}
+		zipReader.Close()
+
+		// Clean up ZIP file
+		os.Remove(zipPath)
+
+		s.downloaded = true
+
+		if s.logger != nil {
+			s.logger.Debug("Live photo ZIP downloaded and extracted", "files", len(s.zipFiles))
+		}
+	}
+
+	// Return the requested file
+	lowerName := strings.ToLower(name)
+	for fname, fpath := range s.zipFiles {
+		if strings.ToLower(fname) == lowerName {
+			f, err := os.Open(fpath)
+			if err != nil {
+				return nil, err
+			}
+
+			// Get file info for size
+			info, err := f.Stat()
+			if err != nil {
+				f.Close()
+				return nil, err
+			}
+
+			s.refCount++
+		return &synologyLivePhotoFile{
+				File:     f,
+				name:     fname,
+				size:     info.Size(),
+				tempPath: fpath,
+				fs:       s,
+			}, nil
+		}
+	}
+
+	return nil, fmt.Errorf("file not found in live photo: %s", name)
+}
+
+// cleanup removes the temp directory and all extracted files
+func (s *synologyLivePhotoFS) cleanup() {
+	if s.tempDir != "" {
+		os.RemoveAll(s.tempDir)
+		s.tempDir = ""
+		s.zipFiles = nil
+		s.downloaded = false
+	}
+}
+
+// synologyLivePhotoFile implements fs.File for live photo extracted files
+type synologyLivePhotoFile struct {
+	*os.File
+	name     string
+	size     int64
+	tempPath string
+	fs       *synologyLivePhotoFS
+}
+
+func (f *synologyLivePhotoFile) Stat() (fs.FileInfo, error) {
+	return &synologyFileInfo{
+		name: f.name,
+		size: f.size,
+	}, nil
+}
+
+func (f *synologyLivePhotoFile) Close() error {
+	err := f.File.Close()
+	// Decrement ref count and cleanup if this is the last file
+	if f.fs != nil {
+		f.fs.refCount--
+		if f.fs.refCount <= 0 {
+			f.fs.cleanup()
+		}
+	}
+	return err
+}

--- a/adapters/synology/synology.go
+++ b/adapters/synology/synology.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/fs"
 	"log/slog"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -780,11 +781,15 @@ func (s *synologyLivePhotoFS) Open(name string) (fs.File, error) {
 		s.tempDir = tempDir
 
 		// Download ZIP
-		reader, err := s.client.DownloadLivePhotoZip(ctx, s.itemID, s.filename)
+		reader, contentType, err := s.client.DownloadLivePhotoZip(ctx, s.itemID, s.filename, s.logger)
 		if err != nil {
 			os.RemoveAll(s.tempDir)
 			s.tempDir = ""
 			return nil, fmt.Errorf("download live photo ZIP: %w", err)
+		}
+
+		if s.logger != nil {
+			s.logger.Debug("Downloaded live photo", "filename", s.filename, "content_type", contentType, "item_id", s.itemID)
 		}
 
 		// Save ZIP to temp file
@@ -813,6 +818,8 @@ func (s *synologyLivePhotoFS) Open(name string) (fs.File, error) {
 
 		// Verify ZIP by checking file header (magic number)
 		if err := verifyZipFile(zipPath); err != nil {
+			// Print debug curl command for manual troubleshooting
+			s.printDebugCurlCommand()
 			os.RemoveAll(s.tempDir)
 			s.tempDir = ""
 			return nil, fmt.Errorf("verify zip: %w", err)
@@ -916,6 +923,47 @@ func (s *synologyLivePhotoFS) cleanup() {
 		s.zipFiles = nil
 		s.downloaded = false
 	}
+}
+
+// printDebugCurlCommand prints a curl command for manual debugging
+func (s *synologyLivePhotoFS) printDebugCurlCommand() {
+	if s.logger == nil {
+		return
+	}
+
+	client := s.client
+	baseURL := client.baseURL
+
+	// Build curl command
+	var cmd strings.Builder
+	cmd.WriteString("curl -v ")
+
+	// Headers
+	cmd.WriteString(`-H "Content-Type: application/x-www-form-urlencoded" `)
+	if client.synotoken != "" {
+		cmd.WriteString(fmt.Sprintf(`-H "X-SYNO-TOKEN: %s" `, client.synotoken))
+	}
+	if client.sid != "" {
+		cmd.WriteString(fmt.Sprintf(`-H "Cookie: id=%s" `, client.sid))
+	}
+
+	// POST data
+	params := fmt.Sprintf("force_download=true&item_id=%s&download_type=source&api=SYNO.Foto.Download&method=download&version=2",
+		url.QueryEscape(fmt.Sprintf("[%d]", s.itemID)))
+	cmd.WriteString(fmt.Sprintf(`--data "%s" `, params))
+
+	// URL
+	filename := url.QueryEscape(s.filename)
+	reqURL := fmt.Sprintf("%s/webapi/entry.cgi/%s", baseURL, filename)
+	if client.synotoken != "" {
+		reqURL = fmt.Sprintf("%s?SynoToken=%s", reqURL, url.QueryEscape(client.synotoken))
+	}
+	cmd.WriteString(fmt.Sprintf(`"%s" `, reqURL))
+
+	// Output to file
+	cmd.WriteString(`-o /tmp/debug_livephoto.zip`)
+
+	s.logger.Error("Live photo ZIP download returned non-ZIP content. Debug with:", "curl", cmd.String())
 }
 
 // verifyZipFile checks if the file is a valid ZIP by reading its magic number

--- a/adapters/synology/synology.go
+++ b/adapters/synology/synology.go
@@ -342,8 +342,13 @@ func (sa *Adapter) processLivePhoto(ctx context.Context, item *Item, album *Albu
 		logger:   sa.app.Log().Logger,
 	}
 
+	// Pre-download to determine if we have a ZIP (with video) or single file
+	// This is necessary because hasVideo() needs to know the response type
+	if err := liveFS.preDownload(ctx); err != nil {
+		return fmt.Errorf("pre-download live photo: %w", err)
+	}
+
 	// Step 1: Process the image part (HEIC/JPG)
-	// This triggers the download and determines if we have a ZIP (with video) or single file
 	imageAsset := sa.mapToAssetForLiveImage(item, album, liveFS)
 	if imageAsset != nil {
 		sa.processor.RecordAssetDiscovered(ctx, imageAsset.File, int64(imageAsset.FileSize), fileevent.DiscoveredImage)
@@ -771,58 +776,17 @@ func (s *synologyLivePhotoFS) Open(name string) (fs.File, error) {
 
 	ctx := context.Background()
 
-	// Use mutex to prevent concurrent downloads in the same FS
+	// Use mutex to prevent concurrent access
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Download on first access
+	// If not pre-downloaded yet, do it now (shouldn't happen if processLivePhoto works correctly)
 	if !s.downloaded {
-		if s.logger != nil {
-			s.logger.Debug("Downloading live photo", "filename", s.filename, "item_id", s.itemID)
+		s.mu.Unlock()
+		if err := s.preDownload(ctx); err != nil {
+			return nil, err
 		}
-
-		// Create temp directory
-		tempDir, err := os.MkdirTemp("", "synology-livephoto-*")
-		if err != nil {
-			return nil, fmt.Errorf("create temp dir: %w", err)
-		}
-		s.tempDir = tempDir
-
-		// Download - may return ZIP or single file
-		reader, contentType, isZip, err := s.client.DownloadLivePhoto(ctx, s.itemID, s.filename, s.logger)
-		if err != nil {
-			os.RemoveAll(s.tempDir)
-			s.tempDir = ""
-			return nil, fmt.Errorf("download live photo: %w", err)
-		}
-
-		s.isZip = isZip
-
-		if s.logger != nil {
-			s.logger.Debug("Downloaded live photo", "filename", s.filename, "content_type", contentType,
-				"is_zip", isZip, "item_id", s.itemID)
-		}
-
-		if isZip {
-			// Handle ZIP download (contains both image and video)
-			if err := s.handleZipDownload(reader, tempDir); err != nil {
-				reader.Close()
-				os.RemoveAll(s.tempDir)
-				s.tempDir = ""
-				return nil, err
-			}
-		} else {
-			// Handle single file download (just the image)
-			if err := s.handleSingleFileDownload(reader, tempDir, name); err != nil {
-				reader.Close()
-				os.RemoveAll(s.tempDir)
-				s.tempDir = ""
-				return nil, err
-			}
-		}
-		reader.Close()
-
-		s.downloaded = true
+		s.mu.Lock()
 	}
 
 	// Return the requested file
@@ -967,6 +931,74 @@ func (s *synologyLivePhotoFS) hasVideo() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.isZip
+}
+
+// preDownload downloads the live photo ahead of time to determine the response type
+// This allows hasVideo() to return the correct value before assets are created
+func (s *synologyLivePhotoFS) preDownload(ctx context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.downloaded {
+		return nil
+	}
+
+	if s.logger != nil {
+		s.logger.Debug("Pre-downloading live photo", "filename", s.filename, "item_id", s.itemID)
+	}
+
+	// Create temp directory
+	tempDir, err := os.MkdirTemp("", "synology-livephoto-*")
+	if err != nil {
+		return fmt.Errorf("create temp dir: %w", err)
+	}
+	s.tempDir = tempDir
+
+	// Download - may return ZIP or single file
+	reader, contentType, isZip, err := s.client.DownloadLivePhoto(ctx, s.itemID, s.filename, s.logger)
+	if err != nil {
+		os.RemoveAll(s.tempDir)
+		s.tempDir = ""
+		return fmt.Errorf("download live photo: %w", err)
+	}
+
+	s.isZip = isZip
+
+	if s.logger != nil {
+		s.logger.Debug("Pre-downloaded live photo", "filename", s.filename, "content_type", contentType,
+			"is_zip", isZip, "item_id", s.itemID)
+	}
+
+	if isZip {
+		// Handle ZIP download (contains both image and video)
+		if err := s.handleZipDownload(reader, tempDir); err != nil {
+			reader.Close()
+			os.RemoveAll(s.tempDir)
+			s.tempDir = ""
+			return err
+		}
+	} else {
+		// Handle single file download (just the image)
+		if err := s.handleSingleFileDownload(reader, tempDir, s.filename); err != nil {
+			reader.Close()
+			os.RemoveAll(s.tempDir)
+			s.tempDir = ""
+			return err
+		}
+	}
+	reader.Close()
+
+	s.downloaded = true
+
+	if s.logger != nil {
+		if isZip {
+			s.logger.Debug("Live photo pre-downloaded as ZIP", "files", len(s.zipFiles))
+		} else {
+			s.logger.Debug("Live photo pre-downloaded as single file")
+		}
+	}
+
+	return nil
 }
 
 // cleanup removes the temp directory and all extracted files

--- a/adapters/synology/synology.go
+++ b/adapters/synology/synology.go
@@ -288,15 +288,7 @@ func (sa *Adapter) getAdditionalFields() []string {
 	// Always request these
 	additional := []string{
 		"thumbnail",
-		"resolution",
-		"orientation",
-		"description",
-		"gps",
-	}
-
-	// Request tags if we need them
-	if len(sa.Tags) > 0 || len(sa.Albums) == 0 {
-		additional = append(additional, "tag")
+		"tag",
 	}
 
 	// Request people if we need them

--- a/adapters/synology/synology.go
+++ b/adapters/synology/synology.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -465,33 +467,63 @@ type synologyFS struct {
 	cacheKey string
 	filename string
 	size     int
+	app      *app.Application // For temp file management
 }
 
 // Open implements fs.FS
+// Downloads the file to a local temp file first to avoid network timeout during upload
 func (s *synologyFS) Open(name string) (fs.File, error) {
 	if name != s.filename {
 		return nil, fmt.Errorf("file not found: %s", name)
 	}
 
 	ctx := context.Background()
+
+	// Create temp file
+	tempFile, err := os.CreateTemp("", "synology-*-"+filepath.Base(s.filename))
+	if err != nil {
+		return nil, fmt.Errorf("create temp file: %w", err)
+	}
+
+	// Download to temp file
 	reader, err := s.client.DownloadItem(ctx, s.itemID, s.cacheKey)
 	if err != nil {
+		tempFile.Close()
+		os.Remove(tempFile.Name())
 		return nil, err
 	}
 
+	_, err = io.Copy(tempFile, reader)
+	reader.Close()
+
+	if err != nil {
+		tempFile.Close()
+		os.Remove(tempFile.Name())
+		return nil, fmt.Errorf("download to temp: %w", err)
+	}
+
+	// Seek to beginning for reading
+	_, err = tempFile.Seek(0, 0)
+	if err != nil {
+		tempFile.Close()
+		os.Remove(tempFile.Name())
+		return nil, fmt.Errorf("seek temp file: %w", err)
+	}
+
 	return &synologyFile{
-		ReadCloser: reader,
-		name:       s.filename,
-		size:       int64(s.size),
+		File:   tempFile,
+		name:   s.filename,
+		size:   int64(s.size),
+		tempPath: tempFile.Name(),
 	}, nil
 }
 
 // synologyFile implements fs.File
 type synologyFile struct {
-	io.ReadCloser
-	name string
-	size int64
-	offset int64
+	*os.File
+	name     string
+	size     int64
+	tempPath string
 }
 
 func (f *synologyFile) Stat() (fs.FileInfo, error) {
@@ -501,14 +533,11 @@ func (f *synologyFile) Stat() (fs.FileInfo, error) {
 	}, nil
 }
 
-func (f *synologyFile) Read(p []byte) (n int, err error) {
-	n, err = f.ReadCloser.Read(p)
-	f.offset += int64(n)
-	return n, err
-}
-
 func (f *synologyFile) Close() error {
-	return f.ReadCloser.Close()
+	// Close the file and remove temp file
+	err := f.File.Close()
+	os.Remove(f.tempPath)
+	return err
 }
 
 // synologyFileInfo implements fs.FileInfo

--- a/adapters/synology/synology.go
+++ b/adapters/synology/synology.go
@@ -500,12 +500,10 @@ func (sa *Adapter) mapToAssetForLiveImage(item *Item, album *Album, liveFS *syno
 	}
 
 	// Store original metadata
+	// Don't set DateTaken, Latitude, Longitude - let Immich read from EXIF
 	imageAsset.FromApplication = &assets.Metadata{
 		FileName:    item.Filename,
-		DateTaken:   item.CaptureTime(),
 		Description: item.Additional.Description,
-		Latitude:    item.Additional.GPS.Latitude,
-		Longitude:   item.Additional.GPS.Longitude,
 	}
 
 	// Copy tags to metadata
@@ -543,12 +541,10 @@ func (sa *Adapter) mapToAssetForLiveVideo(item *Item, album *Album, liveFS *syno
 	}
 
 	// Store original metadata
+	// Don't set DateTaken, Latitude, Longitude - let Immich read from EXIF
 	videoAsset.FromApplication = &assets.Metadata{
 		FileName:    videoFilename,
-		DateTaken:   item.CaptureTime(),
 		Description: item.Additional.Description,
-		Latitude:    item.Additional.GPS.Latitude,
-		Longitude:   item.Additional.GPS.Longitude,
 	}
 
 	return videoAsset
@@ -624,12 +620,10 @@ func (sa *Adapter) mapToAsset(item *Item, album *Album) *assets.Asset {
 	}
 
 	// Store original metadata
+	// Don't set DateTaken, Latitude, Longitude - let Immich read from EXIF
 	asset.FromApplication = &assets.Metadata{
 		FileName:    item.Filename,
-		DateTaken:   item.CaptureTime(),
 		Description: item.Additional.Description,
-		Latitude:    item.Additional.GPS.Latitude,
-		Longitude:   item.Additional.GPS.Longitude,
 	}
 
 	// Copy tags to metadata

--- a/adapters/synology/synology.go
+++ b/adapters/synology/synology.go
@@ -298,6 +298,7 @@ func (sa *Adapter) getAdditionalFields() []string {
 }
 
 // processItem processes a single item and sends it to the output channel
+// For live photos, this creates both the image and video assets
 func (sa *Adapter) processItem(ctx context.Context, item *Item, album *Album, gOut chan *assets.Group) error {
 	// Check tag filter
 	if len(sa.Tags) > 0 && !sa.matchesTagFilter(item) {
@@ -309,6 +310,51 @@ func (sa *Adapter) processItem(ctx context.Context, item *Item, album *Album, gO
 		return nil
 	}
 
+	// For live photos, we need to create two assets: image and video
+	if item.IsLivePhoto() {
+		return sa.processLivePhoto(ctx, item, album, gOut)
+	}
+
+	// Regular single asset
+	return sa.processSingleItem(ctx, item, album, gOut)
+}
+
+// processLivePhoto handles live photos by creating both image and video assets
+func (sa *Adapter) processLivePhoto(ctx context.Context, item *Item, album *Album, gOut chan *assets.Group) error {
+	// Live photos have two files with the same basename:
+	// - Image: e.g., IMG_9948.HEIC
+	// - Video: e.g., IMG_9948.MOV
+
+	// Process the image part first
+	imageAsset := sa.mapToAsset(item, album)
+
+	// Send image
+	sa.processor.RecordAssetDiscovered(ctx, imageAsset.File, int64(imageAsset.FileSize), fileevent.DiscoveredImage)
+	group := assets.NewGroup(assets.GroupByNone, imageAsset)
+	select {
+	case gOut <- group:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	// Infer video filename from image filename
+	// SYNO.Foto.Download API should handle this based on item ID
+	videoAsset := sa.mapToAssetForLiveVideo(item, album)
+	if videoAsset != nil {
+		sa.processor.RecordAssetDiscovered(ctx, videoAsset.File, int64(videoAsset.FileSize), fileevent.DiscoveredVideo)
+		group := assets.NewGroup(assets.GroupByNone, videoAsset)
+		select {
+		case gOut <- group:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	return nil
+}
+
+// processSingleItem processes a regular (non-live) photo or video
+func (sa *Adapter) processSingleItem(ctx context.Context, item *Item, album *Album, gOut chan *assets.Group) error {
 	// Map to asset
 	asset := sa.mapToAsset(item, album)
 
@@ -368,6 +414,66 @@ func (sa *Adapter) matchesPeopleFilter(item *Item) bool {
 	}
 
 	return false
+}
+
+// mapToAssetForLiveVideo creates an Asset for the video part of a live photo
+// For live photos, we create a separate video Asset with the inferred video filename
+func (sa *Adapter) mapToAssetForLiveVideo(item *Item, album *Album) *assets.Asset {
+	videoFilename := item.LivePhotoVideoFilename()
+	if videoFilename == "" {
+		return nil
+	}
+
+	// For the video part, use thumbnail's unit_id if different from main item
+	// This handles cases where photo and video have different IDs
+	videoItemID := item.ID
+	videoCacheKey := item.Additional.Thumbnail.CacheKey
+	if item.Additional.Thumbnail.UnitID > 0 && item.Additional.Thumbnail.UnitID != item.ID {
+		videoItemID = item.Additional.Thumbnail.UnitID
+	}
+
+	// Create a custom FS for the video file
+	synFS := &synologyFS{
+		client:   sa.client,
+		itemID:   videoItemID,
+		cacheKey: videoCacheKey,
+		filename: videoFilename,
+		size:     int(item.Filesize), // Approximate, may not be accurate for video
+	}
+
+	videoAsset := &assets.Asset{
+		File:             fshelper.FSName(synFS, videoFilename),
+		FileSize:         int(item.Filesize), // May need adjustment
+		OriginalFileName: videoFilename,
+		FileDate:         item.IndexedAt(),
+		CaptureDate:      item.CaptureTime(),
+		Description:      item.Additional.Description,
+		Latitude:         item.Additional.GPS.Latitude,
+		Longitude:        item.Additional.GPS.Longitude,
+	}
+
+	// Add album if specified
+	if album != nil {
+		albumName := strings.TrimSpace(album.Name)
+		if albumName != "" {
+			videoAsset.Albums = []assets.Album{
+				{
+					Title: albumName,
+				},
+			}
+		}
+	}
+
+	// Store original metadata
+	videoAsset.FromApplication = &assets.Metadata{
+		FileName:    videoFilename,
+		DateTaken:   item.CaptureTime(),
+		Description: item.Additional.Description,
+		Latitude:    item.Additional.GPS.Latitude,
+		Longitude:   item.Additional.GPS.Longitude,
+	}
+
+	return videoAsset
 }
 
 // mapToAsset converts a Synology Item to an immich-go Asset

--- a/adapters/synology/synology.go
+++ b/adapters/synology/synology.go
@@ -54,7 +54,10 @@ func NewAdapter(app *app.Application, serverURL, account, password string) *Adap
 
 // Open initializes the connection to Synology Photos
 func (sa *Adapter) Open(ctx context.Context) error {
-	client, err := NewClient(sa.ServerURL, sa.Account, sa.Password, WithInsecureSkipVerify(true))
+	client, err := NewClient(sa.ServerURL, sa.Account, sa.Password,
+		WithInsecureSkipVerify(true),
+		WithLogger(sa.app.Log().Logger),
+	)
 	if err != nil {
 		return fmt.Errorf("create client: %w", err)
 	}
@@ -162,14 +165,19 @@ func (sa *Adapter) buildCaches(ctx context.Context) error {
 }
 
 // getAlbumsToProcess returns the list of albums to import
+// Note: SYNO.Foto.Browse.Album may not be available in some DSM versions
 func (sa *Adapter) getAlbumsToProcess(ctx context.Context) ([]Album, error) {
-	// Get all albums
+	// Try to get albums, but if API doesn't exist, return empty list
+	// Photos will be imported without album structure
 	allAlbums := make([]Album, 0)
+
 	offset := 0
 	for {
 		albums, err := sa.client.ListAlbums(ctx, offset, 1000)
 		if err != nil {
-			return nil, fmt.Errorf("list albums: %w", err)
+			// If album API is not available, just log warning and return empty
+			sa.app.Log().Warn("Album API not available, importing without album structure", "error", err)
+			return nil, nil
 		}
 		allAlbums = append(allAlbums, albums...)
 		if len(albums) < 1000 {
@@ -201,6 +209,12 @@ func (sa *Adapter) getAlbumsToProcess(ctx context.Context) ([]Album, error) {
 
 // processAlbum processes items from a specific album
 func (sa *Adapter) processAlbum(ctx context.Context, album Album, gOut chan *assets.Group) error {
+	// Clean up album name (trim whitespace)
+	album.Name = strings.TrimSpace(album.Name)
+	if album.Name == "" {
+		sa.app.Log().Warn("Skipping album with empty name", "id", album.ID)
+		return nil
+	}
 	sa.app.Log().Info("Processing album", "name", album.Name, "item_count", album.ItemCount)
 
 	additional := sa.getAdditionalFields()
@@ -388,28 +402,36 @@ func (sa *Adapter) mapToAsset(item *Item, album *Album) *assets.Asset {
 		Longitude:        item.Additional.GPS.Longitude,
 	}
 
-	// Add album if specified
+	// Add album if specified (with cleaned up name)
 	if album != nil {
-		asset.Albums = []assets.Album{
-			{
-				Title: album.Name,
-			},
+		albumName := strings.TrimSpace(album.Name)
+		if albumName != "" {
+			asset.Albums = []assets.Album{
+				{
+					Title: albumName,
+				},
+			}
 		}
 	}
 
-	// Add tags
+	// Add tags (skip empty names)
 	for _, tag := range item.Additional.Tag {
-		asset.Tags = append(asset.Tags, assets.Tag{
-			Name: tag.Name,
-		})
+		if tag.Name != "" {
+			asset.Tags = append(asset.Tags, assets.Tag{
+				Name: tag.Name,
+			})
+		}
 	}
 
 	// Add people as tags (prefixed with "Person: ") since Immich handles faces separately
+	// Skip empty person names
 	if !sa.SkipFaceData {
 		for _, person := range item.Additional.Person {
-			asset.Tags = append(asset.Tags, assets.Tag{
-				Name: fmt.Sprintf("Person: %s", person.Name),
-			})
+			if person.Name != "" {
+				asset.Tags = append(asset.Tags, assets.Tag{
+					Name: fmt.Sprintf("Person: %s", person.Name),
+				})
+			}
 		}
 	}
 

--- a/adapters/synology/synology.go
+++ b/adapters/synology/synology.go
@@ -329,10 +329,11 @@ func (sa *Adapter) processItem(ctx context.Context, item *Item, album *Album, gO
 
 // processLivePhoto handles live photos by creating both image and video assets
 // Uses Synology's ZIP download API with proper synchronization
+// Note: Synology may return either a ZIP (with both image and video) or just the image file
 func (sa *Adapter) processLivePhoto(ctx context.Context, item *Item, album *Album, gOut chan *assets.Group) error {
 	sa.app.Log().Debug("Processing live photo", "filename", item.Filename, "item_id", item.ID)
 
-	// Create a shared FS for the live photo ZIP bundle
+	// Create a shared FS for the live photo bundle
 	// The FS uses mutex to prevent concurrent downloads
 	liveFS := &synologyLivePhotoFS{
 		client:   sa.client,
@@ -342,6 +343,7 @@ func (sa *Adapter) processLivePhoto(ctx context.Context, item *Item, album *Albu
 	}
 
 	// Step 1: Process the image part (HEIC/JPG)
+	// This triggers the download and determines if we have a ZIP (with video) or single file
 	imageAsset := sa.mapToAssetForLiveImage(item, album, liveFS)
 	if imageAsset != nil {
 		sa.processor.RecordAssetDiscovered(ctx, imageAsset.File, int64(imageAsset.FileSize), fileevent.DiscoveredImage)
@@ -354,9 +356,10 @@ func (sa *Adapter) processLivePhoto(ctx context.Context, item *Item, album *Albu
 		}
 	}
 
-	// Step 2: Process the video part (MOV)
+	// Step 2: Process the video part (MOV) only if we got a ZIP response
+	// Non-ZIP responses only contain the image, no video
 	videoFilename := item.LivePhotoVideoFilename()
-	if videoFilename != "" {
+	if videoFilename != "" && liveFS.hasVideo() {
 		videoAsset := sa.mapToAssetForLiveVideo(item, album, liveFS, videoFilename)
 		if videoAsset != nil {
 			sa.processor.RecordAssetDiscovered(ctx, videoAsset.File, int64(videoAsset.FileSize), fileevent.DiscoveredVideo)
@@ -368,6 +371,8 @@ func (sa *Adapter) processLivePhoto(ctx context.Context, item *Item, album *Albu
 				return ctx.Err()
 			}
 		}
+	} else if videoFilename != "" {
+		sa.app.Log().Debug("Live photo has no video file (single file response)", "filename", item.Filename)
 	} else {
 		sa.app.Log().Warn("Live photo has no video filename", "filename", item.Filename)
 	}
@@ -954,6 +959,14 @@ func (s *synologyLivePhotoFS) handleSingleFileDownload(reader io.ReadCloser, tem
 	}
 
 	return nil
+}
+
+// hasVideo returns true if the live photo contains a video file
+// This is true for ZIP responses, false for single file responses
+func (s *synologyLivePhotoFS) hasVideo() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.isZip
 }
 
 // cleanup removes the temp directory and all extracted files

--- a/adapters/synology/synology.go
+++ b/adapters/synology/synology.go
@@ -518,6 +518,9 @@ func (sa *Adapter) mapToAssetForLive(item *Item, actuleFilePath string) (*assets
 			return nil
 		}
 		dir := filepath.Dir(actuleFilePath)
+		if _, err := os.Stat(dir); os.IsNotExist(err) {
+			return nil
+		}
 		if files, err := os.ReadDir(dir); err != nil {
 			sa.app.Log().Error("Error reading dir", "dir", dir, "err", err)
 		} else if len(files) == 0 {

--- a/adapters/synology/synology.go
+++ b/adapters/synology/synology.go
@@ -198,6 +198,7 @@ func (sa *Adapter) getAlbumsToProcess(ctx context.Context) ([]Album, error) {
 
 	// Cache albums by name
 	for _, album := range allAlbums {
+		sa.app.Log().Debug("Caching album", "name", album.Name, "id", album.ID)
 		sa.albumCache[album.Name] = album
 	}
 
@@ -273,6 +274,7 @@ func (sa *Adapter) processAllItems(ctx context.Context, gOut chan *assets.Group)
 		}
 
 		if len(items) < limit {
+			sa.app.Log().Info("All items processed")
 			break
 		}
 		offset += limit

--- a/adapters/synology/synology.go
+++ b/adapters/synology/synology.go
@@ -739,8 +739,9 @@ func (fi *synologyFileInfo) ModTime() time.Time { return time.Now() }
 func (fi *synologyFileInfo) IsDir() bool        { return false }
 func (fi *synologyFileInfo) Sys() interface{}   { return nil }
 
-// synologyLivePhotoFS implements fs.FS for live photos (ZIP bundle)
-// Downloads a ZIP containing both HEIC and MOV files, extracts on demand
+// synologyLivePhotoFS implements fs.FS for live photos
+// Downloads either a ZIP (containing both HEIC and MOV) or just the image file
+// Synology's API may return either format based on how the live photo is stored
 type synologyLivePhotoFS struct {
 	client       *Client
 	itemID       int
@@ -749,13 +750,15 @@ type synologyLivePhotoFS struct {
 	tempDir      string
 	logger       *slog.Logger
 	downloaded   bool
-	mu           sync.Mutex // protects download operation
-	refCount     int        // number of open files using this FS
+	isZip        bool              // whether the download was a ZIP
+	mu           sync.Mutex        // protects download operation
+	refCount     int               // number of open files using this FS
 }
 
-// Open implements fs.FS - downloads ZIP on first call, returns requested file
+// Open implements fs.FS - downloads on first call, returns requested file
+// Handles both ZIP (containing both image and video) and single file responses
 func (s *synologyLivePhotoFS) Open(name string) (fs.File, error) {
-	// Only allow opening the main file (HEIC) or its corresponding video (MOV)
+	// Only allow opening the main file (HEIC/JPG) or its corresponding video (MOV)
 	expectedVideo := s.filename[:len(s.filename)-len(filepath.Ext(s.filename))] + ".mov"
 	if name != s.filename && strings.ToLower(name) != strings.ToLower(expectedVideo) {
 		return nil, fmt.Errorf("file not found: %s", name)
@@ -767,10 +770,10 @@ func (s *synologyLivePhotoFS) Open(name string) (fs.File, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Download and extract ZIP on first access
+	// Download on first access
 	if !s.downloaded {
 		if s.logger != nil {
-			s.logger.Debug("Downloading live photo ZIP", "filename", s.filename, "item_id", s.itemID)
+			s.logger.Debug("Downloading live photo", "filename", s.filename, "item_id", s.itemID)
 		}
 
 		// Create temp directory
@@ -780,106 +783,41 @@ func (s *synologyLivePhotoFS) Open(name string) (fs.File, error) {
 		}
 		s.tempDir = tempDir
 
-		// Download ZIP
-		reader, contentType, err := s.client.DownloadLivePhotoZip(ctx, s.itemID, s.filename, s.logger)
+		// Download - may return ZIP or single file
+		reader, contentType, isZip, err := s.client.DownloadLivePhoto(ctx, s.itemID, s.filename, s.logger)
 		if err != nil {
 			os.RemoveAll(s.tempDir)
 			s.tempDir = ""
-			return nil, fmt.Errorf("download live photo ZIP: %w", err)
+			return nil, fmt.Errorf("download live photo: %w", err)
 		}
+
+		s.isZip = isZip
 
 		if s.logger != nil {
-			s.logger.Debug("Downloaded live photo", "filename", s.filename, "content_type", contentType, "item_id", s.itemID)
+			s.logger.Debug("Downloaded live photo", "filename", s.filename, "content_type", contentType,
+				"is_zip", isZip, "item_id", s.itemID)
 		}
 
-		// Save ZIP to temp file
-		zipPath := filepath.Join(tempDir, "livephoto.zip")
-		zipFile, err := os.Create(zipPath)
-		if err != nil {
-			reader.Close()
-			os.RemoveAll(s.tempDir)
-			s.tempDir = ""
-			return nil, fmt.Errorf("create zip temp file: %w", err)
+		if isZip {
+			// Handle ZIP download (contains both image and video)
+			if err := s.handleZipDownload(reader, tempDir); err != nil {
+				reader.Close()
+				os.RemoveAll(s.tempDir)
+				s.tempDir = ""
+				return nil, err
+			}
+		} else {
+			// Handle single file download (just the image)
+			if err := s.handleSingleFileDownload(reader, tempDir, name); err != nil {
+				reader.Close()
+				os.RemoveAll(s.tempDir)
+				s.tempDir = ""
+				return nil, err
+			}
 		}
-
-		written, err := io.Copy(zipFile, reader)
 		reader.Close()
-		zipFile.Close()
-
-		if s.logger != nil {
-			s.logger.Debug("Downloaded ZIP to temp file", "filename", s.filename, "bytes", written)
-		}
-
-		if err != nil {
-			os.RemoveAll(s.tempDir)
-			s.tempDir = ""
-			return nil, fmt.Errorf("save zip: %w", err)
-		}
-
-		// Verify ZIP by checking file header (magic number)
-		if err := verifyZipFile(zipPath); err != nil {
-			// Print debug curl command for manual troubleshooting
-			s.printDebugCurlCommand()
-			os.RemoveAll(s.tempDir)
-			s.tempDir = ""
-			return nil, fmt.Errorf("verify zip: %w", err)
-		}
-
-		// Extract ZIP
-		zipReader, err := zip.OpenReader(zipPath)
-		if err != nil {
-			os.RemoveAll(s.tempDir)
-			s.tempDir = ""
-			return nil, fmt.Errorf("open zip: %w", err)
-		}
-
-		s.zipFiles = make(map[string]string)
-		for _, zf := range zipReader.File {
-			// Extract each file
-			extractPath := filepath.Join(tempDir, filepath.Base(zf.Name))
-			rc, err := zf.Open()
-			if err != nil {
-				zipReader.Close()
-				os.RemoveAll(s.tempDir)
-				s.tempDir = ""
-				return nil, fmt.Errorf("extract %s: %w", zf.Name, err)
-			}
-
-			extractFile, err := os.Create(extractPath)
-			if err != nil {
-				rc.Close()
-				zipReader.Close()
-				os.RemoveAll(s.tempDir)
-				s.tempDir = ""
-				return nil, fmt.Errorf("create extract file: %w", err)
-			}
-
-			_, err = io.Copy(extractFile, rc)
-			rc.Close()
-			extractFile.Close()
-
-			if err != nil {
-				zipReader.Close()
-				os.RemoveAll(s.tempDir)
-				s.tempDir = ""
-				return nil, fmt.Errorf("extract %s: %w", zf.Name, err)
-			}
-
-			s.zipFiles[filepath.Base(zf.Name)] = extractPath
-			if s.logger != nil {
-				s.logger.Debug("Extracted live photo file", "name", zf.Name, "size", zf.UncompressedSize64)
-			}
-		}
-		zipReader.Close()
-
-		// Clean up ZIP file
-		os.Remove(zipPath)
 
 		s.downloaded = true
-
-		if s.logger != nil {
-			s.logger.Debug("Live photo ZIP downloaded and extracted", "files", len(s.zipFiles))
-		}
 	}
 
 	// Return the requested file
@@ -899,7 +837,7 @@ func (s *synologyLivePhotoFS) Open(name string) (fs.File, error) {
 			}
 
 			s.refCount++
-		return &synologyLivePhotoFile{
+			return &synologyLivePhotoFile{
 				File:     f,
 				name:     fname,
 				size:     info.Size(),
@@ -910,6 +848,112 @@ func (s *synologyLivePhotoFS) Open(name string) (fs.File, error) {
 	}
 
 	return nil, fmt.Errorf("file not found in live photo: %s", name)
+}
+
+// handleZipDownload processes a ZIP response containing both image and video
+func (s *synologyLivePhotoFS) handleZipDownload(reader io.ReadCloser, tempDir string) error {
+	// Save ZIP to temp file
+	zipPath := filepath.Join(tempDir, "livephoto.zip")
+	zipFile, err := os.Create(zipPath)
+	if err != nil {
+		return fmt.Errorf("create zip temp file: %w", err)
+	}
+
+	written, err := io.Copy(zipFile, reader)
+	zipFile.Close()
+
+	if s.logger != nil {
+		s.logger.Debug("Downloaded ZIP to temp file", "filename", s.filename, "bytes", written)
+	}
+
+	if err != nil {
+		return fmt.Errorf("save zip: %w", err)
+	}
+
+	// Verify ZIP by checking file header (magic number)
+	if err := verifyZipFile(zipPath); err != nil {
+		s.printDebugCurlCommand()
+		return fmt.Errorf("verify zip: %w", err)
+	}
+
+	// Extract ZIP
+	zipReader, err := zip.OpenReader(zipPath)
+	if err != nil {
+		return fmt.Errorf("open zip: %w", err)
+	}
+	defer zipReader.Close()
+
+	s.zipFiles = make(map[string]string)
+	for _, zf := range zipReader.File {
+		// Extract each file
+		extractPath := filepath.Join(tempDir, filepath.Base(zf.Name))
+		rc, err := zf.Open()
+		if err != nil {
+			return fmt.Errorf("extract %s: %w", zf.Name, err)
+		}
+
+		extractFile, err := os.Create(extractPath)
+		if err != nil {
+			rc.Close()
+			return fmt.Errorf("create extract file: %w", err)
+		}
+
+		_, err = io.Copy(extractFile, rc)
+		rc.Close()
+		extractFile.Close()
+
+		if err != nil {
+			return fmt.Errorf("extract %s: %w", zf.Name, err)
+		}
+
+		s.zipFiles[filepath.Base(zf.Name)] = extractPath
+		if s.logger != nil {
+			s.logger.Debug("Extracted live photo file", "name", zf.Name, "size", zf.UncompressedSize64)
+		}
+	}
+
+	// Clean up ZIP file
+	os.Remove(zipPath)
+
+	if s.logger != nil {
+		s.logger.Debug("Live photo ZIP extracted", "files", len(s.zipFiles))
+	}
+
+	return nil
+}
+
+// handleSingleFileDownload processes a single file response (just the image)
+// For non-ZIP responses, we only get the image file. The video may need separate handling.
+func (s *synologyLivePhotoFS) handleSingleFileDownload(reader io.ReadCloser, tempDir string, requestedName string) error {
+	// Save the single file
+	filePath := filepath.Join(tempDir, s.filename)
+	outFile, err := os.Create(filePath)
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+
+	written, err := io.Copy(outFile, reader)
+	outFile.Close()
+
+	if s.logger != nil {
+		s.logger.Debug("Downloaded single file", "filename", s.filename, "bytes", written)
+	}
+
+	if err != nil {
+		return fmt.Errorf("save file: %w", err)
+	}
+
+	s.zipFiles = make(map[string]string)
+	s.zipFiles[s.filename] = filePath
+
+	// Note: For non-ZIP responses, we don't have the video file.
+	// This is a limitation - Synology's API doesn't provide the video separately
+	// in this case. The live photo will be uploaded as a static image.
+	if s.logger != nil {
+		s.logger.Debug("Live photo returned as single file (no video)", "filename", s.filename)
+	}
+
+	return nil
 }
 
 // cleanup removes the temp directory and all extracted files

--- a/adapters/synology/synology.go
+++ b/adapters/synology/synology.go
@@ -106,7 +106,10 @@ func (sa *Adapter) Browse(ctx context.Context) chan *assets.Group {
 		}
 
 		// Process albums or all items
-		if len(albumsToProcess) > 0 {
+		// If user specified specific albums, process only those
+		// Otherwise process ALL items (including those not in any album)
+		if len(sa.Albums) > 0 && len(albumsToProcess) > 0 {
+			// User requested specific albums, process only items in those albums
 			for _, album := range albumsToProcess {
 				if err := sa.processAlbum(ctx, album, gOut); err != nil {
 					sa.app.Log().Error("Failed to process album", "album", album.Name, "error", err)
@@ -114,7 +117,8 @@ func (sa *Adapter) Browse(ctx context.Context) chan *assets.Group {
 				}
 			}
 		} else {
-			// Process all items (not album-based)
+			// No specific albums requested - process ALL items
+			// This includes both album items and non-album items
 			if err := sa.processAllItems(ctx, gOut); err != nil {
 				sa.app.Log().Error("Failed to process items", "error", err)
 				return

--- a/adapters/synology/synology.go
+++ b/adapters/synology/synology.go
@@ -26,22 +26,22 @@ import (
 // Adapter implements the adapters.Reader interface for Synology Photos
 type Adapter struct {
 	// Configuration
-	ServerURL      string
-	Account        string
-	Password       string
-	IncludeShared  bool
-	Albums         []string // Filter: import only these albums
-	Tags           []string // Filter: import only items with these tags
-	People         []string // Filter: import only items with these people
-	SkipFaceData   bool     // Skip face recognition data
+	ServerURL     string
+	Account       string
+	Password      string
+	IncludeShared bool
+	Albums        []string // Filter: import only these albums
+	Tags          []string // Filter: import only items with these tags
+	People        []string // Filter: import only items with these people
+	SkipFaceData  bool     // Skip face recognition data
 
 	// Internal
-	client     *Client
-	app        *app.Application
-	processor  *fileprocessor.FileProcessor
-	albumCache map[string]Album // album name -> album
-	tagCache   map[string]int   // tag name -> tag id
-	peopleCache map[string]int  // person name -> person id
+	client      *Client
+	app         *app.Application
+	processor   *fileprocessor.FileProcessor
+	albumCache  map[string]Album // album name -> album
+	tagCache    map[string]int   // tag name -> tag id
+	peopleCache map[string]int   // person name -> person id
 }
 
 // NewAdapter creates a new Synology Photos adapter
@@ -696,9 +696,9 @@ func (s *synologyFS) Open(name string) (fs.File, error) {
 	}
 
 	return &synologyFile{
-		File:   tempFile,
-		name:   s.filename,
-		size:   int64(s.size),
+		File:     tempFile,
+		name:     s.filename,
+		size:     int64(s.size),
 		tempPath: tempFile.Name(),
 	}, nil
 }
@@ -768,16 +768,16 @@ func (fi *synologyFileInfo) Sys() interface{}   { return nil }
 // Downloads either a ZIP (containing both HEIC and MOV) or just the image file
 // Synology's API may return either format based on how the live photo is stored
 type synologyLivePhotoFS struct {
-	client       *Client
-	itemID       int
-	filename     string            // e.g., "IMG_9948.HEIC"
-	zipFiles     map[string]string // filename -> temp path
-	tempDir      string
-	logger       *slog.Logger
-	downloaded   bool
-	isZip        bool              // whether the download was a ZIP
-	mu           sync.Mutex        // protects download operation
-	refCount     int               // number of open files using this FS
+	client     *Client
+	itemID     int
+	filename   string            // e.g., "IMG_9948.HEIC"
+	zipFiles   map[string]string // filename -> temp path
+	tempDir    string
+	logger     *slog.Logger
+	downloaded bool
+	isZip      bool       // whether the download was a ZIP
+	mu         sync.Mutex // protects download operation
+	refCount   int        // number of open files using this FS
 }
 
 // Open implements fs.FS - downloads on first call, returns requested file

--- a/adapters/synology/synology.go
+++ b/adapters/synology/synology.go
@@ -816,7 +816,39 @@ func (s *synologyLivePhotoFS) Open(name string) (fs.File, error) {
 		}
 	}
 
-	return nil, fmt.Errorf("file not found in live photo: %s", name)
+	// If looking for video but exact name not found, try to find any video file
+	// Synology sometimes has mismatched filenames (e.g., IMG_4009.MOV vs IMG_4009_1.HEIC)
+	if strings.HasSuffix(lowerName, ".mov") {
+		for fname, fpath := range s.zipFiles {
+			lowerFname := strings.ToLower(fname)
+			if strings.HasSuffix(lowerFname, ".mov") || strings.HasSuffix(lowerFname, ".mp4") {
+				if s.logger != nil {
+					s.logger.Debug("Using alternative video file", "requested", name, "found", fname)
+				}
+				f, err := os.Open(fpath)
+				if err != nil {
+					return nil, err
+				}
+
+				info, err := f.Stat()
+				if err != nil {
+					f.Close()
+					return nil, err
+				}
+
+				s.refCount++
+				return &synologyLivePhotoFile{
+					File:     f,
+					name:     fname, // Return actual filename, not requested name
+					size:     info.Size(),
+					tempPath: fpath,
+					fs:       s,
+				}, nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("file not found in live photo: %s (available: %v)", name, s.getAvailableFiles())
 }
 
 // handleZipDownload processes a ZIP response containing both image and video
@@ -931,6 +963,15 @@ func (s *synologyLivePhotoFS) hasVideo() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.isZip
+}
+
+// getAvailableFiles returns a list of available files (for debugging)
+func (s *synologyLivePhotoFS) getAvailableFiles() []string {
+	files := make([]string, 0, len(s.zipFiles))
+	for fname := range s.zipFiles {
+		files = append(files, fname)
+	}
+	return files
 }
 
 // preDownload downloads the live photo ahead of time to determine the response type

--- a/adapters/synology/synology.go
+++ b/adapters/synology/synology.go
@@ -720,6 +720,7 @@ type synologyFile struct {
 	name     string
 	size     int64
 	tempPath string
+	closed   bool
 }
 
 func (f *synologyFile) Stat() (fs.FileInfo, error) {
@@ -730,6 +731,10 @@ func (f *synologyFile) Stat() (fs.FileInfo, error) {
 }
 
 func (f *synologyFile) Close() error {
+	if f.closed {
+		return nil
+	}
+	f.closed = true
 	// Close the file and remove temp file
 	err := f.File.Close()
 	os.Remove(f.tempPath)
@@ -1137,6 +1142,7 @@ type synologyLivePhotoFile struct {
 	size     int64
 	tempPath string
 	fs       *synologyLivePhotoFS
+	closed   bool
 }
 
 func (f *synologyLivePhotoFile) Stat() (fs.FileInfo, error) {
@@ -1147,6 +1153,10 @@ func (f *synologyLivePhotoFile) Stat() (fs.FileInfo, error) {
 }
 
 func (f *synologyLivePhotoFile) Close() error {
+	if f.closed {
+		return nil
+	}
+	f.closed = true
 	err := f.File.Close()
 	// Decrement ref count and cleanup when zero
 	if f.fs != nil {

--- a/adapters/synology/synology.go
+++ b/adapters/synology/synology.go
@@ -409,8 +409,12 @@ func (sa *Adapter) matchesTagFilter(item *Item) bool {
 	return false
 }
 
-// matchesAlbumFilter checks if the item belongs to any of the requested albums
+// matchesAlbumFilter checks if the item belongs to any of the requested albums.
+// Returns true when no album filter is active.
 func (sa *Adapter) matchesAlbumFilter(item *Item) bool {
+	if len(sa.Albums) == 0 {
+		return true
+	}
 	for _, images := range sa.albumImageCache {
 		if images.Contains(item.ID) {
 			return true

--- a/adapters/synology/synology.go
+++ b/adapters/synology/synology.go
@@ -330,38 +330,30 @@ func (sa *Adapter) processItem(ctx context.Context, item *Item, album *Album, gO
 func (sa *Adapter) processLivePhoto(ctx context.Context, item *Item, album *Album, gOut chan *assets.Group) error {
 	sa.app.Log().Debug("Processing live photo", "filename", item.Filename, "item_id", item.ID)
 
-	// Create a shared FS for the live photo ZIP bundle
-	liveFS := &synologyLivePhotoFS{
-		client:   sa.client,
-		itemID:   item.ID,
-		filename: item.Filename,
-		logger:   sa.app.Log().Logger,
-	}
-
 	// Step 1: Process the image part (HEIC/JPG)
-	imageAsset := sa.mapToAssetForLiveImage(item, album, liveFS)
+	// Each asset has its own FS instance to avoid lifecycle issues with shared temp directories
+	imageAsset := sa.mapToAssetForLiveImage(item, album)
 	if imageAsset != nil {
 		sa.processor.RecordAssetDiscovered(ctx, imageAsset.File, int64(imageAsset.FileSize), fileevent.DiscoveredImage)
 		group := assets.NewGroup(assets.GroupByNone, imageAsset)
 		select {
 		case gOut <- group:
 		case <-ctx.Done():
-			liveFS.cleanup()
 			return ctx.Err()
 		}
 	}
 
 	// Step 2: Process the video part (MOV)
+	// Each asset has its own FS instance - ZIP will be downloaded again but avoids cleanup races
 	videoFilename := item.LivePhotoVideoFilename()
 	if videoFilename != "" {
-		videoAsset := sa.mapToAssetForLiveVideo(item, album, liveFS, videoFilename)
+		videoAsset := sa.mapToAssetForLiveVideo(item, album, videoFilename)
 		if videoAsset != nil {
 			sa.processor.RecordAssetDiscovered(ctx, videoAsset.File, int64(videoAsset.FileSize), fileevent.DiscoveredVideo)
 			group := assets.NewGroup(assets.GroupByNone, videoAsset)
 			select {
 			case gOut <- group:
 			case <-ctx.Done():
-				liveFS.cleanup()
 				return ctx.Err()
 			}
 		}
@@ -439,12 +431,18 @@ func (sa *Adapter) matchesPeopleFilter(item *Item) bool {
 }
 
 // mapToAssetForLiveImage creates an Asset for the image part of a live photo
-// Uses the shared liveFS which downloads and extracts the ZIP bundle
-func (sa *Adapter) mapToAssetForLiveImage(item *Item, album *Album, liveFS *synologyLivePhotoFS) *assets.Asset {
+// Each live photo asset gets its own FS instance to avoid lifecycle issues
+func (sa *Adapter) mapToAssetForLiveImage(item *Item, album *Album) *assets.Asset {
 	sa.app.Log().Debug("Creating live photo image asset", "filename", item.Filename, "item_id", item.ID)
 
-	// Use the shared live photo FS (ZIP bundle)
-	// FileSize will be determined when the file is opened
+	// Create a dedicated FS for this image asset
+	liveFS := &synologyLivePhotoFS{
+		client:   sa.client,
+		itemID:   item.ID,
+		filename: item.Filename,
+		logger:   sa.app.Log().Logger,
+	}
+
 	imageAsset := &assets.Asset{
 		File:             fshelper.FSName(liveFS, item.Filename),
 		FileSize:         int(item.Filesize), // Approximate size from API
@@ -509,12 +507,19 @@ func (sa *Adapter) mapToAssetForLiveImage(item *Item, album *Album, liveFS *syno
 }
 
 // mapToAssetForLiveVideo creates an Asset for the video part of a live photo
-// Uses the shared liveFS which contains both HEIC and MOV from the ZIP bundle
-func (sa *Adapter) mapToAssetForLiveVideo(item *Item, album *Album, liveFS *synologyLivePhotoFS, videoFilename string) *assets.Asset {
+// Each live photo asset gets its own FS instance to avoid lifecycle issues
+func (sa *Adapter) mapToAssetForLiveVideo(item *Item, album *Album, videoFilename string) *assets.Asset {
 	sa.app.Log().Debug("Creating live photo video asset", "filename", videoFilename, "item_id", item.ID)
 
-	// Use the shared live photo FS (ZIP bundle)
-	// FileSize is approximate - actual size comes from extracted file
+	// Create a dedicated FS for this video asset
+	// The ZIP will be downloaded again, but this avoids complex lifecycle management
+	liveFS := &synologyLivePhotoFS{
+		client:   sa.client,
+		itemID:   item.ID,
+		filename: item.Filename, // Original filename (HEIC) for the API
+		logger:   sa.app.Log().Logger,
+	}
+
 	videoAsset := &assets.Asset{
 		File:             fshelper.FSName(liveFS, videoFilename),
 		FileSize:         int(item.Filesize), // Approximate size
@@ -752,7 +757,6 @@ type synologyLivePhotoFS struct {
 	tempDir    string
 	logger     *slog.Logger
 	downloaded bool
-	refCount   int // Number of open files
 }
 
 // Open implements fs.FS - downloads ZIP on first call, returns requested file
@@ -879,8 +883,7 @@ func (s *synologyLivePhotoFS) Open(name string) (fs.File, error) {
 				return nil, err
 			}
 
-			s.refCount++
-		return &synologyLivePhotoFile{
+			return &synologyLivePhotoFile{
 				File:     f,
 				name:     fname,
 				size:     info.Size(),
@@ -921,12 +924,10 @@ func (f *synologyLivePhotoFile) Stat() (fs.FileInfo, error) {
 
 func (f *synologyLivePhotoFile) Close() error {
 	err := f.File.Close()
-	// Decrement ref count and cleanup if this is the last file
+	// Cleanup the temp directory when the file is closed
+	// Each asset has its own FS, so cleanup is safe
 	if f.fs != nil {
-		f.fs.refCount--
-		if f.fs.refCount <= 0 {
-			f.fs.cleanup()
-		}
+		f.fs.cleanup()
 	}
 	return err
 }

--- a/adapters/synology/synology.go
+++ b/adapters/synology/synology.go
@@ -59,6 +59,11 @@ func (sa *Adapter) Open(ctx context.Context) error {
 		return fmt.Errorf("create client: %w", err)
 	}
 
+	// Query API info first to verify connection
+	if _, err := client.QueryAPIInfo(ctx, "SYNO.API.Auth"); err != nil {
+		sa.app.Log().Warn("Failed to query API info", "error", err, "tip", "check if URL is correct and Synology is accessible")
+	}
+
 	if err := client.Login(ctx); err != nil {
 		return fmt.Errorf("login: %w", err)
 	}

--- a/adapters/synology/synology.go
+++ b/adapters/synology/synology.go
@@ -721,6 +721,7 @@ type synologyFile struct {
 	size     int64
 	tempPath string
 	closed   bool
+	mu       sync.Mutex
 }
 
 func (f *synologyFile) Stat() (fs.FileInfo, error) {
@@ -730,14 +731,34 @@ func (f *synologyFile) Stat() (fs.FileInfo, error) {
 	}, nil
 }
 
-func (f *synologyFile) Close() error {
+func (f *synologyFile) Read(p []byte) (n int, err error) {
+	f.mu.Lock()
 	if f.closed {
+		f.mu.Unlock()
+		return 0, fmt.Errorf("file is closed")
+	}
+	f.mu.Unlock()
+	return f.File.Read(p)
+}
+
+func (f *synologyFile) Close() error {
+	f.mu.Lock()
+	if f.closed {
+		f.mu.Unlock()
 		return nil
 	}
 	f.closed = true
-	// Close the file and remove temp file
+	f.mu.Unlock()
+
+	// Close the file
 	err := f.File.Close()
-	os.Remove(f.tempPath)
+
+	// Schedule temp file deletion after a delay to ensure all readers are done
+	go func(path string) {
+		time.Sleep(5 * time.Second)
+		os.Remove(path)
+	}(f.tempPath)
+
 	return err
 }
 
@@ -1143,6 +1164,7 @@ type synologyLivePhotoFile struct {
 	tempPath string
 	fs       *synologyLivePhotoFS
 	closed   bool
+	mu       sync.Mutex
 }
 
 func (f *synologyLivePhotoFile) Stat() (fs.FileInfo, error) {
@@ -1152,13 +1174,28 @@ func (f *synologyLivePhotoFile) Stat() (fs.FileInfo, error) {
 	}, nil
 }
 
-func (f *synologyLivePhotoFile) Close() error {
+func (f *synologyLivePhotoFile) Read(p []byte) (n int, err error) {
+	f.mu.Lock()
 	if f.closed {
+		f.mu.Unlock()
+		return 0, fmt.Errorf("file is closed")
+	}
+	f.mu.Unlock()
+	return f.File.Read(p)
+}
+
+func (f *synologyLivePhotoFile) Close() error {
+	f.mu.Lock()
+	if f.closed {
+		f.mu.Unlock()
 		return nil
 	}
 	f.closed = true
+	f.mu.Unlock()
+
 	err := f.File.Close()
-	// Decrement ref count and cleanup when zero
+
+	// Decrement ref count and schedule cleanup
 	if f.fs != nil {
 		f.fs.mu.Lock()
 		f.fs.refCount--
@@ -1166,8 +1203,13 @@ func (f *synologyLivePhotoFile) Close() error {
 		f.fs.mu.Unlock()
 
 		if shouldCleanup {
-			f.fs.cleanup()
+			// Delay cleanup to ensure all readers are done
+			go func(fs *synologyLivePhotoFS) {
+				time.Sleep(5 * time.Second)
+				fs.cleanup()
+			}(f.fs)
 		}
 	}
+
 	return err
 }

--- a/adapters/synology/synology.go
+++ b/adapters/synology/synology.go
@@ -10,15 +10,15 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
-	"sync"
 	"time"
 
-	"github.com/simulot/immich-go/adapters"
 	"github.com/simulot/immich-go/app"
 	"github.com/simulot/immich-go/internal/assets"
 	"github.com/simulot/immich-go/internal/fileevent"
 	"github.com/simulot/immich-go/internal/fileprocessor"
+	"github.com/simulot/immich-go/internal/filetypes"
 	"github.com/simulot/immich-go/internal/fshelper"
 
 	mapset "github.com/deckarep/golang-set/v2"
@@ -286,6 +286,11 @@ func (sa *Adapter) getAdditionalFields() []string {
 // processItem processes a single item and sends it to the output channel
 // For live photos, this creates both the image and video assets
 func (sa *Adapter) processItem(ctx context.Context, item *Item, gOut chan *assets.Group) error {
+	// Check album filter: if specific albums were requested, skip items not in any of them
+	if len(sa.Albums) > 0 && !sa.matchesAlbumFilter(item) {
+		return nil
+	}
+
 	// Check tag filter
 	if len(sa.Tags) > 0 && !sa.matchesTagFilter(item) {
 		return nil
@@ -311,63 +316,60 @@ func (sa *Adapter) processItem(ctx context.Context, item *Item, gOut chan *asset
 func (sa *Adapter) processLivePhoto(ctx context.Context, item *Item, gOut chan *assets.Group) error {
 	sa.app.Log().Debug("Processing live photo", "filename", item.Filename, "item_id", item.ID)
 
-	// Create a shared FS for the live photo bundle
-	// The FS uses mutex to prevent concurrent downloads
-	liveFS := &synologyLivePhotoFS{
-		client:   sa.client,
-		itemID:   item.ID,
-		filename: item.Filename,
-		logger:   sa.app.Log().Logger,
-	}
-
 	// Pre-download to determine if we have a ZIP (with video) or single file
 	// This is necessary because hasVideo() needs to know the response type
-	if err := liveFS.preDownload(ctx); err != nil {
+	var livePhotoSaveDir string
+	var err error
+	if livePhotoSaveDir, err = sa.preDownloadLive(item, ctx); err != nil {
 		return fmt.Errorf("pre-download live photo: %w", err)
 	}
-
-	// Step 1: Process the image part (HEIC/JPG)
-	imageAsset := sa.mapToAssetForLiveImage(item, liveFS)
-	if imageAsset != nil {
-		sa.processor.RecordAssetDiscovered(ctx, imageAsset.File, int64(imageAsset.FileSize), fileevent.DiscoveredImage)
-		group := assets.NewGroup(assets.GroupByNone, imageAsset)
-		select {
-		case gOut <- group:
-		case <-ctx.Done():
-			liveFS.cleanup()
-			return ctx.Err()
-		}
-	}
-
-	// Step 2: Process the video part (MOV) only if we got a ZIP response
-	// Non-ZIP responses only contain the image, no video
-	videoFilename := item.LivePhotoVideoFilename()
-	if videoFilename != "" && liveFS.hasVideo() {
-		videoAsset := sa.mapToAssetForLiveVideo(item, liveFS, videoFilename)
-		if videoAsset != nil {
-			sa.processor.RecordAssetDiscovered(ctx, videoAsset.File, int64(videoAsset.FileSize), fileevent.DiscoveredVideo)
-			group := assets.NewGroup(assets.GroupByNone, videoAsset)
+	// _ = livePhotoSaveDir
+	// list all file in livePhotoSaveDir
+	if files, err := os.ReadDir(livePhotoSaveDir); err != nil {
+		return fmt.Errorf("read dir faild: %w", err)
+	} else {
+		for _, file := range files {
+			if !file.Type().IsRegular() {
+				continue
+			}
+			sa.app.Log().Debug("Get file in live photo dir", "filename", file.Name(), "item_id", item.ID)
+			// Map to asset
+			asset, mediaType := sa.mapToAssetForLive(item, filepath.Join(livePhotoSaveDir, file.Name()))
+			if asset == nil {
+				continue
+			}
+			// Record discovery
+			code := fileevent.DiscoveredImage
+			if mediaType == filetypes.TypeVideo {
+				code = fileevent.DiscoveredVideo
+			}
+			sa.processor.RecordAssetDiscovered(ctx, asset.File, int64(asset.FileSize), code)
+			// Send to output
+			group := assets.NewGroup(assets.GroupByNone, asset)
 			select {
 			case gOut <- group:
 			case <-ctx.Done():
-				liveFS.cleanup()
 				return ctx.Err()
 			}
 		}
-	} else if videoFilename != "" {
-		sa.app.Log().Debug("Live photo has no video file (single file response)", "filename", item.Filename)
-	} else {
-		sa.app.Log().Warn("Live photo has no video filename", "filename", item.Filename)
 	}
-
-	// Note: Cleanup happens when the last file is closed
 	return nil
 }
 
 // processSingleItem processes a regular (non-live) photo or video
 func (sa *Adapter) processSingleItem(ctx context.Context, item *Item, gOut chan *assets.Group) error {
+	var tempFilePath string
+	var err error
+	if tempFilePath, err = sa.preDownload(item, strconv.Itoa(item.ID), ctx); err != nil {
+		return fmt.Errorf("pre-download item: %w", err)
+	}
 	// Map to asset
-	asset := sa.mapToAsset(item)
+	asset := sa.mapToAsset(item, tempFilePath)
+	if asset == nil {
+		// Unsupported file type: clean up temp file and skip
+		os.Remove(tempFilePath)
+		return nil
+	}
 
 	// Record discovery
 	code := fileevent.DiscoveredImage
@@ -407,6 +409,16 @@ func (sa *Adapter) matchesTagFilter(item *Item) bool {
 	return false
 }
 
+// matchesAlbumFilter checks if the item belongs to any of the requested albums
+func (sa *Adapter) matchesAlbumFilter(item *Item) bool {
+	for _, images := range sa.albumImageCache {
+		if images.Contains(item.ID) {
+			return true
+		}
+	}
+	return false
+}
+
 // matchesPeopleFilter checks if the item matches the people filter
 func (sa *Adapter) matchesPeopleFilter(item *Item) bool {
 	if len(sa.People) == 0 {
@@ -427,118 +439,118 @@ func (sa *Adapter) matchesPeopleFilter(item *Item) bool {
 	return false
 }
 
-// mapToAssetForLiveImage creates an Asset for the image part of a live photo
-// Uses the shared liveFS which handles concurrent access safely
-func (sa *Adapter) mapToAssetForLiveImage(item *Item, liveFS *synologyLivePhotoFS) *assets.Asset {
-	sa.app.Log().Debug("Creating live photo image asset", "filename", item.Filename, "item_id", item.ID)
+func (sa *Adapter) mapToAssetForLive(item *Item, actuleFilePath string) (*assets.Asset, string) {
+	// Determine file type
+	ext := strings.ToLower(path.Ext(actuleFilePath))
+	mediaType := ""
+	if _mediaType, ok := sa.app.GetSupportedMedia()[ext]; !ok {
+		sa.app.Log().Warn("Unsupported file type", "filename", actuleFilePath, "ext", ext)
+		return nil, ""
+	} else {
+		mediaType = _mediaType
+	}
+	if mediaType != filetypes.TypeImage && mediaType != filetypes.TypeVideo {
+		sa.app.Log().Warn("Unsupported file type", "filename", actuleFilePath, "ext", ext)
+		return nil, ""
+	}
 
+	fs := &SimpleFileFS{
+		path:   actuleFilePath,
+		logger: sa.app.Log().Logger,
+	}
+
+	// file, err := os.Open(actuleFilePath)
 	captureDate := time.Unix(sa.correctTimestamp(item.Time, sa.app.GetTZ()), 0).In(sa.app.GetTZ())
-	imageAsset := &assets.Asset{
-		File:             fshelper.FSName(liveFS, item.Filename),
-		FileSize:         int(item.Filesize), // Approximate size from API
+	asset := &assets.Asset{
+		File:             fshelper.FSName(fs, item.Filename),
 		OriginalFileName: item.Filename,
-		FileDate:         item.IndexedAt(),
 		Description:      item.Additional.Description,
 		CaptureDate:      captureDate,
 	}
 
+	if stat, err := os.Stat(actuleFilePath); err != nil {
+		sa.app.Log().Warn("Failed to get file info", "filename", actuleFilePath, "error", err)
+		return nil, ""
+	} else {
+		asset.FileSize = int(stat.Size())
+	}
 	// Add album if specified
 	for albumName, images := range sa.albumImageCache {
 		if images.Contains(item.ID) {
-			imageAsset.Albums = append(imageAsset.Albums, assets.Album{
+			asset.Albums = append(asset.Albums, assets.Album{
 				Title: albumName,
 			})
 		}
 	}
 
-	// Add tags
+	// Add tags (skip empty names)
 	for _, tag := range item.Additional.Tag {
 		if tag.Name != "" {
-			imageAsset.Tags = append(imageAsset.Tags, assets.Tag{
+			asset.Tags = append(asset.Tags, assets.Tag{
 				Name:  tag.Name,
 				Value: tag.Name,
 			})
 		}
 	}
 
-	// Add people as tags
+	// Add people as tags (prefixed with "Person: ") since Immich handles faces separately
+	// Skip empty person names
 	if !sa.SkipFaceData {
 		for _, person := range item.Additional.Person {
 			if person.Name != "" {
 				personTag := fmt.Sprintf("Person: %s", person.Name)
-				imageAsset.Tags = append(imageAsset.Tags, assets.Tag{
+				asset.Tags = append(asset.Tags, assets.Tag{
 					Name:  personTag,
 					Value: personTag,
 				})
 			}
 		}
 	}
-
-	return imageAsset
-}
-
-// mapToAssetForLiveVideo creates an Asset for the video part of a live photo
-// Uses the shared liveFS which handles concurrent access safely
-func (sa *Adapter) mapToAssetForLiveVideo(item *Item, liveFS *synologyLivePhotoFS, videoFilename string) *assets.Asset {
-	sa.app.Log().Debug("Creating live photo video asset", "filename", videoFilename, "item_id", item.ID)
-
-	captureDate := time.Unix(sa.correctTimestamp(item.Time, sa.app.GetTZ()), 0).In(sa.app.GetTZ())
-	videoAsset := &assets.Asset{
-		File:             fshelper.FSName(liveFS, videoFilename),
-		FileSize:         int(item.Filesize), // Approximate size
-		OriginalFileName: videoFilename,
-		FileDate:         item.IndexedAt(),
-		Description:      item.Additional.Description,
-		CaptureDate:      captureDate,
-	}
-
-	// Add album if specified
-	for albumName, images := range sa.albumImageCache {
-		if images.Contains(item.ID) {
-			videoAsset.Albums = append(videoAsset.Albums, assets.Album{
-				Title: albumName,
-			})
+	asset.AddCloseOption(func(asset *assets.Asset) error {
+		sa.app.Log().Debug("Removing file", "filename", actuleFilePath)
+		if err := os.Remove(actuleFilePath); err != nil {
+			sa.app.Log().Error("Error removing file", "filename", actuleFilePath, "err", err)
+			// ignore error
+			return nil
 		}
-	}
-	// Store original metadata
-	// Don't set DateTaken, Latitude, Longitude - let Immich read from EXIF
-	videoAsset.FromApplication = &assets.Metadata{
-		FileName:    videoFilename,
-		Description: item.Additional.Description,
-	}
-
-	return videoAsset
+		dir := filepath.Dir(actuleFilePath)
+		if files, err := os.ReadDir(dir); err != nil {
+			sa.app.Log().Error("Error reading dir", "dir", dir, "err", err)
+		} else if len(files) == 0 {
+			sa.app.Log().Debug("Removing dir", "dir", dir)
+			if err := os.RemoveAll(dir); err != nil {
+				sa.app.Log().Error("Error removing dir", "dir", dir, "err", err)
+			}
+		}
+		// ignore error
+		return nil
+	})
+	return asset, mediaType
 }
 
 // mapToAsset converts a Synology Item to an immich-go Asset
-func (sa *Adapter) mapToAsset(item *Item) *assets.Asset {
+func (sa *Adapter) mapToAsset(item *Item, actuleFilePath string) *assets.Asset {
 	// Determine file type
 	ext := strings.ToLower(path.Ext(item.Filename))
-	if ext == "" {
-		// Try to determine from type
-		switch item.Type {
-		case "photo":
-			ext = ".jpg"
-		case "video":
-			ext = ".mp4"
-		}
+	if _mediaType, ok := sa.app.GetSupportedMedia()[ext]; !ok {
+		sa.app.Log().Warn("Unsupported file type", "filename", item.Filename, "ext", ext)
+		return nil
+	} else if _mediaType != filetypes.TypeImage && _mediaType != filetypes.TypeVideo {
+		sa.app.Log().Warn("Unsupported file type", "filename", item.Filename, "ext", ext)
+		return nil
 	}
 
 	// Create a custom FS that can read from Synology
-	synFS := &synologyFS{
-		client:   sa.client,
-		itemID:   item.ID,
-		cacheKey: item.Additional.Thumbnail.CacheKey,
-		filename: item.Filename,
-		size:     int(item.Filesize),
-		logger:   sa.app.Log().Logger,
+
+	fs := &SimpleFileFS{
+		path:   actuleFilePath,
+		logger: sa.app.Log().Logger,
 	}
 	captureDate := time.Unix(sa.correctTimestamp(item.Time, sa.app.GetTZ()), 0).In(sa.app.GetTZ())
 	asset := &assets.Asset{
-		File:             fshelper.FSName(synFS, item.Filename),
+		File:             fshelper.FSName(fs, item.Filename),
 		FileSize:         int(item.Filesize),
 		OriginalFileName: item.Filename,
-		FileDate:         item.IndexedAt(),
 		Description:      item.Additional.Description,
 		CaptureDate:      captureDate,
 	}
@@ -575,7 +587,14 @@ func (sa *Adapter) mapToAsset(item *Item) *assets.Asset {
 			}
 		}
 	}
-
+	asset.AddCloseOption(func(asset *assets.Asset) error {
+		sa.app.Log().Debug("Removing file", "filename", item.Filename, "filepath", actuleFilePath)
+		if err := os.Remove(actuleFilePath); err != nil {
+			sa.app.Log().Error("Error removing file", "filename", item.Filename, "filepath", actuleFilePath, "err", err)
+		}
+		// ignore error
+		return nil
+	})
 	return asset
 }
 func (sa *Adapter) correctTimestamp(wrong int64, loc *time.Location) int64 {
@@ -587,279 +606,49 @@ func (sa *Adapter) correctTimestamp(wrong int64, loc *time.Location) int64 {
 	return t.Unix()
 }
 
-// Ensure Adapter implements adapters.Reader
-var _ adapters.Reader = (*Adapter)(nil)
-
-// synologyFS implements fs.FS to provide access to Synology files
-type synologyFS struct {
-	client   *Client
-	itemID   int
-	cacheKey string
-	filename string
-	size     int
-	logger   *slog.Logger // Optional logger for debugging
-}
-
-// Open implements fs.FS
-// Downloads the file to a local temp file first to avoid network timeout during upload
-func (s *synologyFS) Open(name string) (fs.File, error) {
-	if name != s.filename {
-		return nil, fmt.Errorf("file not found: %s", name)
-	}
-
-	s.logger.Debug("Downloading Synology file", "filename", s.filename, "item_id", s.itemID, "cache_key", s.cacheKey)
-
-	ctx := context.Background()
-
-	// Create temp file
-	tempFile, err := os.CreateTemp("", "synology-*-"+filepath.Base(s.filename))
-	if err != nil {
-		return nil, fmt.Errorf("create temp file: %w", err)
-	}
-
-	// Download to temp file
-	reader, err := s.client.DownloadItem(ctx, s.itemID, s.cacheKey)
-	if err != nil {
-		tempFile.Close()
-		os.Remove(tempFile.Name())
-		return nil, err
-	}
-
-	n, err := io.Copy(tempFile, reader)
-	reader.Close()
-
-	if err != nil {
-		tempFile.Close()
-		os.Remove(tempFile.Name())
-		return nil, fmt.Errorf("download to temp: %w", err)
-	}
-	s.logger.Debug("Downloaded Synology file", "filename", s.filename, "size", n)
-
-	// Seek to beginning for reading
-	_, err = tempFile.Seek(0, 0)
-	if err != nil {
-		tempFile.Close()
-		os.Remove(tempFile.Name())
-		return nil, fmt.Errorf("seek temp file: %w", err)
-	}
-
-	return &synologyFile{
-		File:     tempFile,
-		name:     s.filename,
-		size:     int64(s.size),
-		tempPath: tempFile.Name(),
-	}, nil
-}
-
-// synologyFile implements fs.File
-type synologyFile struct {
-	*os.File
-	name     string
-	size     int64
-	tempPath string
-	closed   bool
-	mu       sync.Mutex
-}
-
-func (f *synologyFile) Stat() (fs.FileInfo, error) {
-	return &synologyFileInfo{
-		name: f.name,
-		size: f.size,
-	}, nil
-}
-
-func (f *synologyFile) Read(p []byte) (n int, err error) {
-	f.mu.Lock()
-	if f.closed {
-		f.mu.Unlock()
-		return 0, fmt.Errorf("file is closed")
-	}
-	f.mu.Unlock()
-	return f.File.Read(p)
-}
-
-func (f *synologyFile) Close() error {
-	f.mu.Lock()
-	if f.closed {
-		f.mu.Unlock()
-		return nil
-	}
-	f.closed = true
-	f.mu.Unlock()
-
-	// Close the file
-	err := f.File.Close()
-
-	// Schedule temp file deletion after a delay to ensure all readers are done
-	go func(path string) {
-		time.Sleep(5 * time.Second)
-		os.Remove(path)
-	}(f.tempPath)
-
-	os.Remove(f.tempPath)
-	return err
-}
-
-// synologyFileInfo implements fs.FileInfo
-type synologyFileInfo struct {
-	name string
-	size int64
-}
-
-func (fi *synologyFileInfo) Name() string       { return fi.name }
-func (fi *synologyFileInfo) Size() int64        { return fi.size }
-func (fi *synologyFileInfo) Mode() fs.FileMode  { return 0444 } // Read-only
-func (fi *synologyFileInfo) ModTime() time.Time { return time.Now() }
-func (fi *synologyFileInfo) IsDir() bool        { return false }
-func (fi *synologyFileInfo) Sys() interface{}   { return nil }
-
-// synologyLivePhotoFS implements fs.FS for live photos
-// Downloads either a ZIP (containing both HEIC and MOV) or just the image file
-// Synology's API may return either format based on how the live photo is stored
-type synologyLivePhotoFS struct {
-	client     *Client
-	itemID     int
-	filename   string            // e.g., "IMG_9948.HEIC"
-	zipFiles   map[string]string // filename -> temp path
-	tempDir    string
-	logger     *slog.Logger
-	downloaded bool
-	isZip      bool       // whether the download was a ZIP
-	mu         sync.Mutex // protects download operation
-	refCount   int        // number of open files using this FS
-}
-
-// Open implements fs.FS - downloads on first call, returns requested file
-// Handles both ZIP (containing both image and video) and single file responses
-func (s *synologyLivePhotoFS) Open(name string) (fs.File, error) {
-	// Only allow opening the main file (HEIC/JPG) or its corresponding video (MOV)
-	expectedVideo := s.filename[:len(s.filename)-len(filepath.Ext(s.filename))] + ".mov"
-	if name != s.filename && strings.ToLower(name) != strings.ToLower(expectedVideo) {
-		return nil, fmt.Errorf("file not found: %s", name)
-	}
-
-	ctx := context.Background()
-
-	// Use mutex to prevent concurrent access
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	// If not pre-downloaded yet, do it now (shouldn't happen if processLivePhoto works correctly)
-	if !s.downloaded {
-		s.mu.Unlock()
-		if err := s.preDownload(ctx); err != nil {
-			return nil, err
-		}
-		s.mu.Lock()
-	}
-
-	// Return the requested file
-	lowerName := strings.ToLower(name)
-	for fname, fpath := range s.zipFiles {
-		if strings.ToLower(fname) == lowerName {
-			f, err := os.Open(fpath)
-			if err != nil {
-				return nil, err
-			}
-
-			// Get file info for size
-			info, err := f.Stat()
-			if err != nil {
-				f.Close()
-				return nil, err
-			}
-
-			s.refCount++
-			return &synologyLivePhotoFile{
-				File:     f,
-				name:     fname,
-				size:     info.Size(),
-				tempPath: fpath,
-				fs:       s,
-			}, nil
-		}
-	}
-
-	// If looking for video but exact name not found, try to find any video file
-	// Synology sometimes has mismatched filenames (e.g., IMG_4009.MOV vs IMG_4009_1.HEIC)
-	if strings.HasSuffix(lowerName, ".mov") {
-		for fname, fpath := range s.zipFiles {
-			lowerFname := strings.ToLower(fname)
-			if strings.HasSuffix(lowerFname, ".mov") || strings.HasSuffix(lowerFname, ".mp4") {
-				if s.logger != nil {
-					s.logger.Debug("Using alternative video file", "requested", name, "found", fname)
-				}
-				f, err := os.Open(fpath)
-				if err != nil {
-					return nil, err
-				}
-
-				info, err := f.Stat()
-				if err != nil {
-					f.Close()
-					return nil, err
-				}
-
-				s.refCount++
-				return &synologyLivePhotoFile{
-					File:     f,
-					name:     fname, // Return actual filename, not requested name
-					size:     info.Size(),
-					tempPath: fpath,
-					fs:       s,
-				}, nil
-			}
-		}
-	}
-
-	return nil, fmt.Errorf("file not found in live photo: %s (available: %v)", name, s.getAvailableFiles())
-}
-
 // handleZipDownload processes a ZIP response containing both image and video
-func (s *synologyLivePhotoFS) handleZipDownload(reader io.ReadCloser, tempDir string) error {
+func (sa *Adapter) handleZipDownload(reader io.ReadCloser, tempDir string) error {
 	// Save ZIP to temp file
 	zipPath := filepath.Join(tempDir, "livephoto.zip")
 	zipFile, err := os.Create(zipPath)
 	if err != nil {
 		return fmt.Errorf("create zip temp file: %w", err)
 	}
-
 	written, err := io.Copy(zipFile, reader)
 	zipFile.Close()
-
-	if s.logger != nil {
-		s.logger.Debug("Downloaded ZIP to temp file", "filename", s.filename, "bytes", written)
-	}
-
 	if err != nil {
-		return fmt.Errorf("save zip: %w", err)
+		return fmt.Errorf("Fail to save zip, path:%s, %w", zipPath, err)
 	}
 
+	sa.app.Log().Debug("Downloaded ZIP to temp file", "path", zipPath, "bytes", written)
 	// Verify ZIP by checking file header (magic number)
 	if err := verifyZipFile(zipPath); err != nil {
-		return fmt.Errorf("verify zip: %w", err)
+		return fmt.Errorf("Fail to verify zip, path:%s, %w", zipPath, err)
 	}
 
 	// Extract ZIP
 	zipReader, err := zip.OpenReader(zipPath)
 	if err != nil {
-		return fmt.Errorf("open zip: %w", err)
+		return fmt.Errorf("Fail to open zip, path:%s, %w", zipPath, err)
 	}
 	defer zipReader.Close()
 
-	s.zipFiles = make(map[string]string)
+	// s.zipFiles = make(map[string]string)
+	unzipFileCount := 0
 	for _, zf := range zipReader.File {
 		// Extract each file
 		extractPath := filepath.Join(tempDir, filepath.Base(zf.Name))
 		rc, err := zf.Open()
 		if err != nil {
-			return fmt.Errorf("extract %s: %w", zf.Name, err)
+			sa.app.Log().Error("Error extracting file", "filename", zf.Name, "err", err)
+			continue
 		}
 
 		extractFile, err := os.Create(extractPath)
 		if err != nil {
 			rc.Close()
-			return fmt.Errorf("create extract file: %w", err)
+			sa.app.Log().Error("Error creating extract file", "filename", zf.Name, "err", err)
+			continue
 		}
 
 		_, err = io.Copy(extractFile, rc)
@@ -867,30 +656,26 @@ func (s *synologyLivePhotoFS) handleZipDownload(reader io.ReadCloser, tempDir st
 		extractFile.Close()
 
 		if err != nil {
-			return fmt.Errorf("extract %s: %w", zf.Name, err)
+			sa.app.Log().Error("Error extracting file", "filename", zf.Name, "err", err)
+			continue
 		}
 
-		s.zipFiles[filepath.Base(zf.Name)] = extractPath
-		if s.logger != nil {
-			s.logger.Debug("Extracted live photo file", "name", zf.Name, "size", zf.UncompressedSize64)
-		}
+		sa.app.Log().Debug("Extracted live photo file", "name", zf.Name, "size", zf.UncompressedSize64)
+		unzipFileCount++
 	}
 
 	// Clean up ZIP file
 	os.Remove(zipPath)
 
-	if s.logger != nil {
-		s.logger.Debug("Live photo ZIP extracted", "files", len(s.zipFiles))
-	}
-
+	sa.app.Log().Debug("Live photo ZIP extracted", "files", unzipFileCount)
 	return nil
 }
 
 // handleSingleFileDownload processes a single file response (just the image)
 // For non-ZIP responses, we only get the image file. The video may need separate handling.
-func (s *synologyLivePhotoFS) handleSingleFileDownload(reader io.ReadCloser, tempDir string, requestedName string) error {
+func (sa *Adapter) handleSingleFileDownload(reader io.ReadCloser, tempDir string, filename string) error {
 	// Save the single file
-	filePath := filepath.Join(tempDir, s.filename)
+	filePath := filepath.Join(tempDir, filename)
 	outFile, err := os.Create(filePath)
 	if err != nil {
 		return fmt.Errorf("create temp file: %w", err)
@@ -899,123 +684,83 @@ func (s *synologyLivePhotoFS) handleSingleFileDownload(reader io.ReadCloser, tem
 	written, err := io.Copy(outFile, reader)
 	outFile.Close()
 
-	if s.logger != nil {
-		s.logger.Debug("Downloaded single file", "filename", s.filename, "bytes", written)
-	}
-
 	if err != nil {
 		return fmt.Errorf("save file: %w", err)
 	}
 
-	s.zipFiles = make(map[string]string)
-	s.zipFiles[s.filename] = filePath
-
-	// Note: For non-ZIP responses, we don't have the video file.
-	// This is a limitation - Synology's API doesn't provide the video separately
-	// in this case. The live photo will be uploaded as a static image.
-	if s.logger != nil {
-		s.logger.Debug("Live photo returned as single file (no video)", "filename", s.filename)
-	}
+	sa.app.Log().Debug("Downloaded single file", "filename", filename, "bytes", written)
 
 	return nil
 }
+func (sa *Adapter) preDownload(item *Item, cacheKey string, ctx context.Context) (string, error) {
+	sa.app.Log().Debug("Downloading Synology file", "filename", item.Filename, "item_id", item.ID, "cache_key", cacheKey)
 
-// hasVideo returns true if the live photo contains a video file
-// This is true for ZIP responses, false for single file responses
-func (s *synologyLivePhotoFS) hasVideo() bool {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.isZip
-}
-
-// getAvailableFiles returns a list of available files (for debugging)
-func (s *synologyLivePhotoFS) getAvailableFiles() []string {
-	files := make([]string, 0, len(s.zipFiles))
-	for fname := range s.zipFiles {
-		files = append(files, fname)
+	// Create temp file
+	tempFile, err := os.CreateTemp("", "synology-*-"+filepath.Base(item.Filename))
+	if err != nil {
+		return "", fmt.Errorf("create temp file: %w", err)
 	}
-	return files
+	defer tempFile.Close()
+
+	// Download to temp file
+	reader, err := sa.client.DownloadItem(ctx, item.ID, cacheKey)
+	if err != nil {
+		sa.app.Log().Error("Error downloading Synology file on start", "filename", item.Filename, "err", err)
+		return "", err
+	}
+
+	n, err := io.Copy(tempFile, reader)
+	reader.Close()
+
+	if err != nil {
+		sa.app.Log().Error("Error downloading Synology file on copy", "filename", item.Filename, "err", err)
+		return "", fmt.Errorf("download to temp: %w", err)
+	}
+	sa.app.Log().Debug("Downloaded Synology file", "filename", item.Filename, "size", n)
+
+	return tempFile.Name(), nil
 }
 
-// preDownload downloads the live photo ahead of time to determine the response type
+// preDownloadLive downloads the live photo ahead of time to determine the response type
 // This allows hasVideo() to return the correct value before assets are created
-func (s *synologyLivePhotoFS) preDownload(ctx context.Context) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+func (sa *Adapter) preDownloadLive(item *Item, ctx context.Context) (string, error) {
 
-	if s.downloaded {
-		return nil
-	}
-
-	if s.logger != nil {
-		s.logger.Debug("Pre-downloading live photo", "filename", s.filename, "item_id", s.itemID)
-	}
+	sa.app.Log().Debug("Pre-downloading live photo", "filename", item.Filename, "item_id", item.ID)
 
 	// Create temp directory
 	tempDir, err := os.MkdirTemp("", "synology-livephoto-*")
 	if err != nil {
-		return fmt.Errorf("create temp dir: %w", err)
+		return "", fmt.Errorf("create temp dir: %w", err)
 	}
-	s.tempDir = tempDir
 
 	// Download - may return ZIP or single file
-	reader, contentType, isZip, err := s.client.DownloadLivePhoto(ctx, s.itemID, s.filename, s.logger)
+	reader, contentType, isZip, err := sa.client.DownloadLivePhoto(ctx, item.ID, item.Filename)
 	if err != nil {
-		os.RemoveAll(s.tempDir)
-		s.tempDir = ""
-		return fmt.Errorf("download live photo: %w", err)
+		os.RemoveAll(tempDir)
+		return "", fmt.Errorf("download live photo: %w", err)
 	}
-
-	s.isZip = isZip
-
-	if s.logger != nil {
-		s.logger.Debug("Pre-downloaded live photo", "filename", s.filename, "content_type", contentType,
-			"is_zip", isZip, "item_id", s.itemID)
-	}
+	sa.app.Log().Debug("Pre-downloaded live photo", "filename", item.Filename, "content_type", contentType,
+		"is_zip", isZip, "item_id", item.ID)
 
 	if isZip {
-		// Handle ZIP download (contains both image and video)
-		if err := s.handleZipDownload(reader, tempDir); err != nil {
+		// reader is a zip file, unzip all file to tempDir
+		// Handle ZIP download (contains mutable files)
+		if err := sa.handleZipDownload(reader, tempDir); err != nil {
 			reader.Close()
-			os.RemoveAll(s.tempDir)
-			s.tempDir = ""
-			return err
+			os.RemoveAll(tempDir)
+			return "", err
 		}
 	} else {
 		// Handle single file download (just the image)
-		if err := s.handleSingleFileDownload(reader, tempDir, s.filename); err != nil {
+		if err := sa.handleSingleFileDownload(reader, tempDir, item.Filename); err != nil {
 			reader.Close()
-			os.RemoveAll(s.tempDir)
-			s.tempDir = ""
-			return err
+			os.RemoveAll(tempDir)
+			return "", err
 		}
 	}
 	reader.Close()
 
-	s.downloaded = true
-
-	if s.logger != nil {
-		if isZip {
-			s.logger.Debug("Live photo pre-downloaded as ZIP", "files", len(s.zipFiles))
-		} else {
-			s.logger.Debug("Live photo pre-downloaded as single file")
-		}
-	}
-
-	return nil
-}
-
-// cleanup removes the temp directory and all extracted files
-func (s *synologyLivePhotoFS) cleanup() {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if s.tempDir != "" {
-		os.RemoveAll(s.tempDir)
-		s.tempDir = ""
-		s.zipFiles = nil
-		s.downloaded = false
-	}
+	return tempDir, nil
 }
 
 // verifyZipFile checks if the file is a valid ZIP by reading its magic number
@@ -1052,60 +797,16 @@ func verifyZipFile(path string) error {
 	return fmt.Errorf("invalid ZIP signature: %02x %02x", magic[2], magic[3])
 }
 
-// synologyLivePhotoFile implements fs.File for live photo extracted files
-type synologyLivePhotoFile struct {
-	*os.File
-	name     string
-	size     int64
-	tempPath string
-	fs       *synologyLivePhotoFS
-	closed   bool
-	mu       sync.Mutex
+type SimpleFileFS struct {
+	path   string
+	logger *slog.Logger
 }
 
-func (f *synologyLivePhotoFile) Stat() (fs.FileInfo, error) {
-	return &synologyFileInfo{
-		name: f.name,
-		size: f.size,
-	}, nil
-}
-
-func (f *synologyLivePhotoFile) Read(p []byte) (n int, err error) {
-	f.mu.Lock()
-	if f.closed {
-		f.mu.Unlock()
-		return 0, fmt.Errorf("file is closed")
+func (fs *SimpleFileFS) Open(name string) (fs.File, error) {
+	if file, err := os.Open(fs.path); err != nil {
+		fs.logger.Error("Error opening file", "filename", name, "err", err)
+		return nil, err
+	} else {
+		return file, nil
 	}
-	f.mu.Unlock()
-	return f.File.Read(p)
-}
-
-func (f *synologyLivePhotoFile) Close() error {
-	f.mu.Lock()
-	if f.closed {
-		f.mu.Unlock()
-		return nil
-	}
-	f.closed = true
-	f.mu.Unlock()
-
-	err := f.File.Close()
-
-	// Decrement ref count and schedule cleanup
-	if f.fs != nil {
-		f.fs.mu.Lock()
-		f.fs.refCount--
-		shouldCleanup := f.fs.refCount <= 0
-		f.fs.mu.Unlock()
-
-		if shouldCleanup {
-			// Delay cleanup to ensure all readers are done
-			go func(fs *synologyLivePhotoFS) {
-				time.Sleep(5 * time.Second)
-				fs.cleanup()
-			}(f.fs)
-		}
-	}
-
-	return err
 }

--- a/adapters/synology/synology.go
+++ b/adapters/synology/synology.go
@@ -418,7 +418,8 @@ func (sa *Adapter) mapToAsset(item *Item, album *Album) *assets.Asset {
 	for _, tag := range item.Additional.Tag {
 		if tag.Name != "" {
 			asset.Tags = append(asset.Tags, assets.Tag{
-				Name: tag.Name,
+				Name:  tag.Name,
+				Value: tag.Name,
 			})
 		}
 	}
@@ -428,8 +429,10 @@ func (sa *Adapter) mapToAsset(item *Item, album *Album) *assets.Asset {
 	if !sa.SkipFaceData {
 		for _, person := range item.Additional.Person {
 			if person.Name != "" {
+				personTag := fmt.Sprintf("Person: %s", person.Name)
 				asset.Tags = append(asset.Tags, assets.Tag{
-					Name: fmt.Sprintf("Person: %s", person.Name),
+					Name:  personTag,
+					Value: personTag,
 				})
 			}
 		}

--- a/adapters/synology/synology.go
+++ b/adapters/synology/synology.go
@@ -1,0 +1,495 @@
+package synology
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/fs"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/simulot/immich-go/adapters"
+	"github.com/simulot/immich-go/app"
+	"github.com/simulot/immich-go/internal/assets"
+	"github.com/simulot/immich-go/internal/fileevent"
+	"github.com/simulot/immich-go/internal/fileprocessor"
+	"github.com/simulot/immich-go/internal/fshelper"
+)
+
+// Adapter implements the adapters.Reader interface for Synology Photos
+type Adapter struct {
+	// Configuration
+	ServerURL      string
+	Account        string
+	Password       string
+	IncludeShared  bool
+	Albums         []string // Filter: import only these albums
+	Tags           []string // Filter: import only items with these tags
+	People         []string // Filter: import only items with these people
+	SkipFaceData   bool     // Skip face recognition data
+
+	// Internal
+	client     *Client
+	app        *app.Application
+	processor  *fileprocessor.FileProcessor
+	albumCache map[string]Album // album name -> album
+	tagCache   map[string]int   // tag name -> tag id
+	peopleCache map[string]int  // person name -> person id
+}
+
+// NewAdapter creates a new Synology Photos adapter
+func NewAdapter(app *app.Application, serverURL, account, password string) *Adapter {
+	return &Adapter{
+		ServerURL:   serverURL,
+		Account:     account,
+		Password:    password,
+		app:         app,
+		processor:   app.FileProcessor(),
+		albumCache:  make(map[string]Album),
+		tagCache:    make(map[string]int),
+		peopleCache: make(map[string]int),
+	}
+}
+
+// Open initializes the connection to Synology Photos
+func (sa *Adapter) Open(ctx context.Context) error {
+	client, err := NewClient(sa.ServerURL, sa.Account, sa.Password, WithInsecureSkipVerify(true))
+	if err != nil {
+		return fmt.Errorf("create client: %w", err)
+	}
+
+	if err := client.Login(ctx); err != nil {
+		return fmt.Errorf("login: %w", err)
+	}
+
+	sa.client = client
+	return nil
+}
+
+// Close closes the connection
+func (sa *Adapter) Close(ctx context.Context) error {
+	if sa.client != nil {
+		return sa.client.Logout(ctx)
+	}
+	return nil
+}
+
+// Browse implements the adapters.Reader interface
+func (sa *Adapter) Browse(ctx context.Context) chan *assets.Group {
+	gOut := make(chan *assets.Group)
+
+	go func() {
+		defer close(gOut)
+
+		// Build caches if filtering
+		if err := sa.buildCaches(ctx); err != nil {
+			sa.app.Log().Error("Failed to build caches", "error", err)
+			return
+		}
+
+		// Determine which albums to process
+		albumsToProcess, err := sa.getAlbumsToProcess(ctx)
+		if err != nil {
+			sa.app.Log().Error("Failed to get albums", "error", err)
+			return
+		}
+
+		// Process albums or all items
+		if len(albumsToProcess) > 0 {
+			for _, album := range albumsToProcess {
+				if err := sa.processAlbum(ctx, album, gOut); err != nil {
+					sa.app.Log().Error("Failed to process album", "album", album.Name, "error", err)
+					continue
+				}
+			}
+		} else {
+			// Process all items (not album-based)
+			if err := sa.processAllItems(ctx, gOut); err != nil {
+				sa.app.Log().Error("Failed to process items", "error", err)
+				return
+			}
+		}
+	}()
+
+	return gOut
+}
+
+// buildCaches builds tag and people caches for filtering
+func (sa *Adapter) buildCaches(ctx context.Context) error {
+	// Build tag cache if filtering by tags
+	if len(sa.Tags) > 0 {
+		offset := 0
+		for {
+			tags, err := sa.client.ListTags(ctx, offset, 1000)
+			if err != nil {
+				return fmt.Errorf("list tags: %w", err)
+			}
+			for _, tag := range tags {
+				sa.tagCache[tag.Name] = tag.ID
+			}
+			if len(tags) < 1000 {
+				break
+			}
+			offset += 1000
+		}
+	}
+
+	// Build people cache if filtering by people
+	if len(sa.People) > 0 {
+		offset := 0
+		for {
+			people, err := sa.client.ListPeople(ctx, offset, 1000)
+			if err != nil {
+				return fmt.Errorf("list people: %w", err)
+			}
+			for _, person := range people {
+				sa.peopleCache[person.Name] = person.ID
+			}
+			if len(people) < 1000 {
+				break
+			}
+			offset += 1000
+		}
+	}
+
+	return nil
+}
+
+// getAlbumsToProcess returns the list of albums to import
+func (sa *Adapter) getAlbumsToProcess(ctx context.Context) ([]Album, error) {
+	// Get all albums
+	allAlbums := make([]Album, 0)
+	offset := 0
+	for {
+		albums, err := sa.client.ListAlbums(ctx, offset, 1000)
+		if err != nil {
+			return nil, fmt.Errorf("list albums: %w", err)
+		}
+		allAlbums = append(allAlbums, albums...)
+		if len(albums) < 1000 {
+			break
+		}
+		offset += 1000
+	}
+
+	// Cache albums by name
+	for _, album := range allAlbums {
+		sa.albumCache[album.Name] = album
+	}
+
+	// If specific albums requested, filter them
+	if len(sa.Albums) > 0 {
+		filtered := make([]Album, 0, len(sa.Albums))
+		for _, name := range sa.Albums {
+			if album, ok := sa.albumCache[name]; ok {
+				filtered = append(filtered, album)
+			} else {
+				sa.app.Log().Warn("Album not found", "name", name)
+			}
+		}
+		return filtered, nil
+	}
+
+	return allAlbums, nil
+}
+
+// processAlbum processes items from a specific album
+func (sa *Adapter) processAlbum(ctx context.Context, album Album, gOut chan *assets.Group) error {
+	sa.app.Log().Info("Processing album", "name", album.Name, "item_count", album.ItemCount)
+
+	additional := sa.getAdditionalFields()
+	offset := 0
+	limit := 100
+
+	for {
+		items, err := sa.client.GetAlbumItems(ctx, album.ID, offset, limit, additional)
+		if err != nil {
+			return fmt.Errorf("get album items: %w", err)
+		}
+
+		for _, item := range items {
+			if err := sa.processItem(ctx, &item, &album, gOut); err != nil {
+				sa.app.Log().Error("Failed to process item", "filename", item.Filename, "error", err)
+			}
+		}
+
+		if len(items) < limit {
+			break
+		}
+		offset += limit
+	}
+
+	return nil
+}
+
+// processAllItems processes all items without album grouping
+func (sa *Adapter) processAllItems(ctx context.Context, gOut chan *assets.Group) error {
+	sa.app.Log().Info("Processing all items")
+
+	additional := sa.getAdditionalFields()
+	offset := 0
+	limit := 100
+
+	for {
+		items, err := sa.client.ListAllItems(ctx, offset, limit, additional)
+		if err != nil {
+			return fmt.Errorf("list items: %w", err)
+		}
+
+		for _, item := range items {
+			if err := sa.processItem(ctx, &item, nil, gOut); err != nil {
+				sa.app.Log().Error("Failed to process item", "filename", item.Filename, "error", err)
+			}
+		}
+
+		if len(items) < limit {
+			break
+		}
+		offset += limit
+	}
+
+	return nil
+}
+
+// getAdditionalFields returns the list of additional fields to request
+func (sa *Adapter) getAdditionalFields() []string {
+	// Always request these
+	additional := []string{
+		"thumbnail",
+		"resolution",
+		"orientation",
+		"description",
+		"gps",
+	}
+
+	// Request tags if we need them
+	if len(sa.Tags) > 0 || len(sa.Albums) == 0 {
+		additional = append(additional, "tag")
+	}
+
+	// Request people if we need them
+	if !sa.SkipFaceData || len(sa.People) > 0 {
+		additional = append(additional, "person")
+	}
+
+	return additional
+}
+
+// processItem processes a single item and sends it to the output channel
+func (sa *Adapter) processItem(ctx context.Context, item *Item, album *Album, gOut chan *assets.Group) error {
+	// Check tag filter
+	if len(sa.Tags) > 0 && !sa.matchesTagFilter(item) {
+		return nil
+	}
+
+	// Check people filter
+	if len(sa.People) > 0 && !sa.matchesPeopleFilter(item) {
+		return nil
+	}
+
+	// Map to asset
+	asset := sa.mapToAsset(item, album)
+
+	// Record discovery
+	code := fileevent.DiscoveredImage
+	if item.IsVideo() {
+		code = fileevent.DiscoveredVideo
+	}
+	sa.processor.RecordAssetDiscovered(ctx, asset.File, int64(asset.FileSize), code)
+
+	// Send to output
+	group := assets.NewGroup(assets.GroupByNone, asset)
+	select {
+	case gOut <- group:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	return nil
+}
+
+// matchesTagFilter checks if the item matches the tag filter
+func (sa *Adapter) matchesTagFilter(item *Item) bool {
+	if len(sa.Tags) == 0 {
+		return true
+	}
+
+	itemTags := make(map[string]bool)
+	for _, tag := range item.Additional.Tag {
+		itemTags[tag.Name] = true
+	}
+
+	for _, filterTag := range sa.Tags {
+		if itemTags[filterTag] {
+			return true
+		}
+	}
+
+	return false
+}
+
+// matchesPeopleFilter checks if the item matches the people filter
+func (sa *Adapter) matchesPeopleFilter(item *Item) bool {
+	if len(sa.People) == 0 {
+		return true
+	}
+
+	itemPeople := make(map[string]bool)
+	for _, person := range item.Additional.Person {
+		itemPeople[person.Name] = true
+	}
+
+	for _, filterPerson := range sa.People {
+		if itemPeople[filterPerson] {
+			return true
+		}
+	}
+
+	return false
+}
+
+// mapToAsset converts a Synology Item to an immich-go Asset
+func (sa *Adapter) mapToAsset(item *Item, album *Album) *assets.Asset {
+	// Determine file type
+	ext := strings.ToLower(path.Ext(item.Filename))
+	if ext == "" {
+		// Try to determine from type
+		switch item.Type {
+		case "photo":
+			ext = ".jpg"
+		case "video":
+			ext = ".mp4"
+		}
+	}
+
+	// Create a custom FS that can read from Synology
+	synFS := &synologyFS{
+		client:   sa.client,
+		itemID:   item.ID,
+		cacheKey: item.Additional.Thumbnail.CacheKey,
+		filename: item.Filename,
+		size:     int(item.Filesize),
+	}
+
+	asset := &assets.Asset{
+		File:             fshelper.FSName(synFS, item.Filename),
+		FileSize:         int(item.Filesize),
+		OriginalFileName: item.Filename,
+		FileDate:         item.IndexedAt(),
+		CaptureDate:      item.CaptureTime(),
+		Description:      item.Additional.Description,
+		Latitude:         item.Additional.GPS.Latitude,
+		Longitude:        item.Additional.GPS.Longitude,
+	}
+
+	// Add album if specified
+	if album != nil {
+		asset.Albums = []assets.Album{
+			{
+				Title: album.Name,
+			},
+		}
+	}
+
+	// Add tags
+	for _, tag := range item.Additional.Tag {
+		asset.Tags = append(asset.Tags, assets.Tag{
+			Name: tag.Name,
+		})
+	}
+
+	// Add people as tags (prefixed with "Person: ") since Immich handles faces separately
+	if !sa.SkipFaceData {
+		for _, person := range item.Additional.Person {
+			asset.Tags = append(asset.Tags, assets.Tag{
+				Name: fmt.Sprintf("Person: %s", person.Name),
+			})
+		}
+	}
+
+	// Store original metadata
+	asset.FromApplication = &assets.Metadata{
+		FileName:    item.Filename,
+		DateTaken:   item.CaptureTime(),
+		Description: item.Additional.Description,
+		Latitude:    item.Additional.GPS.Latitude,
+		Longitude:   item.Additional.GPS.Longitude,
+	}
+
+	// Copy tags to metadata
+	for _, tag := range asset.Tags {
+		asset.FromApplication.Tags = append(asset.FromApplication.Tags, tag)
+	}
+
+	return asset
+}
+
+// Ensure Adapter implements adapters.Reader
+var _ adapters.Reader = (*Adapter)(nil)
+
+// synologyFS implements fs.FS to provide access to Synology files
+type synologyFS struct {
+	client   *Client
+	itemID   int
+	cacheKey string
+	filename string
+	size     int
+}
+
+// Open implements fs.FS
+func (s *synologyFS) Open(name string) (fs.File, error) {
+	if name != s.filename {
+		return nil, fmt.Errorf("file not found: %s", name)
+	}
+
+	ctx := context.Background()
+	reader, err := s.client.DownloadItem(ctx, s.itemID, s.cacheKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return &synologyFile{
+		ReadCloser: reader,
+		name:       s.filename,
+		size:       int64(s.size),
+	}, nil
+}
+
+// synologyFile implements fs.File
+type synologyFile struct {
+	io.ReadCloser
+	name string
+	size int64
+	offset int64
+}
+
+func (f *synologyFile) Stat() (fs.FileInfo, error) {
+	return &synologyFileInfo{
+		name: f.name,
+		size: f.size,
+	}, nil
+}
+
+func (f *synologyFile) Read(p []byte) (n int, err error) {
+	n, err = f.ReadCloser.Read(p)
+	f.offset += int64(n)
+	return n, err
+}
+
+func (f *synologyFile) Close() error {
+	return f.ReadCloser.Close()
+}
+
+// synologyFileInfo implements fs.FileInfo
+type synologyFileInfo struct {
+	name string
+	size int64
+}
+
+func (fi *synologyFileInfo) Name() string       { return fi.name }
+func (fi *synologyFileInfo) Size() int64        { return fi.size }
+func (fi *synologyFileInfo) Mode() fs.FileMode  { return 0444 } // Read-only
+func (fi *synologyFileInfo) ModTime() time.Time { return time.Now() }
+func (fi *synologyFileInfo) IsDir() bool        { return false }
+func (fi *synologyFileInfo) Sys() interface{}   { return nil }

--- a/adapters/synology/synology.go
+++ b/adapters/synology/synology.go
@@ -459,10 +459,9 @@ func (sa *Adapter) mapToAssetForLiveImage(item *Item, album *Album, liveFS *syno
 		FileSize:         int(item.Filesize), // Approximate size from API
 		OriginalFileName: item.Filename,
 		FileDate:         item.IndexedAt(),
-		CaptureDate:      item.CaptureTime(),
 		Description:      item.Additional.Description,
-		Latitude:         item.Additional.GPS.Latitude,
-		Longitude:        item.Additional.GPS.Longitude,
+		// Don't set CaptureDate, Latitude, Longitude - let Immich read from EXIF
+		// Synology's metadata may have timezone/format issues
 	}
 
 	// Add album if specified
@@ -527,10 +526,8 @@ func (sa *Adapter) mapToAssetForLiveVideo(item *Item, album *Album, liveFS *syno
 		FileSize:         int(item.Filesize), // Approximate size
 		OriginalFileName: videoFilename,
 		FileDate:         item.IndexedAt(),
-		CaptureDate:      item.CaptureTime(),
 		Description:      item.Additional.Description,
-		Latitude:         item.Additional.GPS.Latitude,
-		Longitude:        item.Additional.GPS.Longitude,
+		// Don't set CaptureDate, Latitude, Longitude - let Immich read from EXIF
 	}
 
 	// Add album if specified
@@ -586,10 +583,8 @@ func (sa *Adapter) mapToAsset(item *Item, album *Album) *assets.Asset {
 		FileSize:         int(item.Filesize),
 		OriginalFileName: item.Filename,
 		FileDate:         item.IndexedAt(),
-		CaptureDate:      item.CaptureTime(),
 		Description:      item.Additional.Description,
-		Latitude:         item.Additional.GPS.Latitude,
-		Longitude:        item.Additional.GPS.Longitude,
+		// Don't set CaptureDate, Latitude, Longitude - let Immich read from EXIF
 	}
 
 	// Add album if specified (with cleaned up name)

--- a/adapters/synology/synology_test.go
+++ b/adapters/synology/synology_test.go
@@ -1,0 +1,101 @@
+package synology
+
+import (
+	"testing"
+	"time"
+
+	mapset "github.com/deckarep/golang-set/v2"
+)
+
+// newTestAdapter returns a minimal Adapter suitable for unit tests that do not
+// require a network connection or an app.Application instance.
+func newTestAdapter() *Adapter {
+	return &Adapter{
+		albumCache:      make(map[string]Album),
+		tagCache:        make(map[string]int),
+		peopleCache:     make(map[string]int),
+		albumImageCache: make(map[string]mapset.Set[int]),
+	}
+}
+
+// ---------------------------------------------------------------------------
+// matchesAlbumFilter
+// ---------------------------------------------------------------------------
+
+func TestMatchesAlbumFilter_NoAlbumsRequested(t *testing.T) {
+	sa := newTestAdapter()
+	// Albums slice is empty → no filter, every item passes
+	item := &Item{ID: 1}
+	if !sa.matchesAlbumFilter(item) {
+		t.Error("expected item to pass when no albums are requested")
+	}
+}
+
+func TestMatchesAlbumFilter_ItemInRequestedAlbum(t *testing.T) {
+	sa := newTestAdapter()
+	sa.Albums = []string{"Vacation"}
+	sa.albumImageCache["Vacation"] = mapset.NewSet(1, 2, 3)
+
+	item := &Item{ID: 2}
+	if !sa.matchesAlbumFilter(item) {
+		t.Error("expected item to pass when it belongs to a requested album")
+	}
+}
+
+func TestMatchesAlbumFilter_ItemNotInRequestedAlbum(t *testing.T) {
+	sa := newTestAdapter()
+	sa.Albums = []string{"Vacation"}
+	sa.albumImageCache["Vacation"] = mapset.NewSet(1, 2, 3)
+
+	item := &Item{ID: 99}
+	if sa.matchesAlbumFilter(item) {
+		t.Error("expected item to be filtered out when it does not belong to any requested album")
+	}
+}
+
+func TestMatchesAlbumFilter_ItemInOneOfMultipleAlbums(t *testing.T) {
+	sa := newTestAdapter()
+	sa.Albums = []string{"Vacation", "Family"}
+	sa.albumImageCache["Vacation"] = mapset.NewSet(1, 2)
+	sa.albumImageCache["Family"] = mapset.NewSet(3, 4)
+
+	item := &Item{ID: 3}
+	if !sa.matchesAlbumFilter(item) {
+		t.Error("expected item to pass when it belongs to at least one requested album")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// correctTimestamp
+// ---------------------------------------------------------------------------
+
+func TestCorrectTimestamp_UTC(t *testing.T) {
+	sa := newTestAdapter()
+	// In UTC there is no offset, so the timestamp should be unchanged.
+	now := time.Now().Unix()
+	got := sa.correctTimestamp(now, time.UTC)
+	if got != now {
+		t.Errorf("UTC: expected %d, got %d", now, got)
+	}
+}
+
+func TestCorrectTimestamp_FixedOffset(t *testing.T) {
+	sa := newTestAdapter()
+	// Use a fixed +8h timezone (Asia/Shanghai-like).
+	// Synology stores local time as a Unix timestamp, so the "wrong" value is
+	// actually local-time seconds since epoch. correctTimestamp should subtract
+	// the UTC offset to obtain the real UTC timestamp.
+	loc := time.FixedZone("UTC+8", 8*60*60)
+
+	// Pick a reference time: 2024-01-15 12:00:00 UTC
+	realUTC := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC).Unix()
+	// Synology would store 2024-01-15 20:00:00 as if it were a UTC timestamp
+	synologyWrong := realUTC + int64(8*60*60)
+
+	got := sa.correctTimestamp(synologyWrong, loc)
+	if got != realUTC {
+		t.Errorf("UTC+8: expected %d (%s), got %d (%s)",
+			realUTC, time.Unix(realUTC, 0).UTC(),
+			got, time.Unix(got, 0).UTC())
+	}
+}

--- a/app/log.go
+++ b/app/log.go
@@ -167,6 +167,7 @@ func (log *Log) setHandlers(file, con io.Writer) {
 			TimeFormat: time.DateTime,
 			NoColor:    true,
 			Theme:      console.NewDefaultTheme(),
+			AddSource:  true,
 		}))
 	}
 
@@ -178,6 +179,7 @@ func (log *Log) setHandlers(file, con io.Writer) {
 			TimeFormat: time.DateTime,
 			NoColor:    false,
 			Theme:      console.NewDefaultTheme(),
+			AddSource:  true,
 		}))
 	}
 

--- a/app/upload/run.go
+++ b/app/upload/run.go
@@ -317,7 +317,10 @@ func (uc *UpCmd) handleGroup(ctx context.Context, g *assets.Group) error {
 	// Upload assets from the group
 	for _, a := range g.Assets {
 		err := uc.handleAsset(ctx, a)
-		errGroup = errors.Join(err)
+		if err != nil {
+			uc.app.Log().Error("can't handle asset", "asset", a.File, "err", err)
+		}
+		errGroup = errors.Join(errGroup, err)
 	}
 
 	// Manage groups

--- a/app/upload/upload.go
+++ b/app/upload/upload.go
@@ -10,6 +10,7 @@ import (
 	"github.com/simulot/immich-go/adapters/fromimmich"
 	gp "github.com/simulot/immich-go/adapters/googlePhotos"
 	"github.com/simulot/immich-go/adapters/shared"
+	"github.com/simulot/immich-go/adapters/synology"
 	"github.com/simulot/immich-go/app"
 	"github.com/simulot/immich-go/immich"
 	"github.com/simulot/immich-go/internal/assets"
@@ -112,6 +113,7 @@ func NewUploadCommand(ctx context.Context, app *app.Application) *cobra.Command 
 	cmd.AddCommand(folder.NewFromPicasaCommand(ctx, cmd, app, uc))
 	cmd.AddCommand(gp.NewFromGooglePhotosCommand(ctx, cmd, app, uc))
 	cmd.AddCommand(fromimmich.NewFromImmichCommand(ctx, cmd, app, uc))
+	cmd.AddCommand(synology.NewFromSynologyCommand(ctx, cmd, app, uc))
 
 	cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
 		// Initialize the FileProcessor (tracker + logger + event bus)

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/deckarep/golang-set/v2 v2.8.0 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6N
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/deckarep/golang-set/v2 v2.8.0 h1:swm0rlPCmdWn9mESxKOjWk8hXSqoxOp+ZlfuyaAdFlQ=
+github.com/deckarep/golang-set/v2 v2.8.0/go.mod h1:VAky9rY/yGXJOLEDv3OMci+7wtDpOF4IN+y82NBOac4=
 github.com/disintegration/imaging v1.6.2 h1:w1LecBlG2Lnp8B3jk5zSuNqd7b4DXhcjwek1ei82L+c=
 github.com/disintegration/imaging v1.6.2/go.mod h1:44/5580QXChDfwIclfc/PCwrr44amcmDAg8hxG0Ewe4=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=

--- a/internal/assets/asset.go
+++ b/internal/assets/asset.go
@@ -36,6 +36,7 @@ const (
 	VisibilityUnknown  Visibility = ""
 )
 
+type CloseOption func(*Asset) error
 type Asset struct {
 	// File system and file name
 	File     fshelper.FSAndName
@@ -72,6 +73,8 @@ type Asset struct {
 
 	// buffer management
 	cacheReader *cachereader.CacheReader
+
+	closeOptions []CloseOption
 }
 
 // Kind is the probable type of the image
@@ -97,6 +100,14 @@ type NameInfo struct {
 	Taken      time.Time // date taken
 	IsCover    bool      // is this is the cover if the series
 	IsModified bool      // is this is a modified version of the original
+}
+
+func (a *Asset) AddCloseOption(o CloseOption) {
+	if a.closeOptions == nil {
+		a.closeOptions = []CloseOption{o}
+		return
+	}
+	a.closeOptions = append(a.closeOptions, o)
 }
 
 func (a *Asset) SetNameInfo(ni NameInfo) {
@@ -186,7 +197,7 @@ func (a *Asset) GetChecksum() (string, error) {
 		return "", errors.New("no file to compute checksum")
 	}
 
-	f, err := a.File.Open()
+	f, err := a.OpenFile()
 	if err != nil {
 		return "", err
 	}

--- a/internal/assets/assetFile.go
+++ b/internal/assets/assetFile.go
@@ -36,10 +36,17 @@ func (a *Asset) OpenFile() (osfs.OSFS, error) {
 
 // Close close the temporary file  and close the source
 func (a *Asset) Close() error {
-	if a.cacheReader == nil {
-		return nil
+	if a.cacheReader != nil {
+		if err := a.cacheReader.Close(); err != nil {
+			return err
+		}
 	}
-	return a.cacheReader.Close()
+	for _, o := range a.closeOptions {
+		if err := o(a); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 /*

--- a/internal/assets/asset_close_test.go
+++ b/internal/assets/asset_close_test.go
@@ -1,0 +1,57 @@
+package assets
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestClose_NilCacheReader verifies that Close does not panic when the asset
+// has never been opened (cacheReader is nil), which was the bug fixed by
+// inverting the nil check in assetFile.go.
+func TestClose_NilCacheReader(t *testing.T) {
+	a := &Asset{}
+	if err := a.Close(); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+// TestClose_RunsAllCloseOptions verifies that every registered CloseOption is
+// called, and that the results are propagated correctly.
+func TestClose_RunsAllCloseOptions(t *testing.T) {
+	called := make([]bool, 3)
+	a := &Asset{}
+	for i := range called {
+		i := i
+		a.AddCloseOption(func(_ *Asset) error {
+			called[i] = true
+			return nil
+		})
+	}
+
+	if err := a.Close(); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	for i, c := range called {
+		if !c {
+			t.Errorf("closeOption[%d] was not called", i)
+		}
+	}
+}
+
+// TestClose_StopsOnFirstCloseOptionError verifies that the first error from a
+// CloseOption is returned immediately.
+func TestClose_StopsOnFirstCloseOptionError(t *testing.T) {
+	sentinel := errors.New("close failed")
+	secondCalled := false
+	a := &Asset{}
+	a.AddCloseOption(func(_ *Asset) error { return sentinel })
+	a.AddCloseOption(func(_ *Asset) error { secondCalled = true; return nil })
+
+	err := a.Close()
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected sentinel error, got %v", err)
+	}
+	if secondCalled {
+		t.Error("second CloseOption should not have been called after the first returned an error")
+	}
+}

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@
 ## 🌟 Key Features
 
 - **Simple Installation**: No NodeJS or Docker required
-- **Multiple Sources**: Upload from Google Photos Takeouts, iCloud, local folders, ZIP archives, and other Immich servers
+- **Multiple Sources**: Upload from Google Photos Takeouts, iCloud, local folders, ZIP archives, Synology Photos, and other Immich servers
 - **Large Collections**: Successfully handles 100,000+ photos
 - **Smart Management**: Duplicate detection, burst photo stacking, RAW+JPEG handling
 - **Cross-Platform**: Available for Windows, macOS, Linux, and FreeBSD
@@ -27,7 +27,11 @@ immich-go upload from-folder --server=http://your-ip:2283 --api-key=your-api-key
 immich-go upload from-google-photos --server=http://your-ip:2283 --api-key=your-api-key /path/to/takeout-*.zip
 
 # Archive photos from Immich server
-immich-go archive from-immich --server=http://your-ip:2283 --api-key=your-api-key --write-to-folder=/path/to/archive
+immich-go archive from-immich --from-server=http://your-ip:2283 --from-api-key=your-api-key --write-to-folder=/path/to/archive
+
+# Migrate from Synology Photos
+immich-go upload from-synology --server=http://your-ip:2283 --api-key=your-api-key \
+  --synology-url=https://nas:5001 --synology-user=admin --synology-pass=secret
 ```
 
 ### 3. Requirements
@@ -66,6 +70,7 @@ Here's a brief overview of the main upload commands:
 *   **`from-immich`**: A server-to-server migration tool that allows you to copy assets between two Immich instances with fine-grained filtering.
 *   **`from-picasa`**: A specialized version of `from-folder` that automatically reads `.picasa.ini` files to restore your Picasa album organization.
 *   **`from-icloud`**: Another specialized command that handles the complexity of an iCloud Photos takeout, correctly identifying creation dates and album structures from the included CSV files.
+*   **`from-synology`**: Migrate from Synology Photos. Imports photos, videos, albums, tags, and face recognition data (converted to tags) from your Synology NAS.
 
 ### Leveraging Immich's Features
 
@@ -82,6 +87,7 @@ For a detailed explanation of how each upload command works, please see the [Upl
 
 - **Google Photos Migration**: [Complete guide](docs/best-practices.md#google-photos-migration)
 - **iCloud Import**: [Step-by-step instructions](docs/examples.md#icloud-import)
+- **Synology Photos Migration**: Import from Synology Photos with albums, tags, and face recognition preserved
 - **Server Migration**: [Transfer between Immich instances](docs/examples.md#server-migration)
 - **Bulk Organization**: [Stacking and tagging strategies](docs/best-practices.md#organization-strategies)
 


### PR DESCRIPTION
## Summary

Add a new `upload from-synology` command that migrates photos from Synology Photos to Immich.

- **New Synology Photos adapter** (`adapters/synology/`) with full API client for `SYNO.Foto.*` endpoints, supporting authentication with SynoToken
- **Albums, tags, people** — imported with metadata preserved; face recognition data mapped to `Person: <name>` tags
- **Live photos** — handled via ZIP download API (image + video bundled), with fallback for single-file responses
- **Filtering** — `--albums`, `--tags`, `--people` flags to limit scope of import
- **Timestamp correction** — compensates for Synology's local-time-as-UTC storage
- **Bug fixes** in `Asset.Close()` (nil pointer), `errors.Join` accumulation, and temp file cleanup
- **Unit tests** for `Asset.Close`, album filter, and timestamp correction logic

## Usage

```sh
immich-go upload from-synology \
  --server=http://immich:2283 --api-key=<key> \
  --synology-url=https://nas:5001 \
  --synology-user=admin --synology-pass=secret
```

## Tested with

| Component | Version |
|-----------|---------|
| Synology Photos | 1.8.2-10090 |
| Immich | 2.5.6 |

## Test plan

- [x] Unit tests pass (`go test ./...`)
- [x] Build check (`go build ./...`)
- [x] Login to Synology and browse all items
- [x] Filter by album / tag / people
- [x] Live photo upload (ZIP and single-file response paths)
- [x] Timestamps correct in Immich after upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)