### PR TITLE
Add manage command with people-album-sync subcommand

### DIFF
--- a/app/manage/config.go
+++ b/app/manage/config.go
@@ -1,0 +1,69 @@
+package manage
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// PeopleSelector identifies people by name and/or Immich UUID.
+type PeopleSelector struct {
+	Names []string `yaml:"names"`
+	IDs   []string `yaml:"ids"`
+}
+
+// AlbumMapping maps one album to a set of people whose photos should be in it.
+type AlbumMapping struct {
+	Album   string         `yaml:"album,omitempty"`    // album by name (resolved at runtime)
+	AlbumID string         `yaml:"album_id,omitempty"` // album by Immich UUID
+	People  PeopleSelector `yaml:"people"`
+}
+
+// ManageConfig is the top-level YAML configuration for the manage command.
+// Each subcommand has its own section.
+type ManageConfig struct {
+	PeopleAlbumSync *PeopleAlbumSyncConfig `yaml:"people-album-sync"`
+}
+
+// PeopleAlbumSyncConfig holds the configuration for the people-album-sync subcommand.
+type PeopleAlbumSyncConfig struct {
+	Albums []AlbumMapping `yaml:"albums"`
+}
+
+// ParseConfig reads and validates a YAML config file.
+func ParseConfig(path string) (*ManageConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading config: %w", err)
+	}
+
+	var cfg ManageConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parsing config: %w", err)
+	}
+
+	return &cfg, nil
+}
+
+func (c *PeopleAlbumSyncConfig) validate() error {
+	if len(c.Albums) == 0 {
+		return fmt.Errorf("config: people-album-sync.albums list is empty")
+	}
+	for i, a := range c.Albums {
+		if a.Album == "" && a.AlbumID == "" {
+			return fmt.Errorf("config: people-album-sync.albums entry %d has no 'album' name or 'album_id'", i)
+		}
+		if len(a.People.Names) == 0 && len(a.People.IDs) == 0 {
+			return fmt.Errorf("config: people-album-sync.albums entry %d (%s) has no people specified", i, a.albumLabel())
+		}
+	}
+	return nil
+}
+
+func (a *AlbumMapping) albumLabel() string {
+	if a.Album != "" {
+		return a.Album
+	}
+	return a.AlbumID
+}

