### PR TITLE
Manage

### DIFF
--- a/app/manage/config.go
+++ b/app/manage/config.go
@@ -7,6 +7,16 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// SyncMode controls how multiple people are matched when searching for assets.
+type SyncMode string
+
+const (
+	// ModeAll returns only photos where all listed people appear together.
+	ModeAll SyncMode = "all"
+	// ModeAny returns photos where any listed person appears, even solo.
+	ModeAny SyncMode = "any"
+)
+
 // PeopleSelector identifies people by name and/or Immich UUID.
 type PeopleSelector struct {
 	Names []string `yaml:"names"`
@@ -18,6 +28,7 @@ type AlbumMapping struct {
 	Album   string         `yaml:"album,omitempty"`    // album by name (resolved at runtime)
 	AlbumID string         `yaml:"album_id,omitempty"` // album by Immich UUID
 	People  PeopleSelector `yaml:"people"`
+	Mode    SyncMode       `yaml:"mode,omitempty"` // "all" (default): only photos with everyone; "any": photos with any listed person
 }
 
 // ManageConfig is the top-level YAML configuration for the manage command.
@@ -50,12 +61,22 @@ func (c *PeopleAlbumSyncConfig) validate() error {
 	if len(c.Albums) == 0 {
 		return fmt.Errorf("config: people-album-sync.albums list is empty")
 	}
-	for i, a := range c.Albums {
+	for i := range c.Albums {
+		a := &c.Albums[i]
 		if a.Album == "" && a.AlbumID == "" {
 			return fmt.Errorf("config: people-album-sync.albums entry %d has no 'album' name or 'album_id'", i)
 		}
+		if a.Album != "" && a.AlbumID != "" {
+			return fmt.Errorf("config: people-album-sync.albums entry %d has both 'album' and 'album_id'; specify only one", i)
+		}
 		if len(a.People.Names) == 0 && len(a.People.IDs) == 0 {
 			return fmt.Errorf("config: people-album-sync.albums entry %d (%s) has no people specified", i, a.albumLabel())
+		}
+		if a.Mode != "" && a.Mode != ModeAll && a.Mode != ModeAny {
+			return fmt.Errorf("config: people-album-sync.albums entry %d (%s) has invalid mode %q (must be \"all\" or \"any\")", i, a.albumLabel(), a.Mode)
+		}
+		if a.Mode == "" {
+			a.Mode = ModeAll
 		}
 	}
 	return nil

--- a/app/manage/config.go
+++ b/app/manage/config.go
@@ -1,0 +1,69 @@
+package manage
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// PeopleSelector identifies people by name and/or Immich UUID.
+type PeopleSelector struct {
+	Names []string `yaml:"names"`
+	IDs   []string `yaml:"ids"`
+}
+
+// AlbumMapping maps one album to a set of people whose photos should be in it.
+type AlbumMapping struct {
+	Album   string         `yaml:"album,omitempty"`    // album by name (resolved at runtime)
+	AlbumID string         `yaml:"album_id,omitempty"` // album by Immich UUID
+	People  PeopleSelector `yaml:"people"`
+}
+
+// ManageConfig is the top-level YAML configuration for the manage command.
+// Each subcommand has its own section.
+type ManageConfig struct {
+	PeopleAlbumSync *PeopleAlbumSyncConfig `yaml:"people-album-sync"`
+}
+
+// PeopleAlbumSyncConfig holds the configuration for the people-album-sync subcommand.
+type PeopleAlbumSyncConfig struct {
+	Albums []AlbumMapping `yaml:"albums"`
+}
+
+// ParseConfig reads and validates a YAML config file.
+func ParseConfig(path string) (*ManageConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading config: %w", err)
+	}
+
+	var cfg ManageConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parsing config: %w", err)
+	}
+
+	return &cfg, nil
+}
+
+func (c *PeopleAlbumSyncConfig) validate() error {
+	if len(c.Albums) == 0 {
+		return fmt.Errorf("config: people-album-sync.albums list is empty")
+	}
+	for i, a := range c.Albums {
+		if a.Album == "" && a.AlbumID == "" {
+			return fmt.Errorf("config: people-album-sync.albums entry %d has no 'album' name or 'album_id'", i)
+		}
+		if len(a.People.Names) == 0 && len(a.People.IDs) == 0 {
+			return fmt.Errorf("config: people-album-sync.albums entry %d (%s) has no people specified", i, a.albumLabel())
+		}
+	}
+	return nil
+}
+
+func (a *AlbumMapping) albumLabel() string {
+	if a.Album != "" {
+		return a.Album
+	}
+	return a.AlbumID
+}

--- a/app/manage/config_test.go
+++ b/app/manage/config_test.go
@@ -1,0 +1,134 @@
+package manage
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseConfig(t *testing.T) {
+	yaml := `people-album-sync:
+  albums:
+    - album: "Family Vacation"
+      people:
+        names: ["Alice", "Bob"]
+        ids: ["uuid-1"]
+    - album: "Kids"
+      people:
+        names: ["Alice"]
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "manage.yaml")
+	if err := os.WriteFile(path, []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := ParseConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.PeopleAlbumSync == nil {
+		t.Fatal("expected people-album-sync section")
+	}
+
+	if len(cfg.PeopleAlbumSync.Albums) != 2 {
+		t.Fatalf("expected 2 albums, got %d", len(cfg.PeopleAlbumSync.Albums))
+	}
+
+	a0 := cfg.PeopleAlbumSync.Albums[0]
+	if a0.Album != "Family Vacation" {
+		t.Errorf("expected album name 'Family Vacation', got %q", a0.Album)
+	}
+	if len(a0.People.Names) != 2 {
+		t.Errorf("expected 2 people names, got %d", len(a0.People.Names))
+	}
+	if len(a0.People.IDs) != 1 {
+		t.Errorf("expected 1 people ID, got %d", len(a0.People.IDs))
+	}
+
+	a1 := cfg.PeopleAlbumSync.Albums[1]
+	if a1.Album != "Kids" {
+		t.Errorf("expected album name 'Kids', got %q", a1.Album)
+	}
+	if len(a1.People.Names) != 1 {
+		t.Errorf("expected 1 people name, got %d", len(a1.People.Names))
+	}
+	if len(a1.People.IDs) != 0 {
+		t.Errorf("expected 0 people IDs, got %d", len(a1.People.IDs))
+	}
+}
+
+func TestParseConfig_AlbumByID(t *testing.T) {
+	yaml := `people-album-sync:
+  albums:
+    - album_id: "album-uuid-123"
+      people:
+        names: ["Alice"]
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "manage.yaml")
+	if err := os.WriteFile(path, []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := ParseConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.PeopleAlbumSync.Albums[0].AlbumID != "album-uuid-123" {
+		t.Errorf("expected album_id 'album-uuid-123', got %q", cfg.PeopleAlbumSync.Albums[0].AlbumID)
+	}
+}
+
+func TestParseConfig_ValidationErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+	}{
+		{
+			name: "no album identifier",
+			yaml: `people-album-sync:
+  albums:
+    - people:
+        names: ["Alice"]
+`,
+		},
+		{
+			name: "no people specified",
+			yaml: `people-album-sync:
+  albums:
+    - album: "Test"
+      people:
+`,
+		},
+		{
+			name: "empty albums list",
+			yaml: `people-album-sync:
+  albums: []
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "manage.yaml")
+			if err := os.WriteFile(path, []byte(tt.yaml), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			cfg, err := ParseConfig(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if cfg.PeopleAlbumSync == nil {
+				t.Fatal("expected people-album-sync section")
+			}
+			err = cfg.PeopleAlbumSync.validate()
+			if err == nil {
+				t.Fatal("expected validation error, got nil")
+			}
+		})
+	}
+}

--- a/app/manage/config_test.go
+++ b/app/manage/config_test.go
@@ -59,6 +59,53 @@ func TestParseConfig(t *testing.T) {
 	}
 }
 
+func TestParseConfig_Mode(t *testing.T) {
+	yaml := `people-album-sync:
+  albums:
+    - album: "Everyone Together"
+      people:
+        names: ["Alice", "Bob"]
+      mode: "all"
+    - album: "Anyone"
+      people:
+        names: ["Alice", "Bob"]
+      mode: "any"
+    - album: "Default Mode"
+      people:
+        names: ["Alice"]
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "manage.yaml")
+	if err := os.WriteFile(path, []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := ParseConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Before validation, entry with no mode should be empty
+	if cfg.PeopleAlbumSync.Albums[2].Mode != "" {
+		t.Errorf("expected empty mode before validation, got %q", cfg.PeopleAlbumSync.Albums[2].Mode)
+	}
+
+	if err := cfg.PeopleAlbumSync.validate(); err != nil {
+		t.Fatalf("unexpected validation error: %v", err)
+	}
+
+	// After validation, all modes should be normalized
+	if cfg.PeopleAlbumSync.Albums[0].Mode != ModeAll {
+		t.Errorf("expected mode 'all', got %q", cfg.PeopleAlbumSync.Albums[0].Mode)
+	}
+	if cfg.PeopleAlbumSync.Albums[1].Mode != ModeAny {
+		t.Errorf("expected mode 'any', got %q", cfg.PeopleAlbumSync.Albums[1].Mode)
+	}
+	if cfg.PeopleAlbumSync.Albums[2].Mode != ModeAll {
+		t.Errorf("expected mode 'all' after validation (default), got %q", cfg.PeopleAlbumSync.Albums[2].Mode)
+	}
+}
+
 func TestParseConfig_AlbumByID(t *testing.T) {
 	yaml := `people-album-sync:
   albums:
@@ -107,6 +154,26 @@ func TestParseConfig_ValidationErrors(t *testing.T) {
 			name: "empty albums list",
 			yaml: `people-album-sync:
   albums: []
+`,
+		},
+		{
+			name: "both album and album_id",
+			yaml: `people-album-sync:
+  albums:
+    - album: "Test"
+      album_id: "uuid-123"
+      people:
+        names: ["Alice"]
+`,
+		},
+		{
+			name: "invalid mode",
+			yaml: `people-album-sync:
+  albums:
+    - album: "Test"
+      people:
+        names: ["Alice"]
+      mode: "invalid"
 `,
 		},
 	}

--- a/app/manage/manage.go
+++ b/app/manage/manage.go
@@ -1,0 +1,23 @@
+package manage
+
+import (
+	"context"
+
+	"github.com/simulot/immich-go/app"
+	"github.com/spf13/cobra"
+)
+
+// NewManageCommand creates the parent cobra command for manage subcommands.
+func NewManageCommand(ctx context.Context, a *app.Application) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "manage",
+		Short: "Manage Immich resources",
+		Long:  "Parent command for managing Immich resources. Use subcommands for specific operations.",
+	}
+
+	cmd.AddCommand(
+		NewPeopleAlbumSyncCommand(ctx, a),
+	)
+
+	return cmd
+}

--- a/app/manage/manage_test.go
+++ b/app/manage/manage_test.go
@@ -206,6 +206,103 @@ func TestSyncFlow_AddsOnlyMissingAssets(t *testing.T) {
 	}
 }
 
+func TestSyncFlow_AnyMode_UnionsPerPersonResults(t *testing.T) {
+	var mu sync.Mutex
+	var addedAssets []string
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/api/people"):
+			peopleResponse(w, []immich.PersonResponseDto{
+				{ID: "person-alice", Name: "Alice"},
+				{ID: "person-bob", Name: "Bob"},
+			})
+
+		case r.Method == "GET" && r.URL.Path == "/api/albums" && r.URL.Query().Get("assetId") == "":
+			json.NewEncoder(w).Encode([]immich.AlbumSimplified{
+				{ID: "album-1", AlbumName: "Family", AssetIds: []string{}},
+			})
+
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/api/albums/album-1"):
+			json.NewEncoder(w).Encode(immich.AlbumContent{
+				ID:        "album-1",
+				AlbumName: "Family",
+				AssetIDs:  []string{},
+			})
+
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/api/search/metadata"):
+			// Return different assets depending on which person is queried
+			var body struct {
+				PersonIds []string `json:"personIds"`
+			}
+			json.NewDecoder(r.Body).Decode(&body)
+			if len(body.PersonIds) == 1 && body.PersonIds[0] == "person-alice" {
+				searchResponse(w, []string{"asset-1", "asset-2"}, "0")
+			} else if len(body.PersonIds) == 1 && body.PersonIds[0] == "person-bob" {
+				searchResponse(w, []string{"asset-2", "asset-3"}, "0")
+			} else {
+				searchResponse(w, []string{}, "0")
+			}
+
+		case r.Method == "PUT" && strings.Contains(r.URL.Path, "/albums/") && strings.Contains(r.URL.Path, "/assets"):
+			var body struct {
+				IDS []string `json:"ids"`
+			}
+			json.NewDecoder(r.Body).Decode(&body)
+			mu.Lock()
+			addedAssets = append(addedAssets, body.IDS...)
+			mu.Unlock()
+			results := make([]immich.UpdateAlbumResult, len(body.IDS))
+			for i, id := range body.IDS {
+				results[i] = immich.UpdateAlbumResult{ID: id, Success: true}
+			}
+			json.NewEncoder(w).Encode(results)
+
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	client := newTestClient(t, handler)
+	ctx := context.Background()
+
+	cfg := &PeopleAlbumSyncConfig{
+		Albums: []AlbumMapping{
+			{
+				Album:  "Family",
+				People: PeopleSelector{Names: []string{"Alice", "Bob"}},
+				Mode:   ModeAny,
+			},
+		},
+	}
+
+	sc := &PeopleAlbumSyncCmd{}
+	sc.client.Immich = client
+
+	err := sc.run(ctx, slog.Default(), cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// "any" mode should union: Alice has {asset-1, asset-2}, Bob has {asset-2, asset-3}
+	// Union = {asset-1, asset-2, asset-3}
+	addedSet := map[string]bool{}
+	for _, id := range addedAssets {
+		addedSet[id] = true
+	}
+	if !addedSet["asset-1"] {
+		t.Error("asset-1 should have been added (Alice has it)")
+	}
+	if !addedSet["asset-2"] {
+		t.Error("asset-2 should have been added (both have it)")
+	}
+	if !addedSet["asset-3"] {
+		t.Error("asset-3 should have been added (Bob has it)")
+	}
+}
+
 func TestSyncFlow_CreatesAlbumIfMissing(t *testing.T) {
 	albumCreated := false
 

--- a/app/manage/manage_test.go
+++ b/app/manage/manage_test.go
@@ -1,0 +1,341 @@
+package manage
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/simulot/immich-go/immich"
+)
+
+// newTestClient creates an ImmichClient pointed at a test server.
+func newTestClient(t *testing.T, handler http.Handler) *immich.ImmichClient {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	client, err := immich.NewImmichClient(server.URL, "test-key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client
+}
+
+func TestResolvePeopleIDs(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/api/people") {
+			resp := immich.PeopleResponseDto{
+				People: []immich.PersonResponseDto{
+					{ID: "person-1", Name: "Alice"},
+					{ID: "person-2", Name: "Bob"},
+					{ID: "person-3", Name: "Charlie"},
+				},
+				HasNextPage: false,
+				Total:       3,
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(resp)
+			return
+		}
+		http.NotFound(w, r)
+	})
+
+	client := newTestClient(t, handler)
+	ctx := context.Background()
+
+	sel := PeopleSelector{
+		Names: []string{"Alice", "Bob"},
+		IDs:   []string{"direct-uuid-1"},
+	}
+
+	ids, err := resolvePeopleIDs(ctx, client, sel)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(ids) != 3 {
+		t.Fatalf("expected 3 IDs, got %d: %v", len(ids), ids)
+	}
+
+	expected := map[string]bool{"person-1": true, "person-2": true, "direct-uuid-1": true}
+	for _, id := range ids {
+		if !expected[id] {
+			t.Errorf("unexpected ID %q", id)
+		}
+	}
+}
+
+// searchResponse builds the JSON body for the /search/metadata endpoint.
+// nextPage should be "0" to indicate no more pages.
+func searchResponse(w http.ResponseWriter, assetIDs []string, nextPage string) {
+	type item struct {
+		ID string `json:"id"`
+	}
+	items := make([]item, len(assetIDs))
+	for i, id := range assetIDs {
+		items[i] = item{ID: id}
+	}
+	resp := struct {
+		Assets struct {
+			Total    int    `json:"total"`
+			Count    int    `json:"count"`
+			Items    []item `json:"items"`
+			NextPage string `json:"nextPage"`
+		} `json:"assets"`
+	}{}
+	resp.Assets.Total = len(assetIDs)
+	resp.Assets.Count = len(assetIDs)
+	resp.Assets.Items = items
+	resp.Assets.NextPage = nextPage
+	json.NewEncoder(w).Encode(resp)
+}
+
+// peopleResponse writes a standard people response.
+func peopleResponse(w http.ResponseWriter, people []immich.PersonResponseDto) {
+	json.NewEncoder(w).Encode(immich.PeopleResponseDto{
+		People:      people,
+		HasNextPage: false,
+		Total:       len(people),
+	})
+}
+
+func TestResolvePeopleIDs_NameNotFound(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(immich.PeopleResponseDto{
+			People:      []immich.PersonResponseDto{},
+			HasNextPage: false,
+			Total:       0,
+		})
+	})
+
+	client := newTestClient(t, handler)
+	ctx := context.Background()
+
+	sel := PeopleSelector{Names: []string{"NonExistent"}}
+	_, err := resolvePeopleIDs(ctx, client, sel)
+	if err == nil {
+		t.Fatal("expected error for unresolved name, got nil")
+	}
+}
+
+func TestSyncFlow_AddsOnlyMissingAssets(t *testing.T) {
+	var mu sync.Mutex
+	var addedAssets []string
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/api/people"):
+			peopleResponse(w, []immich.PersonResponseDto{{ID: "person-alice", Name: "Alice"}})
+
+		case r.Method == "GET" && r.URL.Path == "/api/albums" && r.URL.Query().Get("assetId") == "":
+			json.NewEncoder(w).Encode([]immich.AlbumSimplified{
+				{ID: "album-1", AlbumName: "Family", AssetIds: []string{"asset-1"}},
+			})
+
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/api/albums/album-1"):
+			json.NewEncoder(w).Encode(immich.AlbumContent{
+				ID:        "album-1",
+				AlbumName: "Family",
+				AssetIDs:  []string{"asset-1"},
+			})
+
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/api/search/metadata"):
+			searchResponse(w, []string{"asset-1", "asset-2", "asset-3"}, "0")
+
+		case r.Method == "PUT" && strings.Contains(r.URL.Path, "/albums/") && strings.Contains(r.URL.Path, "/assets"):
+			var body struct {
+				IDS []string `json:"ids"`
+			}
+			json.NewDecoder(r.Body).Decode(&body)
+			mu.Lock()
+			addedAssets = append(addedAssets, body.IDS...)
+			mu.Unlock()
+			results := make([]immich.UpdateAlbumResult, len(body.IDS))
+			for i, id := range body.IDS {
+				results[i] = immich.UpdateAlbumResult{ID: id, Success: true}
+			}
+			json.NewEncoder(w).Encode(results)
+
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	client := newTestClient(t, handler)
+	ctx := context.Background()
+
+	cfg := &PeopleAlbumSyncConfig{
+		Albums: []AlbumMapping{
+			{
+				Album:  "Family",
+				People: PeopleSelector{Names: []string{"Alice"}},
+			},
+		},
+	}
+
+	sc := &PeopleAlbumSyncCmd{}
+	sc.client.Immich = client
+
+	err := sc.run(ctx, slog.Default(), cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Should only add asset-2 and asset-3 (asset-1 already in album)
+	// Note: GetFilteredAssetsFn runs 3 concurrent queries (one per visibility),
+	// so we may get duplicates, if so use a set to deduplicate.
+	addedSet := map[string]bool{}
+	for _, id := range addedAssets {
+		addedSet[id] = true
+	}
+	if addedSet["asset-1"] {
+		t.Error("asset-1 should NOT have been added (already in album)")
+	}
+	if !addedSet["asset-2"] {
+		t.Error("asset-2 should have been added")
+	}
+	if !addedSet["asset-3"] {
+		t.Error("asset-3 should have been added")
+	}
+}
+
+func TestSyncFlow_CreatesAlbumIfMissing(t *testing.T) {
+	albumCreated := false
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/api/people"):
+			peopleResponse(w, []immich.PersonResponseDto{{ID: "person-1", Name: "Alice"}})
+
+		case r.Method == "GET" && r.URL.Path == "/api/albums" && r.URL.Query().Get("assetId") == "":
+			json.NewEncoder(w).Encode([]immich.AlbumSimplified{})
+
+		case r.Method == "POST" && r.URL.Path == "/api/albums":
+			albumCreated = true
+			json.NewEncoder(w).Encode(immich.AlbumSimplified{
+				ID:        "new-album-id",
+				AlbumName: "New Album",
+			})
+
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/api/albums/new-album-id"):
+			json.NewEncoder(w).Encode(immich.AlbumContent{
+				ID:        "new-album-id",
+				AlbumName: "New Album",
+				AssetIDs:  []string{},
+			})
+
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/api/search/metadata"):
+			searchResponse(w, []string{"asset-1"}, "0")
+
+		case r.Method == "PUT" && strings.Contains(r.URL.Path, "/assets"):
+			var body struct {
+				IDS []string `json:"ids"`
+			}
+			json.NewDecoder(r.Body).Decode(&body)
+			results := make([]immich.UpdateAlbumResult, len(body.IDS))
+			for i, id := range body.IDS {
+				results[i] = immich.UpdateAlbumResult{ID: id, Success: true}
+			}
+			json.NewEncoder(w).Encode(results)
+
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	client := newTestClient(t, handler)
+	ctx := context.Background()
+
+	cfg := &PeopleAlbumSyncConfig{
+		Albums: []AlbumMapping{
+			{
+				Album:  "New Album",
+				People: PeopleSelector{Names: []string{"Alice"}},
+			},
+		},
+	}
+
+	sc := &PeopleAlbumSyncCmd{}
+	sc.client.Immich = client
+
+	err := sc.run(ctx, slog.Default(), cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !albumCreated {
+		t.Error("expected album to be created")
+	}
+}
+
+func TestSyncFlow_NeverCallsDestructiveAPIs(t *testing.T) {
+	var mu sync.Mutex
+	destructiveCalled := ""
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.Method == "DELETE" {
+			mu.Lock()
+			destructiveCalled = "DELETE " + r.URL.Path
+			mu.Unlock()
+			http.Error(w, "should not be called", http.StatusInternalServerError)
+			return
+		}
+
+		switch {
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/api/people"):
+			peopleResponse(w, []immich.PersonResponseDto{{ID: "p1", Name: "Alice"}})
+		case r.Method == "GET" && r.URL.Path == "/api/albums" && r.URL.Query().Get("assetId") == "":
+			json.NewEncoder(w).Encode([]immich.AlbumSimplified{
+				{ID: "a1", AlbumName: "Test", AssetIds: []string{}},
+			})
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/api/albums/a1"):
+			json.NewEncoder(w).Encode(immich.AlbumContent{ID: "a1", AlbumName: "Test", AssetIDs: []string{}})
+		case r.Method == "POST" && strings.HasPrefix(r.URL.Path, "/api/search/metadata"):
+			searchResponse(w, []string{"x1"}, "0")
+		case r.Method == "PUT" && strings.Contains(r.URL.Path, "/assets"):
+			var body struct {
+				IDS []string `json:"ids"`
+			}
+			json.NewDecoder(r.Body).Decode(&body)
+			results := []immich.UpdateAlbumResult{{ID: "x1", Success: true}}
+			json.NewEncoder(w).Encode(results)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	client := newTestClient(t, handler)
+	ctx := context.Background()
+
+	cfg := &PeopleAlbumSyncConfig{
+		Albums: []AlbumMapping{{
+			Album:  "Test",
+			People: PeopleSelector{Names: []string{"Alice"}},
+		}},
+	}
+
+	sc := &PeopleAlbumSyncCmd{}
+	sc.client.Immich = client
+
+	err := sc.run(ctx, slog.Default(), cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if destructiveCalled != "" {
+		t.Fatalf("destructive API call made: %s", destructiveCalled)
+	}
+}

--- a/app/manage/people_album_sync.go
+++ b/app/manage/people_album_sync.go
@@ -1,0 +1,189 @@
+package manage
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"github.com/simulot/immich-go/app"
+	"github.com/simulot/immich-go/immich"
+	"github.com/spf13/cobra"
+)
+
+// PeopleAlbumSyncCmd holds the state for the people-album-sync subcommand.
+type PeopleAlbumSyncCmd struct {
+	ConfigFile string
+	client     app.Client
+}
+
+// NewPeopleAlbumSyncCommand creates the cobra command for syncing people to albums.
+func NewPeopleAlbumSyncCommand(ctx context.Context, a *app.Application) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "people-album-sync [flags]",
+		Short: "Sync people to album mappings",
+		Long:  "Reads a YAML config that maps albums to people and ensures each album contains all photos of its mapped people. Additive only, never removes or deletes.",
+	}
+
+	syncCmd := &PeopleAlbumSyncCmd{}
+	cmd.Flags().StringVar(&syncCmd.ConfigFile, "config", "", "Path to the manage YAML config file (required)")
+	_ = cmd.MarkFlagRequired("config")
+	syncCmd.client.RegisterFlags(cmd.Flags(), "")
+	cmd.TraverseChildren = true
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+		err := syncCmd.client.Open(ctx, a)
+		if err != nil {
+			return err
+		}
+
+		manageCfg, err := ParseConfig(syncCmd.ConfigFile)
+		if err != nil {
+			return err
+		}
+
+		if manageCfg.PeopleAlbumSync == nil {
+			return fmt.Errorf("config: missing 'people-album-sync' section")
+		}
+
+		if err := manageCfg.PeopleAlbumSync.validate(); err != nil {
+			return err
+		}
+
+		return syncCmd.run(ctx, a.Log().Logger, manageCfg.PeopleAlbumSync)
+	}
+
+	return cmd
+}
+
+func (syncCmd *PeopleAlbumSyncCmd) run(ctx context.Context, log *slog.Logger, cfg *PeopleAlbumSyncConfig) error {
+	immichClient := syncCmd.client.Immich
+
+	for _, mapping := range cfg.Albums {
+		label := mapping.albumLabel()
+		log.Info("Processing album mapping", "album", label)
+
+		peopleIDs, err := resolvePeopleIDs(ctx, immichClient, mapping.People)
+		if err != nil {
+			return fmt.Errorf("album %q: %w", label, err)
+		}
+		log.Info("Resolved people", "album", label, "people_ids", peopleIDs)
+
+		albumID, err := resolveOrCreateAlbum(ctx, immichClient, mapping, log)
+		if err != nil {
+			return fmt.Errorf("album %q: %w", label, err)
+		}
+		log.Info("Resolved album", "album", label, "album_id", albumID)
+
+		albumInfo, err := immichClient.GetAlbumInfo(ctx, albumID, true)
+		if err != nil {
+			return fmt.Errorf("album %q: getting album info: %w", label, err)
+		}
+		existingAssets := toSet(albumInfo.AssetIDs)
+
+		so := immich.SearchOptions().WithPeople(peopleIDs...)
+		var mu sync.Mutex
+		toAddSet := make(map[string]bool)
+		err = immichClient.GetFilteredAssetsFn(ctx, so, func(asset *immich.Asset) error {
+			mu.Lock()
+			defer mu.Unlock()
+			if !existingAssets[asset.ID] {
+				toAddSet[asset.ID] = true
+			}
+			return nil
+		})
+		if err != nil {
+			return fmt.Errorf("album %q: searching assets: %w", label, err)
+		}
+
+		toAdd := make([]string, 0, len(toAddSet))
+		for id := range toAddSet {
+			toAdd = append(toAdd, id)
+		}
+
+		if len(toAdd) == 0 {
+			log.Info("Album already up to date", "album", label)
+			continue
+		}
+
+		log.Info("Adding assets to album", "album", label, "count", len(toAdd))
+		batchSize := 500
+		for i := 0; i < len(toAdd); i += batchSize {
+			end := min(i+batchSize, len(toAdd))
+			batch := toAdd[i:end]
+			results, err := immichClient.AddAssetToAlbum(ctx, albumID, batch)
+			if err != nil {
+				return fmt.Errorf("album %q: adding assets: %w", label, err)
+			}
+			added := 0
+			for _, r := range results {
+				if r.Success {
+					added++
+				}
+			}
+			log.Info("Batch complete", "album", label, "added", added, "batch_size", len(batch))
+		}
+	}
+
+	return nil
+}
+
+// resolvePeopleIDs converts a PeopleSelector (names + direct IDs) into a flat list of Immich person UUIDs.
+func resolvePeopleIDs(ctx context.Context, immichClient immich.ImmichInterface, sel PeopleSelector) ([]string, error) {
+	var ids []string
+
+	ids = append(ids, sel.IDs...)
+
+	if len(sel.Names) > 0 {
+		icP, ok := immichClient.(immich.ImmichPeopleInterface)
+		if !ok {
+			return nil, fmt.Errorf("immich client does not support people API")
+		}
+		peopleMap, err := icP.GetPeopleByNames(ctx, sel.Names)
+		if err != nil {
+			return nil, fmt.Errorf("resolving people names: %w", err)
+		}
+		for _, name := range sel.Names {
+			person, found := peopleMap[name]
+			if !found || person == nil {
+				return nil, fmt.Errorf("person %q not found in Immich", name)
+			}
+			ids = append(ids, person.ID)
+		}
+	}
+
+	return ids, nil
+}
+
+// resolveOrCreateAlbum finds an existing album by name/ID or creates a new one.
+func resolveOrCreateAlbum(ctx context.Context, immichClient immich.ImmichInterface, mapping AlbumMapping, log *slog.Logger) (string, error) {
+	if mapping.AlbumID != "" {
+		return mapping.AlbumID, nil
+	}
+
+	albums, err := immichClient.GetAllAlbums(ctx)
+	if err != nil {
+		return "", fmt.Errorf("listing albums: %w", err)
+	}
+	for _, album := range albums {
+		if album.AlbumName == mapping.Album {
+			return album.ID, nil
+		}
+	}
+
+	log.Info("Album not found, creating", "album", mapping.Album)
+	album, err := immichClient.CreateAlbum(ctx, mapping.Album, "", nil)
+	if err != nil {
+		return "", fmt.Errorf("creating album: %w", err)
+	}
+	return album.ID, nil
+}
+
+func toSet(ids []string) map[string]bool {
+	m := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		m[id] = true
+	}
+	return m
+}

--- a/app/manage/people_album_sync.go
+++ b/app/manage/people_album_sync.go
@@ -60,6 +60,11 @@ func NewPeopleAlbumSyncCommand(ctx context.Context, a *app.Application) *cobra.C
 func (syncCmd *PeopleAlbumSyncCmd) run(ctx context.Context, log *slog.Logger, cfg *PeopleAlbumSyncConfig) error {
 	immichClient := syncCmd.client.Immich
 
+	allAlbums, err := immichClient.GetAllAlbums(ctx)
+	if err != nil {
+		return fmt.Errorf("listing albums: %w", err)
+	}
+
 	for _, mapping := range cfg.Albums {
 		label := mapping.albumLabel()
 		log.Info("Processing album mapping", "album", label)
@@ -70,7 +75,7 @@ func (syncCmd *PeopleAlbumSyncCmd) run(ctx context.Context, log *slog.Logger, cf
 		}
 		log.Info("Resolved people", "album", label, "people_ids", peopleIDs)
 
-		albumID, err := resolveOrCreateAlbum(ctx, immichClient, mapping, log)
+		albumID, err := resolveOrCreateAlbum(ctx, immichClient, mapping, allAlbums, log)
 		if err != nil {
 			return fmt.Errorf("album %q: %w", label, err)
 		}
@@ -82,19 +87,37 @@ func (syncCmd *PeopleAlbumSyncCmd) run(ctx context.Context, log *slog.Logger, cf
 		}
 		existingAssets := toSet(albumInfo.AssetIDs)
 
-		so := immich.SearchOptions().WithPeople(peopleIDs...)
 		var mu sync.Mutex
 		toAddSet := make(map[string]bool)
-		err = immichClient.GetFilteredAssetsFn(ctx, so, func(asset *immich.Asset) error {
-			mu.Lock()
-			defer mu.Unlock()
-			if !existingAssets[asset.ID] {
-				toAddSet[asset.ID] = true
+
+		if mapping.Mode == ModeAny {
+			for _, pid := range peopleIDs {
+				so := immich.SearchOptions().WithPeople(pid)
+				err = immichClient.GetFilteredAssetsFn(ctx, so, func(asset *immich.Asset) error {
+					mu.Lock()
+					defer mu.Unlock()
+					if !existingAssets[asset.ID] {
+						toAddSet[asset.ID] = true
+					}
+					return nil
+				})
+				if err != nil {
+					return fmt.Errorf("album %q: searching assets for person %s: %w", label, pid, err)
+				}
 			}
-			return nil
-		})
-		if err != nil {
-			return fmt.Errorf("album %q: searching assets: %w", label, err)
+		} else {
+			so := immich.SearchOptions().WithPeople(peopleIDs...)
+			err = immichClient.GetFilteredAssetsFn(ctx, so, func(asset *immich.Asset) error {
+				mu.Lock()
+				defer mu.Unlock()
+				if !existingAssets[asset.ID] {
+					toAddSet[asset.ID] = true
+				}
+				return nil
+			})
+			if err != nil {
+				return fmt.Errorf("album %q: searching assets: %w", label, err)
+			}
 		}
 
 		toAdd := make([]string, 0, len(toAddSet))
@@ -157,16 +180,12 @@ func resolvePeopleIDs(ctx context.Context, immichClient immich.ImmichInterface, 
 }
 
 // resolveOrCreateAlbum finds an existing album by name/ID or creates a new one.
-func resolveOrCreateAlbum(ctx context.Context, immichClient immich.ImmichInterface, mapping AlbumMapping, log *slog.Logger) (string, error) {
+func resolveOrCreateAlbum(ctx context.Context, immichClient immich.ImmichInterface, mapping AlbumMapping, allAlbums []immich.AlbumSimplified, log *slog.Logger) (string, error) {
 	if mapping.AlbumID != "" {
 		return mapping.AlbumID, nil
 	}
 
-	albums, err := immichClient.GetAllAlbums(ctx)
-	if err != nil {
-		return "", fmt.Errorf("listing albums: %w", err)
-	}
-	for _, album := range albums {
+	for _, album := range allAlbums {
 		if album.AlbumName == mapping.Album {
 			return album.ID, nil
 		}

--- a/app/root/rootCmd.go
+++ b/app/root/rootCmd.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/simulot/immich-go/app"
 	"github.com/simulot/immich-go/app/archive"
+	"github.com/simulot/immich-go/app/manage"
 	"github.com/simulot/immich-go/app/stack"
 	"github.com/simulot/immich-go/app/upload"
 	"github.com/simulot/immich-go/app/version"
@@ -42,6 +43,7 @@ func RootImmichGoCommand(ctx context.Context) (*cobra.Command, *app.Application)
 		upload.NewUploadCommand(ctx, a),   // Upload command for uploading assets
 		archive.NewArchiveCommand(ctx, a), // Archive command for archiving assets
 		stack.NewStackCommand(ctx, a),     // Stack command for managing stacks
+		manage.NewManageCommand(ctx, a),   // Manage command for people-to-album sync
 	)
 
 	// PersistentPreRunE is executed before any command runs, used for initialization

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ This documentation is organized into several sections to help you get started qu
 - [**Commands Overview**](commands/README.md) - Complete command structure and global options
 - [**Upload Commands**](commands/upload.md) - Detailed upload command documentation
 - [**Archive Commands**](commands/archive.md) - Export and archival operations
+- [**Manage Commands**](commands/manage.md) - Server-side resource management (people-album-sync)
 - [**Stack Commands**](commands/stack.md) - Photo organization and stacking
 
 ### 📋 Best Practices & Advanced Topics
@@ -55,6 +56,9 @@ immich-go upload from-google-photos --server=SERVER --api-key=KEY /path/to/takeo
 # Archive from Immich server
 immich-go archive from-immich --server=SERVER --api-key=KEY --write-to-folder=/archive
 
+# Sync people to albums
+immich-go manage people-album-sync --server=SERVER --api-key=KEY --config=manage.yaml
+
 # Stack similar photos
 immich-go stack --server=SERVER --api-key=KEY
 ```
@@ -74,6 +78,7 @@ docs/
 │   ├── README.md              # Command overview
 │   ├── upload.md              # Upload commands
 │   ├── archive.md             # Archive commands
+│   ├── manage.md              # Manage commands
 │   └── stack.md               # Stack commands
 ├── concurrency/               # Performance optimization
 │   ├── README.md             # Concurrency overview

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -14,6 +14,7 @@ immich-go [global-options] command sub-command [command-options] [path]
 |---------|-------------|--------------|
 | [upload](upload.md) | Upload photos/videos to Immich server | from-folder, from-google-photos, from-icloud, from-picasa, from-immich |
 | [archive](archive.md) | Export/archive photos to local folder structure | from-folder, from-google-photos, from-icloud, from-picasa, from-immich |
+| [manage](manage.md) | Manage Immich server resources | people-album-sync |
 | [stack](stack.md) | Organize related photos into stacks on server | (none) |
 | version | Display version information | (none) |
 
@@ -55,6 +56,9 @@ immich-go archive from-immich --server=http://localhost:2283 --api-key=your-key 
 # Stack photos on server
 immich-go stack --server=http://localhost:2283 --api-key=your-key --manage-burst=Stack
 
+# Sync people to albums
+immich-go manage people-album-sync --server=http://localhost:2283 --api-key=your-key --config=manage.yaml
+
 # Show version
 immich-go version
 ```
@@ -63,4 +67,5 @@ immich-go version
 
 - [Upload Command](upload.md) - Comprehensive upload options and sub-commands
 - [Archive Command](archive.md) - Export and archival features  
+- [Manage Command](manage.md) - Server-side resource management
 - [Stack Command](stack.md) - Photo organization and stacking

--- a/docs/commands/manage.md
+++ b/docs/commands/manage.md
@@ -1,0 +1,225 @@
+# Manage Command
+
+The `manage` command provides tools for managing resources on your Immich server. Unlike `upload` or `archive`, it operates entirely on existing server-side data.
+
+## Syntax
+
+```bash
+immich-go manage <sub-command> [options]
+```
+
+## Sub-commands
+
+| Sub-command | Description |
+|-------------|-------------|
+| [people-album-sync](#people-album-sync) | Sync photos of specific people into albums |
+
+---
+
+## people-album-sync
+
+Reads a YAML config file that maps albums to people and ensures each album contains all photos of its mapped people. The command is **additive only** — it never removes photos from albums or deletes anything.
+
+### Syntax
+
+```bash
+immich-go manage people-album-sync --config=<path> [options]
+```
+
+### Required Options
+
+| Option | Required | Description |
+|--------|:--------:|-------------|
+| `--config` | Y | Path to the manage YAML config file |
+| `-s, --server` | Y | Immich server URL |
+| `-k, --api-key` | Y | Your API key |
+
+### Connection Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--skip-verify-ssl` | `false` | Skip SSL certificate verification |
+| `--client-timeout` | `20m` | Server call timeout |
+| `--api-trace` | `false` | Enable API call tracing |
+
+### Config File Format
+
+The config file is a standalone YAML file (separate from the main `immich-go.toml` configuration). It has a `people-album-sync` section containing a list of album mappings:
+
+```yaml
+people-album-sync:
+  albums:
+    - album: "Family Gatherings"
+      mode: "all"
+      people:
+        names:
+          - "Alice"
+          - "Bob"
+
+    - album: "Kids"
+      mode: "any"
+      people:
+        ids:
+          - "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+          - "ffffffff-1111-2222-3333-444444444444"
+```
+
+### Album Mapping Fields
+
+| Field | Required | Description |
+|-------|:--------:|-------------|
+| `album` | Y* | Album name (created if it doesn't exist) |
+| `album_id` | Y* | Album UUID (use instead of `album` to target an existing album by ID) |
+| `people` | Y | People selector (see below) |
+| `mode` | | `"all"` (default) or `"any"` — controls how multiple people are matched |
+
+\* Specify exactly one of `album` or `album_id`.
+
+### People Selector
+
+People can be identified by name, by Immich UUID, or both:
+
+```yaml
+people:
+  names:
+    - "Alice"
+    - "Bob"
+  ids:
+    - "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+```
+
+### Mode
+
+| Mode | Behavior |
+|------|----------|
+| `all` (default) | Only photos where **all** listed people appear together are added to the album |
+| `any` | Photos where **any** listed person appears are added, including solo shots |
+
+**Example**: Given people Alice, Bob, and Charlie:
+- `mode: "all"` — only photos containing all three together
+- `mode: "any"` — any photo containing Alice, Bob, or Charlie (or any combination)
+
+### How It Works
+
+1. Reads the YAML config file
+2. For each album mapping:
+   - Resolves people names to Immich person UUIDs (if using `names`)
+   - Finds or creates the target album
+   - Searches for matching photos based on the `mode`
+   - Adds any missing photos to the album (in batches of 500)
+3. Never removes photos from albums or deletes anything
+
+Multiple mappings can target the same album. For example, you can combine `mode: "any"` and `mode: "all"` entries for the same album to build up the desired set of photos.
+
+## Examples
+
+### Basic Usage — Group Photos
+
+Ensure an album contains all photos where both parents appear together:
+
+```yaml
+# family-sync.yaml
+people-album-sync:
+  albums:
+    - album: "Mom & Dad"
+      mode: "all"
+      people:
+        names:
+          - "Mom"
+          - "Dad"
+```
+
+```bash
+immich-go manage people-album-sync \
+  --server=http://localhost:2283 \
+  --api-key=your-api-key \
+  --config=family-sync.yaml
+```
+
+### Any Mode — Solo and Group Shots
+
+Collect all photos of any child into one album:
+
+```yaml
+# kids-sync.yaml
+people-album-sync:
+  albums:
+    - album: "All Kids Photos"
+      mode: "any"
+      people:
+        names:
+          - "Emma"
+          - "Jack"
+          - "Lily"
+```
+
+```bash
+immich-go manage people-album-sync \
+  --server=http://localhost:2283 \
+  --api-key=your-api-key \
+  --config=kids-sync.yaml
+```
+
+### Mixed Modes — Complex Album Rules
+
+Build a "Family" album that includes any photo of the kids plus all photos where both parents appear:
+
+```yaml
+# family-complete.yaml
+people-album-sync:
+  albums:
+    - album: "Family"
+      mode: "any"
+      people:
+        names:
+          - "Emma"
+          - "Jack"
+    - album: "Family"
+      mode: "all"
+      people:
+        names:
+          - "Mom"
+          - "Dad"
+```
+
+### Using Person IDs
+
+Reference people by their Immich UUIDs instead of names:
+
+```yaml
+people-album-sync:
+  albums:
+    - album: "Shared"
+      mode: "any"
+      people:
+        ids:
+          - "b1ba8aca-1a36-4b4b-a6e7-871afa2bfa2b"
+          - "97d06b61-b01f-4f19-a931-69c33468cf9b"
+```
+
+### Debug Run
+
+Use logging to verify behavior before running for real:
+
+```bash
+immich-go --log-level=DEBUG \
+  manage people-album-sync \
+  --server=http://localhost:2283 \
+  --api-key=your-api-key \
+  --api-trace \
+  --config=family-sync.yaml
+```
+
+## Tips
+
+- **Start small**: Test with a single album mapping before adding more.
+- **Use names for readability**: `names` are easier to maintain than UUIDs, but require that the person is named in Immich.
+- **Use IDs for stability**: Person UUIDs won't break if you rename someone in Immich.
+- **Run repeatedly**: The command is idempotent — running it again skips photos already in the album.
+- **Automate with cron**: Since the command is additive and idempotent, it's safe to run on a schedule.
+
+## See Also
+
+- [Upload Command](upload.md) - Upload photos to Immich
+- [Stack Command](stack.md) - Organize photos into stacks
+- [Examples](../examples.md) - More usage examples

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -12,6 +12,7 @@ This guide provides practical examples for common Immich-Go scenarios.
 | [Server backup](#server-backup) | `archive from-immich` | Full server archive |
 | [Server migration](#server-migration) | `upload from-immich` | Transfer between servers |
 | [Photo organization](#photo-organization) | `stack` | Organize existing photos |
+| [People-album sync](#people-album-sync) | `manage people-album-sync` | Auto-populate albums by person |
 | [Selective sync](#selective-sync) | Various filters | Partial imports |
 
 ## Local Photo Upload
@@ -239,6 +240,41 @@ immich-go archive from-folder \
   --write-to-folder=/organized-photos \
   --manage-raw-jpeg=StackCoverRaw \
   /messy/photo/folders
+```
+
+## People-Album Sync
+
+### Auto-Populate Albums by Person
+```yaml
+# manage.yaml — map albums to people
+people-album-sync:
+  albums:
+    - album: "Family Trips"
+      mode: "all"
+      people:
+        names:
+          - "Alice"
+          - "Bob"
+    - album: "Kids"
+      mode: "any"
+      people:
+        names:
+          - "Emma"
+          - "Jack"
+```
+
+```bash
+# Run the sync
+immich-go manage people-album-sync \
+  --server=http://localhost:2283 \
+  --api-key=your-api-key \
+  --config=manage.yaml
+```
+
+### Scheduled Sync (Cron)
+```bash
+# Run nightly at 1 AM — the command is idempotent, so repeated runs are safe
+0 1 * * * immich-go manage people-album-sync --server=http://localhost:2283 --api-key=your-key --config=/etc/immich-go/manage.yaml
 ```
 
 ## Selective Sync

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@
 - **Simple Installation**: No NodeJS or Docker required
 - **Multiple Sources**: Upload from Google Photos Takeouts, iCloud, local folders, ZIP archives, and other Immich servers
 - **Large Collections**: Successfully handles 100,000+ photos
-- **Smart Management**: Duplicate detection, burst photo stacking, RAW+JPEG handling
+- **Smart Management**: Duplicate detection, burst photo stacking, RAW+JPEG handling, people-to-album sync
 - **Cross-Platform**: Available for Windows, macOS, Linux, and FreeBSD
 
 ## 🚀 Quick Start
@@ -28,6 +28,9 @@ immich-go upload from-google-photos --server=http://your-ip:2283 --api-key=your-
 
 # Archive photos from Immich server
 immich-go archive from-immich --server=http://your-ip:2283 --api-key=your-api-key --write-to-folder=/path/to/archive
+
+# Sync people to albums from a YAML config
+immich-go manage people-album-sync --server=http://your-ip:2283 --api-key=your-api-key --config=manage.yaml
 ```
 
 ### 3. Requirements
@@ -47,7 +50,7 @@ immich-go archive from-immich --server=http://your-ip:2283 --api-key=your-api-ke
 | Topic | Description |
 |-------|-------------|
 | [Installation](docs/installation.md) | Detailed installation instructions for all platforms |
-| [Commands](docs/commands/) | Complete command reference and options |
+| [Commands](docs/commands/) | Complete command reference and options (upload, archive, manage, stack) |
 | [Configuration](docs/configuration.md) | Configuration options and environment variables |
 | [Examples](docs/examples.md) | Common use cases and practical examples |
 | [Best Practices](docs/best-practices.md) | Tips for optimal performance and reliability |
@@ -57,15 +60,21 @@ immich-go archive from-immich --server=http://your-ip:2283 --api-key=your-api-ke
 
 ## ✨ How immich-go Works
 
-`immich-go` offers a versatile set of commands to handle your photo and video uploads. Whether you're uploading from a simple folder, migrating from a Google Photos Takeout, or transferring assets between Immich servers, the tool provides intelligent features to preserve your metadata and organization.
+`immich-go` offers a versatile set of commands to handle your photo and video uploads and management. Whether you're uploading from a simple folder, migrating 
+from a Google Photos Takeout, transferring assets between Immich servers, or managing your existing library, the tool provides intelligent features to 
+preserve your metadata and organization.
 
-Here's a brief overview of the main upload commands:
+Here's a brief overview of the main commands:
 
 *   **`from-folder`**: The basic command for uploading from any local folder. It can create albums from your directory structure and read XMP sidecar files.
 *   **`from-google-photos`**: A powerful command to migrate from a Google Photos Takeout. It intelligently matches photos with their JSON metadata to preserve albums, descriptions, and locations.
 *   **`from-immich`**: A server-to-server migration tool that allows you to copy assets between two Immich instances with fine-grained filtering.
 *   **`from-picasa`**: A specialized version of `from-folder` that automatically reads `.picasa.ini` files to restore your Picasa album organization.
 *   **`from-icloud`**: Another specialized command that handles the complexity of an iCloud Photos takeout, correctly identifying creation dates and album structures from the included CSV files.
+
+### Managing Your Library
+
+*   **`manage people-album-sync`**: Reads a YAML config that maps albums to people and automatically adds matching photos. Supports two modes: `"all"` (photos where every listed person appears together) and `"any"` (photos where any listed person appears). The command is additive and idempotent — safe to run on a schedule. See the [Manage Command docs](docs/commands/manage.md) for details.
 
 ### Leveraging Immich's Features
 
@@ -83,6 +92,7 @@ For a detailed explanation of how each upload command works, please see the [Upl
 - **Google Photos Migration**: [Complete guide](docs/best-practices.md#google-photos-migration)
 - **iCloud Import**: [Step-by-step instructions](docs/examples.md#icloud-import)
 - **Server Migration**: [Transfer between Immich instances](docs/examples.md#server-migration)
+- **People-Album Sync**: [Auto-populate albums by person](docs/commands/manage.md)
 - **Bulk Organization**: [Stacking and tagging strategies](docs/best-practices.md#organization-strategies)
 
 ## 💡 Support the Project


### PR DESCRIPTION
## Summary
- Adds a new `manage` CLI command and people-album-sync subcommand that syncs people to albums based on a YAML config
- Resolves people by name or Immich UUID, creates albums if missing, and adds only photos not already in the album
- Allows multiple modes of addition
- All operations are strictly additive — no deletes or removals from albums

## Tests
- Unit tests for YAML config parsing and validation
- Tests for verifying only missing assets are added
- Test verifying albums are created when missing
- Safety test verifying no destructive (DELETE) API calls are made
- Full project test suite passes with no regressions

PS: Please do let me know if this is unnecessary and unwelcome if the project is just to manage takeouts. I just found the library well structured and had a good foundation for these management CLI commands which I could build on top of.