--- a/app/manage/config_test.go
+++ b/app/manage/config_test.go
@@ -1,0 +1,134 @@
+package manage
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseConfig(t *testing.T) {
+	yaml := `people-album-sync:
+  albums:
+    - album: "Family Vacation"
+      people:
+        names: ["Alice", "Bob"]
+        ids: ["uuid-1"]
+    - album: "Kids"
+      people:
+        names: ["Alice"]
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "manage.yaml")
+	if err := os.WriteFile(path, []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := ParseConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.PeopleAlbumSync == nil {
+		t.Fatal("expected people-album-sync section")
+	}
+
+	if len(cfg.PeopleAlbumSync.Albums) != 2 {
+		t.Fatalf("expected 2 albums, got %d", len(cfg.PeopleAlbumSync.Albums))
+	}
+
+	a0 := cfg.PeopleAlbumSync.Albums[0]
+	if a0.Album != "Family Vacation" {
+		t.Errorf("expected album name 'Family Vacation', got %q", a0.Album)
+	}
+	if len(a0.People.Names) != 2 {
+		t.Errorf("expected 2 people names, got %d", len(a0.People.Names))
+	}
+	if len(a0.People.IDs) != 1 {
+		t.Errorf("expected 1 people ID, got %d", len(a0.People.IDs))
+	}
+
+	a1 := cfg.PeopleAlbumSync.Albums[1]
+	if a1.Album != "Kids" {
+		t.Errorf("expected album name 'Kids', got %q", a1.Album)
+	}
+	if len(a1.People.Names) != 1 {
+		t.Errorf("expected 1 people name, got %d", len(a1.People.Names))
+	}
+	if len(a1.People.IDs) != 0 {
+		t.Errorf("expected 0 people IDs, got %d", len(a1.People.IDs))
+	}
+}
+
+func TestParseConfig_AlbumByID(t *testing.T) {
+	yaml := `people-album-sync:
+  albums:
+    - album_id: "album-uuid-123"
+      people:
+        names: ["Alice"]
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "manage.yaml")
+	if err := os.WriteFile(path, []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := ParseConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.PeopleAlbumSync.Albums[0].AlbumID != "album-uuid-123" {
+		t.Errorf("expected album_id 'album-uuid-123', got %q", cfg.PeopleAlbumSync.Albums[0].AlbumID)
+	}
+}
+
+func TestParseConfig_ValidationErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+	}{
+		{
+			name: "no album identifier",
+			yaml: `people-album-sync:
+  albums:
+    - people:
+        names: ["Alice"]
+`,
+		},
+		{
+			name: "no people specified",
+			yaml: `people-album-sync:
+  albums:
+    - album: "Test"
+      people:
+`,
+		},
+		{
+			name: "empty albums list",
+			yaml: `people-album-sync:
+  albums: []
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "manage.yaml")
+			if err := os.WriteFile(path, []byte(tt.yaml), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			cfg, err := ParseConfig(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if cfg.PeopleAlbumSync == nil {
+				t.Fatal("expected people-album-sync section")
+			}
+			err = cfg.PeopleAlbumSync.validate()
+			if err == nil {
+				t.Fatal("expected validation error, got nil")
+			}
+		})
+	}
+}

--- a/app/manage/manage.go
+++ b/app/manage/manage.go
@@ -1,0 +1,23 @@
+package manage
+
+import (
+	"context"
+
+	"github.com/simulot/immich-go/app"
+	"github.com/spf13/cobra"
+)
+
+// NewManageCommand creates the parent cobra command for manage subcommands.
+func NewManageCommand(ctx context.Context, a *app.Application) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "manage",
+		Short: "Manage Immich resources",
+		Long:  "Parent command for managing Immich resources. Use subcommands for specific operations.",
+	}
+
+	cmd.AddCommand(
+		NewPeopleAlbumSyncCommand(ctx, a),
+	)
+
+	return cmd
+}

--- a/app/manage/manage_test.go
+++ b/app/manage/manage_test.go
@@ -1,0 +1,341 @@
+package manage
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/simulot/immich-go/immich"
+)
+
+// newTestClient creates an ImmichClient pointed at a test server.
+func newTestClient(t *testing.T, handler http.Handler) *immich.ImmichClient {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	client, err := immich.NewImmichClient(server.URL, "test-key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client
+}
+
+func TestResolvePeopleIDs(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/api/people") {
+			resp := immich.PeopleResponseDto{
+				People: []immich.PersonResponseDto{
+					{ID: "person-1", Name: "Alice"},
+					{ID: "person-2", Name: "Bob"},
+					{ID: "person-3", Name: "Charlie"},
+				},
+				HasNextPage: false,
+				Total:       3,
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(resp)
+			return
+		}
+		http.NotFound(w, r)
+	})
+
+	client := newTestClient(t, handler)
+	ctx := context.Background()
+
+	sel := PeopleSelector{
+		Names: []string{"Alice", "Bob"},
+		IDs:   []string{"direct-uuid-1"},
+	}
+
+	ids, err := resolvePeopleIDs(ctx, client, sel)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(ids) != 3 {
+		t.Fatalf("expected 3 IDs, got %d: %v", len(ids), ids)
+	}
+
+	expected := map[string]bool{"person-1": true, "person-2": true, "direct-uuid-1": true}
+	for _, id := range ids {
+		if !expected[id] {
+			t.Errorf("unexpected ID %q", id)
+		}
+	}
+}
+
+// searchResponse builds the JSON body for the /search/metadata endpoint.
+// nextPage should be "0" to indicate no more pages.
+func searchResponse(w http.ResponseWriter, assetIDs []string, nextPage string) {
+	type item struct {
+		ID string `json:"id"`
+	}
+	items := make([]item, len(assetIDs))
+	for i, id := range assetIDs {
+		items[i] = item{ID: id}
+	}
+	resp := struct {
+		Assets struct {
+			Total    int    `json:"total"`
+			Count    int    `json:"count"`
+			Items    []item `json:"items"`
+			NextPage string `json:"nextPage"`
+		} `json:"assets"`
+	}{}
+	resp.Assets.Total = len(assetIDs)
+	resp.Assets.Count = len(assetIDs)
+	resp.Assets.Items = items
+	resp.Assets.NextPage = nextPage
+	json.NewEncoder(w).Encode(resp)
+}
+
+// peopleResponse writes a standard people response.
+func peopleResponse(w http.ResponseWriter, people []immich.PersonResponseDto) {
+	json.NewEncoder(w).Encode(immich.PeopleResponseDto{
+		People:      people,
+		HasNextPage: false,
+		Total:       len(people),
+	})
+}
+
+func TestResolvePeopleIDs_NameNotFound(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(immich.PeopleResponseDto{
+			People:      []immich.PersonResponseDto{},
+			HasNextPage: false,
+			Total:       0,
+		})
+	})
+
+	client := newTestClient(t, handler)
+	ctx := context.Background()
+
+	sel := PeopleSelector{Names: []string{"NonExistent"}}
+	_, err := resolvePeopleIDs(ctx, client, sel)
+	if err == nil {
+		t.Fatal("expected error for unresolved name, got nil")
+	}
+}
+
+func TestSyncFlow_AddsOnlyMissingAssets(t *testing.T) {
+	var mu sync.Mutex
+	var addedAssets []string
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/api/people"):
+			peopleResponse(w, []immich.PersonResponseDto{{ID: "person-alice", Name: "Alice"}})
+
+		case r.Method == "GET" && r.URL.Path == "/api/albums" && r.URL.Query().Get("assetId") == "":
+			json.NewEncoder(w).Encode([]immich.AlbumSimplified{
+				{ID: "album-1", AlbumName: "Family", AssetIds: []string{"asset-1"}},
+			})
+
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/api/albums/album-1"):
+			json.NewEncoder(w).Encode(immich.AlbumContent{
+				ID:        "album-1",
+				AlbumName: "Family",
+				AssetIDs:  []string{"asset-1"},
+			})
+
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/api/search/metadata"):
+			searchResponse(w, []string{"asset-1", "asset-2", "asset-3"}, "0")
+
+		case r.Method == "PUT" && strings.Contains(r.URL.Path, "/albums/") && strings.Contains(r.URL.Path, "/assets"):
+			var body struct {
+				IDS []string `json:"ids"`
+			}
+			json.NewDecoder(r.Body).Decode(&body)
+			mu.Lock()
+			addedAssets = append(addedAssets, body.IDS...)
+			mu.Unlock()
+			results := make([]immich.UpdateAlbumResult, len(body.IDS))
+			for i, id := range body.IDS {
+				results[i] = immich.UpdateAlbumResult{ID: id, Success: true}
+			}
+			json.NewEncoder(w).Encode(results)
+
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	client := newTestClient(t, handler)
+	ctx := context.Background()
+
+	cfg := &PeopleAlbumSyncConfig{
+		Albums: []AlbumMapping{
+			{
+				Album:  "Family",
+				People: PeopleSelector{Names: []string{"Alice"}},
+			},
+		},
+	}
+
+	sc := &PeopleAlbumSyncCmd{}
+	sc.client.Immich = client
+
+	err := sc.run(ctx, slog.Default(), cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Should only add asset-2 and asset-3 (asset-1 already in album)
+	// Note: GetFilteredAssetsFn runs 3 concurrent queries (one per visibility),
+	// so we may get duplicates, if so use a set to deduplicate.
+	addedSet := map[string]bool{}
+	for _, id := range addedAssets {
+		addedSet[id] = true
+	}
+	if addedSet["asset-1"] {
+		t.Error("asset-1 should NOT have been added (already in album)")
+	}
+	if !addedSet["asset-2"] {
+		t.Error("asset-2 should have been added")
+	}
+	if !addedSet["asset-3"] {
+		t.Error("asset-3 should have been added")
+	}
+}
+
+func TestSyncFlow_CreatesAlbumIfMissing(t *testing.T) {
+	albumCreated := false
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/api/people"):
+			peopleResponse(w, []immich.PersonResponseDto{{ID: "person-1", Name: "Alice"}})
+
+		case r.Method == "GET" && r.URL.Path == "/api/albums" && r.URL.Query().Get("assetId") == "":
+			json.NewEncoder(w).Encode([]immich.AlbumSimplified{})
+
+		case r.Method == "POST" && r.URL.Path == "/api/albums":
+			albumCreated = true
+			json.NewEncoder(w).Encode(immich.AlbumSimplified{
+				ID:        "new-album-id",
+				AlbumName: "New Album",
+			})
+
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/api/albums/new-album-id"):
+			json.NewEncoder(w).Encode(immich.AlbumContent{
+				ID:        "new-album-id",
+				AlbumName: "New Album",
+				AssetIDs:  []string{},
+			})
+
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/api/search/metadata"):
+			searchResponse(w, []string{"asset-1"}, "0")
+
+		case r.Method == "PUT" && strings.Contains(r.URL.Path, "/assets"):
+			var body struct {
+				IDS []string `json:"ids"`
+			}
+			json.NewDecoder(r.Body).Decode(&body)
+			results := make([]immich.UpdateAlbumResult, len(body.IDS))
+			for i, id := range body.IDS {
+				results[i] = immich.UpdateAlbumResult{ID: id, Success: true}
+			}
+			json.NewEncoder(w).Encode(results)
+
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	client := newTestClient(t, handler)
+	ctx := context.Background()
+
+	cfg := &PeopleAlbumSyncConfig{
+		Albums: []AlbumMapping{
+			{
+				Album:  "New Album",
+				People: PeopleSelector{Names: []string{"Alice"}},
+			},
+		},
+	}
+
+	sc := &PeopleAlbumSyncCmd{}
+	sc.client.Immich = client
+
+	err := sc.run(ctx, slog.Default(), cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !albumCreated {
+		t.Error("expected album to be created")
+	}
+}
+
+func TestSyncFlow_NeverCallsDestructiveAPIs(t *testing.T) {
+	var mu sync.Mutex
+	destructiveCalled := ""
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.Method == "DELETE" {
+			mu.Lock()
+			destructiveCalled = "DELETE " + r.URL.Path
+			mu.Unlock()
+			http.Error(w, "should not be called", http.StatusInternalServerError)
+			return
+		}
+
+		switch {
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/api/people"):
+			peopleResponse(w, []immich.PersonResponseDto{{ID: "p1", Name: "Alice"}})
+		case r.Method == "GET" && r.URL.Path == "/api/albums" && r.URL.Query().Get("assetId") == "":
+			json.NewEncoder(w).Encode([]immich.AlbumSimplified{
+				{ID: "a1", AlbumName: "Test", AssetIds: []string{}},
+			})
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/api/albums/a1"):
+			json.NewEncoder(w).Encode(immich.AlbumContent{ID: "a1", AlbumName: "Test", AssetIDs: []string{}})
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/api/search/metadata"):
+			searchResponse(w, []string{"x1"}, "0")
+		case r.Method == "PUT" && strings.Contains(r.URL.Path, "/assets"):
+			var body struct {
+				IDS []string `json:"ids"`
+			}
+			json.NewDecoder(r.Body).Decode(&body)
+			results := []immich.UpdateAlbumResult{{ID: "x1", Success: true}}
+			json.NewEncoder(w).Encode(results)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	client := newTestClient(t, handler)
+	ctx := context.Background()
+
+	cfg := &PeopleAlbumSyncConfig{
+		Albums: []AlbumMapping{{
+			Album:  "Test",
+			People: PeopleSelector{Names: []string{"Alice"}},
+		}},
+	}
+
+	sc := &PeopleAlbumSyncCmd{}
+	sc.client.Immich = client
+
+	err := sc.run(ctx, slog.Default(), cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if destructiveCalled != "" {
+		t.Fatalf("destructive API call made: %s", destructiveCalled)
+	}
+}

--- a/app/manage/people_album_sync.go
+++ b/app/manage/people_album_sync.go
@@ -1,0 +1,189 @@
+package manage
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"github.com/simulot/immich-go/app"
+	"github.com/simulot/immich-go/immich"
+	"github.com/spf13/cobra"
+)
+
+// PeopleAlbumSyncCmd holds the state for the people-album-sync subcommand.
+type PeopleAlbumSyncCmd struct {
+	ConfigFile string
+	client     app.Client
+}
+
+// NewPeopleAlbumSyncCommand creates the cobra command for syncing people to albums.
+func NewPeopleAlbumSyncCommand(ctx context.Context, a *app.Application) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "people-album-sync [flags]",
+		Short: "Sync people to album mappings",
+		Long:  "Reads a YAML config that maps albums to people and ensures each album contains all photos of its mapped people. Additive only, never removes or deletes.",
+	}
+
+	syncCmd := &PeopleAlbumSyncCmd{}
+	cmd.Flags().StringVar(&syncCmd.ConfigFile, "config", "", "Path to the manage YAML config file (required)")
+	_ = cmd.MarkFlagRequired("config")
+	syncCmd.client.RegisterFlags(cmd.Flags(), "")
+	cmd.TraverseChildren = true
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+		err := syncCmd.client.Open(ctx, a)
+		if err != nil {
+			return err
+		}
+
+		manageCfg, err := ParseConfig(syncCmd.ConfigFile)
+		if err != nil {
+			return err
+		}
+
+		if manageCfg.PeopleAlbumSync == nil {
+			return fmt.Errorf("config: missing 'people-album-sync' section")
+		}
+
+		if err := manageCfg.PeopleAlbumSync.validate(); err != nil {
+			return err
+		}
+
+		return syncCmd.run(ctx, a.Log().Logger, manageCfg.PeopleAlbumSync)
+	}
+
+	return cmd
+}
+
+func (syncCmd *PeopleAlbumSyncCmd) run(ctx context.Context, log *slog.Logger, cfg *PeopleAlbumSyncConfig) error {
+	immichClient := syncCmd.client.Immich
+
+	for _, mapping := range cfg.Albums {
+		label := mapping.albumLabel()
+		log.Info("Processing album mapping", "album", label)
+
+		peopleIDs, err := resolvePeopleIDs(ctx, immichClient, mapping.People)
+		if err != nil {
+			return fmt.Errorf("album %q: %w", label, err)
+		}
+		log.Info("Resolved people", "album", label, "people_ids", peopleIDs)
+
+		albumID, err := resolveOrCreateAlbum(ctx, immichClient, mapping, log)
+		if err != nil {
+			return fmt.Errorf("album %q: %w", label, err)
+		}
+		log.Info("Resolved album", "album", label, "album_id", albumID)
+
+		albumInfo, err := immichClient.GetAlbumInfo(ctx, albumID, true)
+		if err != nil {
+			return fmt.Errorf("album %q: getting album info: %w", label, err)
+		}
+		existingAssets := toSet(albumInfo.AssetIDs)
+
+		so := immich.SearchOptions().WithPeople(peopleIDs...)
+		var mu sync.Mutex
+		toAddSet := make(map[string]bool)
+		err = immichClient.GetFilteredAssetsFn(ctx, so, func(asset *immich.Asset) error {
+			mu.Lock()
+			defer mu.Unlock()
+			if !existingAssets[asset.ID] {
+				toAddSet[asset.ID] = true
+			}
+			return nil
+		})
+		if err != nil {
+			return fmt.Errorf("album %q: searching assets: %w", label, err)
+		}
+
+		toAdd := make([]string, 0, len(toAddSet))
+		for id := range toAddSet {
+			toAdd = append(toAdd, id)
+		}
+
+		if len(toAdd) == 0 {
+			log.Info("Album already up to date", "album", label)
+			continue
+		}
+
+		log.Info("Adding assets to album", "album", label, "count", len(toAdd))
+		batchSize := 500
+		for i := 0; i < len(toAdd); i += batchSize {
+			end := min(i+batchSize, len(toAdd))
+			batch := toAdd[i:end]
+			results, err := immichClient.AddAssetToAlbum(ctx, albumID, batch)
+			if err != nil {
+				return fmt.Errorf("album %q: adding assets: %w", label, err)
+			}
+			added := 0
+			for _, r := range results {
+				if r.Success {
+					added++
+				}
+			}
+			log.Info("Batch complete", "album", label, "added", added, "batch_size", len(batch))
+		}
+	}
+
+	return nil
+}
+
+// resolvePeopleIDs converts a PeopleSelector (names + direct IDs) into a flat list of Immich person UUIDs.
+func resolvePeopleIDs(ctx context.Context, immichClient immich.ImmichInterface, sel PeopleSelector) ([]string, error) {
+	var ids []string
+
+	ids = append(ids, sel.IDs...)
+
+	if len(sel.Names) > 0 {
+		icP, ok := immichClient.(immich.ImmichPeopleInterface)
+		if !ok {
+			return nil, fmt.Errorf("immich client does not support people API")
+		}
+		peopleMap, err := icP.GetPeopleByNames(ctx, sel.Names)
+		if err != nil {
+			return nil, fmt.Errorf("resolving people names: %w", err)
+		}
+		for _, name := range sel.Names {
+			person, found := peopleMap[name]
+			if !found || person == nil {
+				return nil, fmt.Errorf("person %q not found in Immich", name)
+			}
+			ids = append(ids, person.ID)
+		}
+	}
+
+	return ids, nil
+}
+
+// resolveOrCreateAlbum finds an existing album by name/ID or creates a new one.
+func resolveOrCreateAlbum(ctx context.Context, immichClient immich.ImmichInterface, mapping AlbumMapping, log *slog.Logger) (string, error) {
+	if mapping.AlbumID != "" {
+		return mapping.AlbumID, nil
+	}
+
+	albums, err := immichClient.GetAllAlbums(ctx)
+	if err != nil {
+		return "", fmt.Errorf("listing albums: %w", err)
+	}
+	for _, album := range albums {
+		if album.AlbumName == mapping.Album {
+			return album.ID, nil
+		}
+	}
+
+	log.Info("Album not found, creating", "album", mapping.Album)
+	album, err := immichClient.CreateAlbum(ctx, mapping.Album, "", nil)
+	if err != nil {
+		return "", fmt.Errorf("creating album: %w", err)
+	}
+	return album.ID, nil
+}
+
+func toSet(ids []string) map[string]bool {
+	m := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		m[id] = true
+	}
+	return m
+}

--- a/app/root/rootCmd.go
+++ b/app/root/rootCmd.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/simulot/immich-go/app"
 	"github.com/simulot/immich-go/app/archive"
+	"github.com/simulot/immich-go/app/manage"
 	"github.com/simulot/immich-go/app/stack"
 	"github.com/simulot/immich-go/app/upload"
 	"github.com/simulot/immich-go/app/version"
@@ -42,6 +43,7 @@ func RootImmichGoCommand(ctx context.Context) (*cobra.Command, *app.Application)
 		upload.NewUploadCommand(ctx, a),   // Upload command for uploading assets
 		archive.NewArchiveCommand(ctx, a), // Archive command for archiving assets
 		stack.NewStackCommand(ctx, a),     // Stack command for managing stacks
+		manage.NewManageCommand(ctx, a),   // Manage command for people-to-album sync
 	)
 
 	// PersistentPreRunE is executed before any command runs, used for initialization


### PR DESCRIPTION
The manage command addresses the missing piece between Immich's people-tagging and album organization, right now there's no declarative way to say "keep this album in sync with these people" without manual intervention or one-off scripts.

Why did I use immich-go as base:
- immich client package already provided witha solid foundation and no new API plumbing was needed.
- app.Client provided connection, auth, and --dry-run come for free via RegisterFlags / Open.
- The app using Cobra wiring was helpful as it was pretty straight forward to add a single AddCommand call in rootCmd.go, same pattern as stack.
- Typed DTOs — PeopleResponseDto, AlbumContent, UpdateAlbumResult etc. mean the mock test handlers map directly to real response shapes and I could reuse them for tests.

PLEASE, let me know if this package is only ever intended to be a sync client and should not be extended. I shall keepit in my fork

## Notes
- Adds a new `manage` CLI command and a subsequent subcommand that syncs people to albums based on a YAML config
- Resolves people by name or Immich UUID, creates albums if missing, and adds only photos not already in the album
- All operations are strictly additive,  no deletes or removals from albums But the API key with right permissions should definitely used 

## Tests
- Unit tests for YAML config parsing and validation
- Tests verifying only missing assets are added
- Test verifying albums are created when missing
- Safety test verifying no destructive (DELETE) API calls are made
- Full project test suite passes with no regressions