### PR TITLE
Feat/archive idempotent reruns

### DIFF
--- a/adapters/folder/writeFolder.go
+++ b/adapters/folder/writeFolder.go
@@ -19,6 +19,16 @@ import (
 	"github.com/simulot/immich-go/internal/fshelper/debugfiles"
 )
 
+// WriteOutcome describes the result of a WriteAsset call.
+type WriteOutcome int
+
+const (
+	OutcomeDownloaded WriteOutcome = iota // path A: new file downloaded and saved
+	OutcomeSkipped                        // path B: already on disk, metadata identical
+	OutcomeUpdated                        // path B: already on disk, JSON sidecar refreshed
+	OutcomeMoved                          // path B: already on disk, file moved or renamed (± metadata)
+)
+
 type closer interface {
 	Close() error
 }
@@ -53,7 +63,8 @@ func NewLocalAssetWriter(fsys fs.FS, writeToPath string) (*LocalAssetWriter, err
 // BuildIndex scans all existing JSON sidecars in the destination FS and builds an
 // in-memory index of checksum → file location. Must be called before WriteAsset.
 // Sidecars without a Checksum field (written before this change) are skipped.
-func (w *LocalAssetWriter) BuildIndex(ctx context.Context, log *slog.Logger) error {
+// Returns the number of indexed entries.
+func (w *LocalAssetWriter) BuildIndex(ctx context.Context, log *slog.Logger) (int, error) {
 	count := 0
 	err := fs.WalkDir(w.WriteToFS, ".", func(p string, d fs.DirEntry, err error) error {
 		if err != nil || d.IsDir() {
@@ -87,7 +98,7 @@ func (w *LocalAssetWriter) BuildIndex(ctx context.Context, log *slog.Logger) err
 	if log != nil && count > 0 {
 		log.Info("archive index loaded", "entries", count)
 	}
-	return err
+	return count, err
 }
 
 func (w *LocalAssetWriter) registerInFileset(dir, base string) {
@@ -115,21 +126,22 @@ func (w *LocalAssetWriter) WriteGroup(ctx context.Context, group *assets.Group) 
 		case <-ctx.Done():
 			return errors.Join(err, ctx.Err())
 		default:
-			err = errors.Join(err, w.WriteAsset(ctx, a))
+			_, writeErr := w.WriteAsset(ctx, a)
+			err = errors.Join(err, writeErr)
 		}
 	}
 	return err
 }
 
-func (w *LocalAssetWriter) WriteAsset(ctx context.Context, a *assets.Asset) error {
+func (w *LocalAssetWriter) WriteAsset(ctx context.Context, a *assets.Asset) (WriteOutcome, error) {
 	dir := w.pathOfAsset(a)
 	if err := w.ensureDir(dir); err != nil {
-		return err
+		return OutcomeDownloaded, err
 	}
 
 	select {
 	case <-ctx.Done():
-		return ctx.Err()
+		return OutcomeDownloaded, ctx.Err()
 	default:
 	}
 
@@ -160,7 +172,7 @@ func (w *LocalAssetWriter) buildMetadata(a *assets.Asset) assets.Metadata {
 }
 
 // writeNew downloads the asset and writes binary + JSON sidecar (path A).
-func (w *LocalAssetWriter) writeNew(ctx context.Context, dir string, a *assets.Asset, incomingMd assets.Metadata) error {
+func (w *LocalAssetWriter) writeNew(ctx context.Context, dir string, a *assets.Asset, incomingMd assets.Metadata) (WriteOutcome, error) {
 	base := incomingMd.FileName
 	if base == "" {
 		base = a.Base
@@ -175,42 +187,42 @@ func (w *LocalAssetWriter) writeNew(ctx context.Context, dir string, a *assets.A
 
 	r, err := a.OpenFile()
 	if err != nil {
-		return err
+		return OutcomeDownloaded, err
 	}
 	defer r.Close()
 
 	select {
 	case <-ctx.Done():
-		return ctx.Err()
+		return OutcomeDownloaded, ctx.Err()
 	default:
 	}
 
 	if err := fshelper.WriteFile(w.WriteToFS, path.Join(dir, base), r); err != nil {
-		return err
+		return OutcomeDownloaded, err
 	}
 
 	// XMP sidecar (copy from source if present)
 	if a.FromSideCar != nil {
 		scr, err := a.FromSideCar.File.Open()
 		if err != nil {
-			return err
+			return OutcomeDownloaded, err
 		}
 		debugfiles.TrackOpenFile(scr, a.FromSideCar.File.Name())
 		defer scr.Close()
 		defer debugfiles.TrackCloseFile(scr)
 		scw, err := fshelper.OpenFile(w.WriteToFS, path.Join(dir, base+".XMP"), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o644)
 		if err != nil {
-			return err
+			return OutcomeDownloaded, err
 		}
 		_, err = io.Copy(scw, scr)
 		scw.Close()
 		if err != nil {
-			return err
+			return OutcomeDownloaded, err
 		}
 	}
 
 	if err := w.writeJSON(dir, base, &incomingMd); err != nil {
-		return err
+		return OutcomeDownloaded, err
 	}
 
 	// Register in index and fileset
@@ -219,13 +231,13 @@ func (w *LocalAssetWriter) writeNew(ctx context.Context, dir string, a *assets.A
 	}
 	w.registerInFileset(dir, base)
 
-	return nil
+	return OutcomeDownloaded, nil
 }
 
 // updateExisting handles an asset already present on disk (path B):
 // moves/renames if location or filename changed, then refreshes the JSON sidecar
 // if metadata changed. The binary is never re-downloaded.
-func (w *LocalAssetWriter) updateExisting(ctx context.Context, desiredDir string, a *assets.Asset, incomingMd assets.Metadata, entry indexEntry) error {
+func (w *LocalAssetWriter) updateExisting(_ context.Context, desiredDir string, a *assets.Asset, incomingMd assets.Metadata, entry indexEntry) (WriteOutcome, error) {
 	desiredBase := incomingMd.FileName
 	if desiredBase == "" {
 		desiredBase = entry.base
@@ -245,29 +257,41 @@ func (w *LocalAssetWriter) updateExisting(ctx context.Context, desiredDir string
 		}
 	}
 
+	moved := false
 	// Move/rename if location or name changed
 	if desiredDir != entry.dir || desiredBase != entry.base {
 		if err := w.ensureDir(desiredDir); err != nil {
-			return err
+			return OutcomeMoved, err
 		}
 		if err := w.moveFiles(entry.dir, entry.base, desiredDir, desiredBase); err != nil {
-			return err
+			return OutcomeMoved, err
 		}
 		w.deregisterFromFileset(entry.dir, entry.base)
 		w.registerInFileset(desiredDir, desiredBase)
 		entry = indexEntry{dir: desiredDir, base: desiredBase, metadata: entry.metadata}
 		w.index[a.Checksum] = entry
+		moved = true
 	}
 
 	// Refresh JSON sidecar only if metadata changed (preserves mtime for unchanged files)
 	if !metadataEqual(entry.metadata, incomingMd) {
 		if err := w.writeJSON(desiredDir, desiredBase, &incomingMd); err != nil {
-			return err
+			if moved {
+				return OutcomeMoved, err
+			}
+			return OutcomeUpdated, err
 		}
 		w.index[a.Checksum] = indexEntry{dir: desiredDir, base: desiredBase, metadata: incomingMd}
+		if moved {
+			return OutcomeMoved, nil
+		}
+		return OutcomeUpdated, nil
 	}
 
-	return nil
+	if moved {
+		return OutcomeMoved, nil
+	}
+	return OutcomeSkipped, nil
 }
 
 // moveFiles moves binary + JSON (and XMP if present) from old location to new.

--- a/adapters/folder/writeFolder.go
+++ b/adapters/folder/writeFolder.go
@@ -1,13 +1,17 @@
 package folder
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"io/fs"
+	"log/slog"
 	"os"
 	"path"
+	"strings"
 
 	"github.com/simulot/immich-go/internal/assets"
 	"github.com/simulot/immich-go/internal/exif/sidecars/jsonsidecar"
@@ -15,17 +19,23 @@ import (
 	"github.com/simulot/immich-go/internal/fshelper/debugfiles"
 )
 
-// type minimalFSWriter interface {
-// 	fs.FS
-// 	fshelper.FSCanWrite
-// }
-
 type closer interface {
 	Close() error
 }
+
+type indexEntry struct {
+	dir      string
+	base     string          // full filename including extension, e.g. "photo.jpg"
+	metadata assets.Metadata // loaded at index-build time for comparison
+}
+
+// LocalAssetWriter writes assets to a local directory tree organised by year/month.
+// Call BuildIndex once before the first WriteAsset to enable idempotent reruns.
 type LocalAssetWriter struct {
 	WriteToFS  fs.FS
 	createdDir map[string]struct{}
+	index      map[string]indexEntry // checksum (base64) → on-disk location + metadata
+	fileset    map[string]struct{}   // "dir/base" → present; O(1) collision detection
 }
 
 func NewLocalAssetWriter(fsys fs.FS, writeToPath string) (*LocalAssetWriter, error) {
@@ -35,12 +45,68 @@ func NewLocalAssetWriter(fsys fs.FS, writeToPath string) (*LocalAssetWriter, err
 	return &LocalAssetWriter{
 		WriteToFS:  fsys,
 		createdDir: make(map[string]struct{}),
+		index:      make(map[string]indexEntry),
+		fileset:    make(map[string]struct{}),
 	}, nil
+}
+
+// BuildIndex scans all existing JSON sidecars in the destination FS and builds an
+// in-memory index of checksum → file location. Must be called before WriteAsset.
+// Sidecars without a Checksum field (written before this change) are skipped.
+func (w *LocalAssetWriter) BuildIndex(ctx context.Context, log *slog.Logger) error {
+	count := 0
+	err := fs.WalkDir(w.WriteToFS, ".", func(p string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+		if !strings.EqualFold(path.Ext(p), ".json") {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		f, err := w.WriteToFS.Open(p)
+		if err != nil {
+			return nil // skip unreadable files
+		}
+		var md assets.Metadata
+		readErr := jsonsidecar.Read(f, &md)
+		f.Close()
+		if readErr != nil || md.Checksum == "" {
+			return nil // skip sidecars not written by archive (no checksum)
+		}
+		dir := path.Dir(p)
+		base := strings.TrimSuffix(path.Base(p), path.Ext(p)) // strip ".JSON" / ".json"
+		w.index[md.Checksum] = indexEntry{dir: dir, base: base, metadata: md}
+		w.registerInFileset(dir, base)
+		count++
+		return nil
+	})
+	if log != nil && count > 0 {
+		log.Info("archive index loaded", "entries", count)
+	}
+	return err
+}
+
+func (w *LocalAssetWriter) registerInFileset(dir, base string) {
+	w.fileset[dir+"/"+base] = struct{}{}
+	w.fileset[dir+"/"+base+".JSON"] = struct{}{}
+}
+
+func (w *LocalAssetWriter) deregisterFromFileset(dir, base string) {
+	delete(w.fileset, dir+"/"+base)
+	delete(w.fileset, dir+"/"+base+".JSON")
+}
+
+func (w *LocalAssetWriter) filesetContains(dir, base string) bool {
+	_, ok := w.fileset[dir+"/"+base]
+	return ok
 }
 
 func (w *LocalAssetWriter) WriteGroup(ctx context.Context, group *assets.Group) error {
 	var err error
-
 	if fsys, ok := w.WriteToFS.(closer); ok {
 		defer fsys.Close()
 	}
@@ -56,94 +122,227 @@ func (w *LocalAssetWriter) WriteGroup(ctx context.Context, group *assets.Group) 
 }
 
 func (w *LocalAssetWriter) WriteAsset(ctx context.Context, a *assets.Asset) error {
-	base := a.Base
 	dir := w.pathOfAsset(a)
-	if _, ok := w.createdDir[dir]; !ok {
-		err := fshelper.MkdirAll(w.WriteToFS, dir, 0o755)
-		if err != nil {
-			return err
-		}
-		w.createdDir[dir] = struct{}{}
+	if err := w.ensureDir(dir); err != nil {
+		return err
 	}
+
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
 	default:
-		r, err := a.OpenFile()
+	}
+
+	incomingMd := w.buildMetadata(a)
+
+	// Path B: asset already on disk (checksum found in index)
+	if a.Checksum != "" {
+		if entry, exists := w.index[a.Checksum]; exists {
+			return w.updateExisting(ctx, dir, a, incomingMd, entry)
+		}
+	}
+
+	// Path A: new asset
+	return w.writeNew(ctx, dir, a, incomingMd)
+}
+
+// buildMetadata constructs the Metadata to write to the JSON sidecar from the asset.
+func (w *LocalAssetWriter) buildMetadata(a *assets.Asset) assets.Metadata {
+	var md assets.Metadata
+	if a.FromApplication != nil {
+		md = *a.FromApplication
+	}
+	md.Checksum = a.Checksum
+	if md.FileName == "" {
+		md.FileName = a.Base
+	}
+	return md
+}
+
+// writeNew downloads the asset and writes binary + JSON sidecar (path A).
+func (w *LocalAssetWriter) writeNew(ctx context.Context, dir string, a *assets.Asset, incomingMd assets.Metadata) error {
+	base := incomingMd.FileName
+	if base == "" {
+		base = a.Base
+	}
+
+	// Collision avoidance using O(1) fileset lookup
+	ext := path.Ext(base)
+	radical := base[:len(base)-len(ext)]
+	for i := 1; w.filesetContains(dir, base) || w.filesetContains(dir, base+".JSON"); i++ {
+		base = fmt.Sprintf("%s-%d%s", radical, i, ext)
+	}
+
+	r, err := a.OpenFile()
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	if err := fshelper.WriteFile(w.WriteToFS, path.Join(dir, base), r); err != nil {
+		return err
+	}
+
+	// XMP sidecar (copy from source if present)
+	if a.FromSideCar != nil {
+		scr, err := a.FromSideCar.File.Open()
 		if err != nil {
 			return err
 		}
-		defer r.Close()
-
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-			// Add an index to the file name if it already exists, or the XMP or JSON
-			index := 0
-			ext := path.Ext(base)
-			radical := base[:len(base)-len(ext)]
-			for {
-				if index > 0 {
-					base = fmt.Sprintf("%s~%d%s", radical, index, path.Ext(base))
-				}
-				_, err := fs.Stat(w.WriteToFS, path.Join(dir, base))
-				if err == nil {
-					index++
-					continue
-				}
-				_, err = fs.Stat(w.WriteToFS, path.Join(dir, base+".XMP"))
-				if err == nil {
-					index++
-					continue
-				}
-				_, err = fs.Stat(w.WriteToFS, path.Join(dir, base+".JSON"))
-				if err == nil {
-					index++
-					continue
-				}
-				break
-			}
-
-			// write the asset
-			err = fshelper.WriteFile(w.WriteToFS, path.Join(dir, base), r)
-			if err != nil {
-				return err
-			}
-			// XMP?
-			if a.FromSideCar != nil {
-				// Sidecar file is set, copy it
-				var scr fs.File
-				scr, err = a.FromSideCar.File.Open()
-				if err != nil {
-					return err
-				}
-				debugfiles.TrackOpenFile(scr, a.FromSideCar.File.Name())
-				defer scr.Close()
-				defer debugfiles.TrackCloseFile(scr)
-				var scw fshelper.WFile
-				scw, err = fshelper.OpenFile(w.WriteToFS, path.Join(dir, base+".XMP"), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o644)
-				if err != nil {
-					return err
-				}
-				_, err = io.Copy(scw, scr)
-				scw.Close()
-			}
-
-			// Having metadata from an Application or immich-go JSON?
-			if a.FromApplication != nil {
-				var scw fshelper.WFile
-				scw, err = fshelper.OpenFile(w.WriteToFS, path.Join(dir, base+".JSON"), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o644)
-				if err != nil {
-					return err
-				}
-				err = jsonsidecar.Write(a.FromApplication, scw)
-				scw.Close()
-			}
-
+		debugfiles.TrackOpenFile(scr, a.FromSideCar.File.Name())
+		defer scr.Close()
+		defer debugfiles.TrackCloseFile(scr)
+		scw, err := fshelper.OpenFile(w.WriteToFS, path.Join(dir, base+".XMP"), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o644)
+		if err != nil {
+			return err
+		}
+		_, err = io.Copy(scw, scr)
+		scw.Close()
+		if err != nil {
 			return err
 		}
 	}
+
+	if err := w.writeJSON(dir, base, &incomingMd); err != nil {
+		return err
+	}
+
+	// Register in index and fileset
+	if incomingMd.Checksum != "" {
+		w.index[incomingMd.Checksum] = indexEntry{dir: dir, base: base, metadata: incomingMd}
+	}
+	w.registerInFileset(dir, base)
+
+	return nil
+}
+
+// updateExisting handles an asset already present on disk (path B):
+// moves/renames if location or filename changed, then refreshes the JSON sidecar
+// if metadata changed. The binary is never re-downloaded.
+func (w *LocalAssetWriter) updateExisting(ctx context.Context, desiredDir string, a *assets.Asset, incomingMd assets.Metadata, entry indexEntry) error {
+	desiredBase := incomingMd.FileName
+	if desiredBase == "" {
+		desiredBase = entry.base
+	}
+
+	// Resolve filename collision: if desiredBase is occupied by a *different* entry, use -N suffix.
+	if desiredBase != entry.base || desiredDir != entry.dir {
+		ext := path.Ext(desiredBase)
+		radical := desiredBase[:len(desiredBase)-len(ext)]
+		currentSlot := entry.dir + "/" + entry.base
+		for i := 1; ; i++ {
+			slot := desiredDir + "/" + desiredBase
+			if !w.filesetContains(desiredDir, desiredBase) || slot == currentSlot {
+				break
+			}
+			desiredBase = fmt.Sprintf("%s-%d%s", radical, i, ext)
+		}
+	}
+
+	// Move/rename if location or name changed
+	if desiredDir != entry.dir || desiredBase != entry.base {
+		if err := w.ensureDir(desiredDir); err != nil {
+			return err
+		}
+		if err := w.moveFiles(entry.dir, entry.base, desiredDir, desiredBase); err != nil {
+			return err
+		}
+		w.deregisterFromFileset(entry.dir, entry.base)
+		w.registerInFileset(desiredDir, desiredBase)
+		entry = indexEntry{dir: desiredDir, base: desiredBase, metadata: entry.metadata}
+		w.index[a.Checksum] = entry
+	}
+
+	// Refresh JSON sidecar only if metadata changed (preserves mtime for unchanged files)
+	if !metadataEqual(entry.metadata, incomingMd) {
+		if err := w.writeJSON(desiredDir, desiredBase, &incomingMd); err != nil {
+			return err
+		}
+		w.index[a.Checksum] = indexEntry{dir: desiredDir, base: desiredBase, metadata: incomingMd}
+	}
+
+	return nil
+}
+
+// moveFiles moves binary + JSON (and XMP if present) from old location to new.
+func (w *LocalAssetWriter) moveFiles(oldDir, oldBase, newDir, newBase string) error {
+	for _, suffix := range []string{"", ".JSON", ".XMP"} {
+		oldP := path.Join(oldDir, oldBase+suffix)
+		newP := path.Join(newDir, newBase+suffix)
+
+		if suffix == ".XMP" {
+			if _, err := fs.Stat(w.WriteToFS, oldP); err != nil {
+				continue // XMP is optional
+			}
+		}
+
+		if err := fshelper.Rename(w.WriteToFS, oldP, newP); err != nil {
+			// Fallback: copy + delete
+			if copyErr := w.copyAndDelete(oldP, newP); copyErr != nil {
+				return copyErr
+			}
+		}
+	}
+	return nil
+}
+
+func (w *LocalAssetWriter) copyAndDelete(oldP, newP string) error {
+	src, err := w.WriteToFS.Open(oldP)
+	if err != nil {
+		return err
+	}
+	dst, err := fshelper.OpenFile(w.WriteToFS, newP, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		src.Close()
+		return err
+	}
+	_, copyErr := io.Copy(dst, src)
+	dst.Close()
+	src.Close()
+	if copyErr != nil {
+		return copyErr
+	}
+	return fshelper.Remove(w.WriteToFS, oldP)
+}
+
+func (w *LocalAssetWriter) writeJSON(dir, base string, md *assets.Metadata) error {
+	scw, err := fshelper.OpenFile(w.WriteToFS, path.Join(dir, base+".JSON"), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return err
+	}
+	err = jsonsidecar.Write(md, scw)
+	scw.Close()
+	return err
+}
+
+func (w *LocalAssetWriter) ensureDir(dir string) error {
+	if _, ok := w.createdDir[dir]; ok {
+		return nil
+	}
+	if err := fshelper.MkdirAll(w.WriteToFS, dir, 0o755); err != nil {
+		return err
+	}
+	w.createdDir[dir] = struct{}{}
+	return nil
+}
+
+// metadataEqual compares two Metadata structs field-by-field at the JSON level,
+// ignoring the File field (not serialized) and the software version header.
+func metadataEqual(a, b assets.Metadata) bool {
+	a.File = fshelper.FSAndName{}
+	b.File = fshelper.FSAndName{}
+	ab, err1 := json.Marshal(a)
+	bb, err2 := json.Marshal(b)
+	if err1 != nil || err2 != nil {
+		return false
+	}
+	return bytes.Equal(ab, bb)
 }
 
 func (w *LocalAssetWriter) pathOfAsset(a *assets.Asset) string {
@@ -151,6 +350,5 @@ func (w *LocalAssetWriter) pathOfAsset(a *assets.Asset) string {
 	if d.IsZero() {
 		return "no-date"
 	}
-	p := path.Join(fmt.Sprintf("%04d", d.Year()), fmt.Sprintf("%04d-%02d", d.Year(), d.Month()))
-	return p
+	return path.Join(fmt.Sprintf("%04d", d.Year()), fmt.Sprintf("%04d-%02d", d.Year(), d.Month()))
 }

--- a/adapters/folder/writeFolder_test.go
+++ b/adapters/folder/writeFolder_test.go
@@ -1,0 +1,297 @@
+package folder
+
+import (
+	"io/fs"
+	"path"
+	"testing"
+	"testing/fstest"
+	"time"
+
+	"github.com/simulot/immich-go/internal/assets"
+	"github.com/simulot/immich-go/internal/exif/sidecars/jsonsidecar"
+	"github.com/simulot/immich-go/internal/fshelper"
+	"github.com/simulot/immich-go/internal/fshelper/osfs"
+)
+
+const (
+	contentA  = "content_a"
+	checksumA = "Gql7vB/FAktegtXcDYLHwt4dfD8=" // base64 SHA1 of "content_a"
+	contentB  = "content_b"
+	checksumB = "VMiRD+59AzeUhR2QABoo7y7Cwe8=" // base64 SHA1 of "content_b"
+)
+
+var testDate = time.Date(2025, 1, 15, 0, 0, 0, 0, time.UTC)
+var testDate2 = time.Date(2025, 3, 10, 0, 0, 0, 0, time.UTC)
+
+func makeAsset(srcFS fs.FS, srcName, base, checksum string, captureDate time.Time) *assets.Asset {
+	a := &assets.Asset{
+		File:        fshelper.FSName(srcFS, srcName),
+		Checksum:    checksum,
+		CaptureDate: captureDate,
+		FromApplication: &assets.Metadata{
+			FileName:  base,
+			Checksum:  checksum,
+			DateTaken: captureDate,
+		},
+	}
+	a.Base = base
+	a.OriginalFileName = base
+	return a
+}
+
+func newWriter(t *testing.T) (*LocalAssetWriter, fs.FS) {
+	t.Helper()
+	destFS := osfs.DirFS(t.TempDir())
+	w, err := NewLocalAssetWriter(destFS, ".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := w.BuildIndex(t.Context(), nil); err != nil {
+		t.Fatal(err)
+	}
+	return w, destFS
+}
+
+func readSidecar(t *testing.T, destFS fs.FS, jsonPath string) assets.Metadata {
+	t.Helper()
+	f, err := destFS.Open(jsonPath)
+	if err != nil {
+		t.Fatalf("open sidecar %s: %v", jsonPath, err)
+	}
+	defer f.Close()
+	var md assets.Metadata
+	if err := jsonsidecar.Read(f, &md); err != nil {
+		t.Fatalf("read sidecar %s: %v", jsonPath, err)
+	}
+	return md
+}
+
+func TestWriteAsset_NewAsset(t *testing.T) {
+	// Binary and JSON sidecar are created; sidecar has checksum and fileName.
+	srcFS := fstest.MapFS{
+		"asset-a": &fstest.MapFile{Data: []byte(contentA)},
+	}
+	w, destFS := newWriter(t)
+
+	a := makeAsset(srcFS, "asset-a", "photo.jpg", checksumA, testDate)
+	if err := w.WriteAsset(t.Context(), a); err != nil {
+		t.Fatal(err)
+	}
+
+	dir := path.Join("2025", "2025-01")
+	if _, err := fs.Stat(destFS, path.Join(dir, "photo.jpg")); err != nil {
+		t.Errorf("binary not found: %v", err)
+	}
+	md := readSidecar(t, destFS, path.Join(dir, "photo.jpg.JSON"))
+	if md.Checksum != checksumA {
+		t.Errorf("expected checksum %q, got %q", checksumA, md.Checksum)
+	}
+	if md.FileName != "photo.jpg" {
+		t.Errorf("expected fileName photo.jpg, got %q", md.FileName)
+	}
+}
+
+func TestWriteAsset_IdempotentRerun(t *testing.T) {
+	// Writing the same asset twice with identical metadata: binary not re-downloaded,
+	// JSON sidecar NOT rewritten (mtime preserved for backup tools).
+	srcFS := fstest.MapFS{
+		"asset-a": &fstest.MapFile{Data: []byte(contentA)},
+	}
+	w, destFS := newWriter(t)
+	ctx := t.Context()
+
+	a1 := makeAsset(srcFS, "asset-a", "photo.jpg", checksumA, testDate)
+	if err := w.WriteAsset(ctx, a1); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+
+	dir := path.Join("2025", "2025-01")
+	jsonPath := path.Join(dir, "photo.jpg.JSON")
+	info1, _ := fs.Stat(destFS, jsonPath)
+
+	// Build a fresh writer with BuildIndex to simulate a new run
+	w2, _ := NewLocalAssetWriter(destFS, ".")
+	if err := w2.BuildIndex(ctx, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	a2 := makeAsset(srcFS, "asset-a", "photo.jpg", checksumA, testDate)
+	if err := w2.WriteAsset(ctx, a2); err != nil {
+		t.Fatalf("second write: %v", err)
+	}
+
+	info2, _ := fs.Stat(destFS, jsonPath)
+	if !info1.ModTime().Equal(info2.ModTime()) {
+		t.Error("JSON mtime changed on idempotent rerun — sidecar was rewritten unnecessarily")
+	}
+
+	// Exactly one binary + one JSON
+	entries, _ := fs.ReadDir(destFS, dir)
+	if len(entries) != 2 {
+		names := make([]string, len(entries))
+		for i, e := range entries {
+			names[i] = e.Name()
+		}
+		t.Errorf("expected 2 entries, got %d: %v", len(entries), names)
+	}
+}
+
+func TestWriteAsset_MetadataUpdated(t *testing.T) {
+	// Second write with a new album: JSON overwritten with updated metadata.
+	srcFS := fstest.MapFS{
+		"asset-a": &fstest.MapFile{Data: []byte(contentA)},
+	}
+	w, destFS := newWriter(t)
+	ctx := t.Context()
+
+	a1 := makeAsset(srcFS, "asset-a", "photo.jpg", checksumA, testDate)
+	if err := w.WriteAsset(ctx, a1); err != nil {
+		t.Fatal(err)
+	}
+
+	// Second run: asset now belongs to an album
+	w2, _ := NewLocalAssetWriter(destFS, ".")
+	if err := w2.BuildIndex(ctx, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	a2 := makeAsset(srcFS, "asset-a", "photo.jpg", checksumA, testDate)
+	a2.FromApplication.Albums = []assets.Album{{Title: "Vacation"}}
+	if err := w2.WriteAsset(ctx, a2); err != nil {
+		t.Fatal(err)
+	}
+
+	md := readSidecar(t, destFS, path.Join("2025", "2025-01", "photo.jpg.JSON"))
+	if len(md.Albums) != 1 || md.Albums[0].Title != "Vacation" {
+		t.Errorf("expected album Vacation in sidecar, got %v", md.Albums)
+	}
+}
+
+func TestWriteAsset_CollisionFallback(t *testing.T) {
+	// No checksum → two different assets with the same filename get
+	// photo.jpg and photo-1.jpg (dash suffix, not tilde).
+	srcFS := fstest.MapFS{
+		"asset-a": &fstest.MapFile{Data: []byte(contentA)},
+		"asset-b": &fstest.MapFile{Data: []byte(contentB)},
+	}
+	w, destFS := newWriter(t)
+	ctx := t.Context()
+
+	aA := makeAsset(srcFS, "asset-a", "photo.jpg", "", testDate)
+	aA.FromApplication.Checksum = ""
+	aA.Checksum = ""
+	aB := makeAsset(srcFS, "asset-b", "photo.jpg", "", testDate)
+	aB.FromApplication.Checksum = ""
+	aB.Checksum = ""
+
+	if err := w.WriteAsset(ctx, aA); err != nil {
+		t.Fatalf("write A: %v", err)
+	}
+	if err := w.WriteAsset(ctx, aB); err != nil {
+		t.Fatalf("write B: %v", err)
+	}
+
+	dir := path.Join("2025", "2025-01")
+	entries, _ := fs.ReadDir(destFS, dir)
+	names := make(map[string]bool, len(entries))
+	for _, e := range entries {
+		names[e.Name()] = true
+	}
+	if !names["photo.jpg"] {
+		t.Error("expected photo.jpg")
+	}
+	if !names["photo-1.jpg"] {
+		t.Errorf("expected photo-1.jpg (dash suffix); files: %v", names)
+	}
+	if names["photo~1.jpg"] {
+		t.Error("photo~1.jpg must not exist — tilde suffix is not used")
+	}
+}
+
+func TestWriteAsset_DateFolderMove(t *testing.T) {
+	// Second run with corrected CaptureDate: binary + JSON moved to new month folder.
+	srcFS := fstest.MapFS{
+		"asset-a": &fstest.MapFile{Data: []byte(contentA)},
+	}
+	w, destFS := newWriter(t)
+	ctx := t.Context()
+
+	a1 := makeAsset(srcFS, "asset-a", "photo.jpg", checksumA, testDate)
+	if err := w.WriteAsset(ctx, a1); err != nil {
+		t.Fatal(err)
+	}
+
+	oldDir := path.Join("2025", "2025-01")
+	if _, err := fs.Stat(destFS, path.Join(oldDir, "photo.jpg")); err != nil {
+		t.Fatalf("file not in expected initial location: %v", err)
+	}
+
+	// Second run: date corrected to March 2025
+	w2, _ := NewLocalAssetWriter(destFS, ".")
+	if err := w2.BuildIndex(ctx, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	a2 := makeAsset(srcFS, "asset-a", "photo.jpg", checksumA, testDate2)
+	if err := w2.WriteAsset(ctx, a2); err != nil {
+		t.Fatal(err)
+	}
+
+	newDir := path.Join("2025", "2025-03")
+	if _, err := fs.Stat(destFS, path.Join(newDir, "photo.jpg")); err != nil {
+		t.Errorf("file not moved to new dir: %v", err)
+	}
+	if _, err := fs.Stat(destFS, path.Join(newDir, "photo.jpg.JSON")); err != nil {
+		t.Errorf("JSON not moved to new dir: %v", err)
+	}
+	// Old location must be gone
+	if _, err := fs.Stat(destFS, path.Join(oldDir, "photo.jpg")); err == nil {
+		t.Error("old binary still present after move")
+	}
+}
+
+func TestWriteAsset_FilenameChange(t *testing.T) {
+	// Same checksum, but FileName changed server-side: binary + JSON renamed.
+	srcFS := fstest.MapFS{
+		"asset-a": &fstest.MapFile{Data: []byte(contentA)},
+	}
+	w, destFS := newWriter(t)
+	ctx := t.Context()
+
+	a1 := makeAsset(srcFS, "asset-a", "photo.jpg", checksumA, testDate)
+	if err := w.WriteAsset(ctx, a1); err != nil {
+		t.Fatal(err)
+	}
+
+	w2, _ := NewLocalAssetWriter(destFS, ".")
+	if err := w2.BuildIndex(ctx, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// Server-side rename
+	a2 := makeAsset(srcFS, "asset-a", "vacation.jpg", checksumA, testDate)
+	if err := w2.WriteAsset(ctx, a2); err != nil {
+		t.Fatal(err)
+	}
+
+	dir := path.Join("2025", "2025-01")
+	if _, err := fs.Stat(destFS, path.Join(dir, "vacation.jpg")); err != nil {
+		t.Errorf("renamed binary not found: %v", err)
+	}
+	if _, err := fs.Stat(destFS, path.Join(dir, "vacation.jpg.JSON")); err != nil {
+		t.Errorf("renamed JSON not found: %v", err)
+	}
+	if _, err := fs.Stat(destFS, path.Join(dir, "photo.jpg")); err == nil {
+		t.Error("old binary still present after rename")
+	}
+}
+
+func TestUseMetadata_AppliesFileName(t *testing.T) {
+	// UseMetadata must update OriginalFileName from md.FileName.
+	a := &assets.Asset{OriginalFileName: "hash123.jpg"}
+	md := &assets.Metadata{FileName: "original_photo.jpg"}
+	a.UseMetadata(md)
+	if a.OriginalFileName != "original_photo.jpg" {
+		t.Errorf("expected OriginalFileName=original_photo.jpg, got %q", a.OriginalFileName)
+	}
+}

--- a/adapters/folder/writeFolder_test.go
+++ b/adapters/folder/writeFolder_test.go
@@ -46,7 +46,7 @@ func newWriter(t *testing.T) (*LocalAssetWriter, fs.FS) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := w.BuildIndex(t.Context(), nil); err != nil {
+	if _, err := w.BuildIndex(t.Context(), nil); err != nil {
 		t.Fatal(err)
 	}
 	return w, destFS
@@ -74,8 +74,12 @@ func TestWriteAsset_NewAsset(t *testing.T) {
 	w, destFS := newWriter(t)
 
 	a := makeAsset(srcFS, "asset-a", "photo.jpg", checksumA, testDate)
-	if err := w.WriteAsset(t.Context(), a); err != nil {
+	outcome, err := w.WriteAsset(t.Context(), a)
+	if err != nil {
 		t.Fatal(err)
+	}
+	if outcome != OutcomeDownloaded {
+		t.Errorf("expected OutcomeDownloaded, got %v", outcome)
 	}
 
 	dir := path.Join("2025", "2025-01")
@@ -101,7 +105,7 @@ func TestWriteAsset_IdempotentRerun(t *testing.T) {
 	ctx := t.Context()
 
 	a1 := makeAsset(srcFS, "asset-a", "photo.jpg", checksumA, testDate)
-	if err := w.WriteAsset(ctx, a1); err != nil {
+	if _, err := w.WriteAsset(ctx, a1); err != nil {
 		t.Fatalf("first write: %v", err)
 	}
 
@@ -111,13 +115,17 @@ func TestWriteAsset_IdempotentRerun(t *testing.T) {
 
 	// Build a fresh writer with BuildIndex to simulate a new run
 	w2, _ := NewLocalAssetWriter(destFS, ".")
-	if err := w2.BuildIndex(ctx, nil); err != nil {
+	if _, err := w2.BuildIndex(ctx, nil); err != nil {
 		t.Fatal(err)
 	}
 
 	a2 := makeAsset(srcFS, "asset-a", "photo.jpg", checksumA, testDate)
-	if err := w2.WriteAsset(ctx, a2); err != nil {
+	outcome, err := w2.WriteAsset(ctx, a2)
+	if err != nil {
 		t.Fatalf("second write: %v", err)
+	}
+	if outcome != OutcomeSkipped {
+		t.Errorf("expected OutcomeSkipped on idempotent rerun, got %v", outcome)
 	}
 
 	info2, _ := fs.Stat(destFS, jsonPath)
@@ -145,20 +153,24 @@ func TestWriteAsset_MetadataUpdated(t *testing.T) {
 	ctx := t.Context()
 
 	a1 := makeAsset(srcFS, "asset-a", "photo.jpg", checksumA, testDate)
-	if err := w.WriteAsset(ctx, a1); err != nil {
+	if _, err := w.WriteAsset(ctx, a1); err != nil {
 		t.Fatal(err)
 	}
 
 	// Second run: asset now belongs to an album
 	w2, _ := NewLocalAssetWriter(destFS, ".")
-	if err := w2.BuildIndex(ctx, nil); err != nil {
+	if _, err := w2.BuildIndex(ctx, nil); err != nil {
 		t.Fatal(err)
 	}
 
 	a2 := makeAsset(srcFS, "asset-a", "photo.jpg", checksumA, testDate)
 	a2.FromApplication.Albums = []assets.Album{{Title: "Vacation"}}
-	if err := w2.WriteAsset(ctx, a2); err != nil {
+	outcome, err := w2.WriteAsset(ctx, a2)
+	if err != nil {
 		t.Fatal(err)
+	}
+	if outcome != OutcomeUpdated {
+		t.Errorf("expected OutcomeUpdated, got %v", outcome)
 	}
 
 	md := readSidecar(t, destFS, path.Join("2025", "2025-01", "photo.jpg.JSON"))
@@ -184,10 +196,10 @@ func TestWriteAsset_CollisionFallback(t *testing.T) {
 	aB.FromApplication.Checksum = ""
 	aB.Checksum = ""
 
-	if err := w.WriteAsset(ctx, aA); err != nil {
+	if _, err := w.WriteAsset(ctx, aA); err != nil {
 		t.Fatalf("write A: %v", err)
 	}
-	if err := w.WriteAsset(ctx, aB); err != nil {
+	if _, err := w.WriteAsset(ctx, aB); err != nil {
 		t.Fatalf("write B: %v", err)
 	}
 
@@ -217,7 +229,7 @@ func TestWriteAsset_DateFolderMove(t *testing.T) {
 	ctx := t.Context()
 
 	a1 := makeAsset(srcFS, "asset-a", "photo.jpg", checksumA, testDate)
-	if err := w.WriteAsset(ctx, a1); err != nil {
+	if _, err := w.WriteAsset(ctx, a1); err != nil {
 		t.Fatal(err)
 	}
 
@@ -228,13 +240,17 @@ func TestWriteAsset_DateFolderMove(t *testing.T) {
 
 	// Second run: date corrected to March 2025
 	w2, _ := NewLocalAssetWriter(destFS, ".")
-	if err := w2.BuildIndex(ctx, nil); err != nil {
+	if _, err := w2.BuildIndex(ctx, nil); err != nil {
 		t.Fatal(err)
 	}
 
 	a2 := makeAsset(srcFS, "asset-a", "photo.jpg", checksumA, testDate2)
-	if err := w2.WriteAsset(ctx, a2); err != nil {
+	outcome, err := w2.WriteAsset(ctx, a2)
+	if err != nil {
 		t.Fatal(err)
+	}
+	if outcome != OutcomeMoved {
+		t.Errorf("expected OutcomeMoved, got %v", outcome)
 	}
 
 	newDir := path.Join("2025", "2025-03")
@@ -259,19 +275,23 @@ func TestWriteAsset_FilenameChange(t *testing.T) {
 	ctx := t.Context()
 
 	a1 := makeAsset(srcFS, "asset-a", "photo.jpg", checksumA, testDate)
-	if err := w.WriteAsset(ctx, a1); err != nil {
+	if _, err := w.WriteAsset(ctx, a1); err != nil {
 		t.Fatal(err)
 	}
 
 	w2, _ := NewLocalAssetWriter(destFS, ".")
-	if err := w2.BuildIndex(ctx, nil); err != nil {
+	if _, err := w2.BuildIndex(ctx, nil); err != nil {
 		t.Fatal(err)
 	}
 
 	// Server-side rename
 	a2 := makeAsset(srcFS, "asset-a", "vacation.jpg", checksumA, testDate)
-	if err := w2.WriteAsset(ctx, a2); err != nil {
+	outcome, err := w2.WriteAsset(ctx, a2)
+	if err != nil {
 		t.Fatal(err)
+	}
+	if outcome != OutcomeMoved {
+		t.Errorf("expected OutcomeMoved on rename, got %v", outcome)
 	}
 
 	dir := path.Join("2025", "2025-01")

--- a/adapters/fromimmich/command.go
+++ b/adapters/fromimmich/command.go
@@ -386,6 +386,9 @@ func (fic *FromImmichCmd) getAssets(ctx context.Context, grpChan chan *assets.Gr
 		}
 
 		asset := a.AsAsset()
+		asset.SetNameInfo(fic.ic.GetInfo(asset.OriginalFileName))
+		asset.File = fshelper.FSName(fic.ifs, a.ID)
+
 		asset.FromApplication = &assets.Metadata{
 			FileName:    a.OriginalFileName,
 			Latitude:    a.ExifInfo.Latitude,
@@ -399,7 +402,6 @@ func (fic *FromImmichCmd) getAssets(ctx context.Context, grpChan chan *assets.Gr
 			Tags:        asset.Tags,
 		}
 		asset.UseMetadata(asset.FromApplication)
-		asset.File = fshelper.FSName(fic.ifs, a.ID)
 
 		// Record asset discovery
 		code := fileevent.DiscoveredImage

--- a/adapters/fromimmich/command.go
+++ b/adapters/fromimmich/command.go
@@ -385,6 +385,13 @@ func (fic *FromImmichCmd) getAssets(ctx context.Context, grpChan chan *assets.Gr
 			return err
 		}
 
+		// Transfer the album
+		simplifiedA, err := fic.client.Immich.GetAssetAlbums(ctx, a.ID)
+		if err = fic.app.ProcessError(err); err != nil {
+			return err
+		}
+		albums := immich.AlbumsFromAlbumSimplified(simplifiedA)
+
 		asset := a.AsAsset()
 		asset.SetNameInfo(fic.ic.GetInfo(asset.OriginalFileName))
 		asset.File = fshelper.FSName(fic.ifs, a.ID)
@@ -399,6 +406,7 @@ func (fic *FromImmichCmd) getAssets(ctx context.Context, grpChan chan *assets.Gr
 			Archived:    a.IsArchived,
 			Favorited:   a.IsFavorite,
 			Rating:      byte(a.ExifInfo.Rating),
+			Albums:      albums,
 			Tags:        asset.Tags,
 		}
 		asset.UseMetadata(asset.FromApplication)
@@ -410,19 +418,10 @@ func (fic *FromImmichCmd) getAssets(ctx context.Context, grpChan chan *assets.Gr
 		}
 		fic.processor.RecordAssetDiscovered(ctx, asset.File, int64(asset.FileSize), code)
 
-		// Transfer the album
-		simplifiedA, err := fic.client.Immich.GetAssetAlbums(ctx, a.ID)
-		if err = fic.app.ProcessError(err); err != nil {
-			return err
-		}
-
-		albums := immich.AlbumsFromAlbumSimplified(simplifiedA)
 		// clear the ID of the album that exists in from server, but not in to server
-		for i := range albums {
-			albums[i].ID = ""
+		for i := range asset.Albums {
+			asset.Albums[i].ID = ""
 		}
-
-		asset.Albums = albums
 
 		// Transfer tags
 		for t := range asset.Tags {

--- a/app/archive/archiveCmd.go
+++ b/app/archive/archiveCmd.go
@@ -17,8 +17,9 @@ import (
 type ArchiveCmd struct {
 	ArchivePath string
 
-	app  *app.Application
-	dest *folder.LocalAssetWriter
+	app        *app.Application
+	dest       *folder.LocalAssetWriter
+	indexCount int // number of files already in local archive (from BuildIndex)
 }
 
 func NewArchiveCommand(ctx context.Context, app *app.Application) *cobra.Command {

--- a/app/archive/run.go
+++ b/app/archive/run.go
@@ -1,9 +1,12 @@
 package archive
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"os"
 
+	"github.com/gdamore/tcell/v2"
 	"github.com/simulot/immich-go/adapters"
 	"github.com/simulot/immich-go/adapters/folder"
 	"github.com/simulot/immich-go/internal/assettracker"
@@ -14,7 +17,6 @@ import (
 )
 
 func (ac *ArchiveCmd) Run(cmd *cobra.Command, adapter adapters.Reader) error {
-	// ready to run
 	ctx := cmd.Context()
 	log := ac.app.Log()
 	log.Info("in ArchiveCmd.Run", "archivePath", ac.ArchivePath)
@@ -28,20 +30,40 @@ func (ac *ArchiveCmd) Run(cmd *cobra.Command, adapter adapters.Reader) error {
 	}
 
 	p := ac.ArchivePath
-	err := os.MkdirAll(p, 0o755)
-	if err != nil {
+	if err := os.MkdirAll(p, 0o755); err != nil {
 		return err
 	}
 
 	destFS := osfs.DirFS(p)
+	var err error
 	ac.dest, err = folder.NewLocalAssetWriter(destFS, ".")
 	if err != nil {
 		return err
 	}
-	if err := ac.dest.BuildIndex(ctx, log.Logger); err != nil {
+	ac.indexCount, err = ac.dest.BuildIndex(ctx, log.Logger)
+	if err != nil {
 		return err
 	}
 
+	// Choose UI vs plain log
+	runner := ac.runUIMode
+	if _, err := tcell.NewScreen(); err != nil {
+		log.Warn("can't initialize screen, falling back to plain log", "err", err)
+		fmt.Println("can't initialize screen, falling back to plain log")
+		runner = ac.runPlain
+	}
+
+	return runner(ctx, adapter)
+}
+
+// runPlain runs the archive loop without a TUI (plain log output).
+func (ac *ArchiveCmd) runPlain(ctx context.Context, adapter adapters.Reader) error {
+	return ac.browseAndArchive(ctx, adapter)
+}
+
+// browseAndArchive is the core processing loop: reads from adapter.Browse, writes each asset.
+func (ac *ArchiveCmd) browseAndArchive(ctx context.Context, adapter adapters.Reader) error {
+	log := ac.app.Log()
 	gChan := adapter.Browse(ctx)
 	errCount := 0
 	for {
@@ -53,12 +75,12 @@ func (ac *ArchiveCmd) Run(cmd *cobra.Command, adapter adapters.Reader) error {
 				return nil
 			}
 			for _, a := range g.Assets {
-				err := ac.dest.WriteAsset(ctx, a)
-				if err == nil {
-					err = a.Close()
+				outcome, writeErr := ac.dest.WriteAsset(ctx, a)
+				if writeErr == nil {
+					writeErr = a.Close()
 				}
-				if err != nil {
-					ac.app.FileProcessor().RecordAssetError(ctx, a.File, int64(a.FileSize), fileevent.ErrorFileAccess, err)
+				if writeErr != nil {
+					ac.app.FileProcessor().RecordAssetError(ctx, a.File, int64(a.FileSize), fileevent.ErrorFileAccess, writeErr)
 					errCount++
 					if errCount > 5 {
 						err := errors.New("too many errors, aborting")
@@ -66,8 +88,20 @@ func (ac *ArchiveCmd) Run(cmd *cobra.Command, adapter adapters.Reader) error {
 						return err
 					}
 				} else {
-					// Asset successfully archived
-					ac.app.FileProcessor().RecordAssetProcessed(ctx, a.File, int64(a.FileSize), fileevent.ProcessedFileArchived)
+					switch outcome {
+					case folder.OutcomeDownloaded:
+						ac.app.FileProcessor().RecordAssetProcessed(ctx, a.File, int64(a.FileSize), fileevent.ProcessedFileArchived)
+						log.Info("downloaded", "file", a.File.Name())
+					case folder.OutcomeSkipped:
+						ac.app.FileProcessor().RecordAssetDiscarded(ctx, a.File, int64(a.FileSize), fileevent.DiscardedLocalDuplicate, "no change")
+						log.Debug("skipped (no change)", "file", a.File.Name())
+					case folder.OutcomeUpdated:
+						ac.app.FileProcessor().RecordAssetProcessed(ctx, a.File, int64(a.FileSize), fileevent.ProcessedMetadataUpdated)
+						log.Info("metadata updated", "file", a.File.Name())
+					case folder.OutcomeMoved:
+						ac.app.FileProcessor().RecordAssetProcessed(ctx, a.File, int64(a.FileSize), fileevent.ProcessedFileMoved)
+						log.Info("moved/renamed", "file", a.File.Name())
+					}
 				}
 			}
 		}

--- a/app/archive/run.go
+++ b/app/archive/run.go
@@ -38,6 +38,9 @@ func (ac *ArchiveCmd) Run(cmd *cobra.Command, adapter adapters.Reader) error {
 	if err != nil {
 		return err
 	}
+	if err := ac.dest.BuildIndex(ctx, log.Logger); err != nil {
+		return err
+	}
 
 	gChan := adapter.Browse(ctx)
 	errCount := 0

--- a/app/archive/ui.go
+++ b/app/archive/ui.go
@@ -1,0 +1,270 @@
+package archive
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+	"github.com/simulot/immich-go/adapters"
+	"github.com/simulot/immich-go/app"
+	"github.com/simulot/immich-go/internal/assettracker"
+	"github.com/simulot/immich-go/internal/fileevent"
+	"github.com/simulot/immich-go/internal/fileprocessor"
+	"golang.org/x/sync/errgroup"
+)
+
+type archiveUI struct {
+	screen        *tview.Grid
+	discoveryZone *tview.Grid
+	resultsZone   *tview.Grid
+	logView       *tview.TextView
+
+	counts     map[fileevent.Code]*tview.TextView
+	extraViews map[string]*tview.TextView
+
+	tracker *assettracker.AssetTracker
+	fp      *fileprocessor.FileProcessor
+}
+
+// runUIMode launches the tview-based archive UI and runs browseAndArchive in a goroutine.
+func (ac *ArchiveCmd) runUIMode(ctx context.Context, adapter adapters.Reader) error {
+	ctx, cancel := context.WithCancelCause(ctx)
+	defer cancel(nil)
+
+	uiApp := tview.NewApplication()
+	ui := ac.newArchiveUI(ac.app)
+
+	pages := tview.NewPages()
+	pages.AddPage("ui", ui.screen, true, true)
+	uiApp.SetRoot(pages, true)
+
+	var archiveDone atomic.Bool
+	var messages strings.Builder
+
+	stopUI := func(err error) {
+		cancel(err)
+		uiApp.Stop()
+	}
+
+	uiApp.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+		switch event.Key() {
+		case tcell.KeyCtrlQ, tcell.KeyCtrlC:
+			ui.restoreLogger(ac.app)
+			cancel(errors.New("interrupted: Ctrl+C or Ctrl+Q pressed"))
+		case tcell.KeyEnter:
+			if archiveDone.Load() {
+				stopUI(nil)
+			}
+		}
+		return event
+	})
+
+	// 100 ms tick to refresh counters
+	go func() {
+		tick := time.NewTicker(100 * time.Millisecond)
+		defer tick.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-tick.C:
+				uiApp.QueueUpdateDraw(func() {
+					ui.refresh(ac.app)
+				})
+			}
+		}
+	}()
+
+	var g errgroup.Group
+
+	// tview event loop
+	g.Go(func() error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			err := uiApp.Run()
+			cancel(err)
+			return err
+		}
+	})
+
+	// archive processing
+	g.Go(func() error {
+		err := ac.browseAndArchive(ctx, adapter)
+
+		counts := ac.app.FileProcessor().Logger().GetCounts()
+		if counts[fileevent.ErrorFileAccess] > 0 {
+			messages.WriteString("Some errors occurred. Check the log file for details.\n")
+		}
+
+		archiveDone.Store(true)
+		uiApp.QueueUpdateDraw(func() {
+			ui.refresh(ac.app)
+			modal := newArchiveModal(messages.String())
+			pages.AddPage("modal", modal, true, false)
+			pages.ShowPage("modal")
+		})
+
+		return err
+	})
+
+	if err := g.Wait(); err != nil {
+		return context.Cause(ctx)
+	}
+	if messages.Len() > 0 {
+		return errors.New(messages.String())
+	}
+	return nil
+}
+
+func newArchiveModal(message string) tview.Primitive {
+	message += "\nYou can quit the program safely.\n\nPress the [enter] key to exit."
+	lines := strings.Count(message, "\n")
+	modal := func(p tview.Primitive, width, height int) tview.Primitive {
+		return tview.NewFlex().
+			AddItem(nil, 0, 1, false).
+			AddItem(tview.NewFlex().SetDirection(tview.FlexRow).
+				AddItem(nil, 0, 1, false).
+				AddItem(p, height, 1, true).
+				AddItem(nil, 0, 1, false), width, 1, true).
+			AddItem(nil, 0, 1, false)
+	}
+	text := tview.NewTextView().SetText(message)
+	box := tview.NewBox().SetBorder(true).SetTitle("Archive completed")
+	text.Box = box
+	return modal(text, 80, 2+lines)
+}
+
+func (ac *ArchiveCmd) newArchiveUI(a *app.Application) *archiveUI {
+	ui := &archiveUI{
+		counts:     make(map[fileevent.Code]*tview.TextView),
+		extraViews: make(map[string]*tview.TextView),
+	}
+	if a.FileProcessor() != nil {
+		ui.tracker = a.FileProcessor().Tracker()
+		ui.fp = a.FileProcessor()
+	}
+
+	ui.screen = tview.NewGrid()
+
+	header := tview.NewTextView().
+		SetText(fmt.Sprintf("%s\nLocal index: %s files already archived", app.Banner(), formatCount(ac.indexCount))).
+		SetDynamicColors(true)
+	ui.screen.AddItem(header, 0, 0, 1, 1, 0, 0, false)
+
+	ui.discoveryZone = ui.buildDiscoveryZone()
+	ui.resultsZone = ui.buildResultsZone()
+
+	zones := tview.NewGrid()
+	zones.AddItem(ui.discoveryZone, 0, 0, 1, 1, 0, 0, false)
+	zones.AddItem(ui.resultsZone, 0, 1, 1, 1, 0, 0, false)
+	zones.SetColumns(35, 0)
+	ui.screen.AddItem(zones, 1, 0, 1, 1, 0, 0, false)
+
+	ui.logView = tview.NewTextView().SetMaxLines(100).ScrollToEnd()
+	ui.logView.SetBorder(true).SetTitle("Log")
+	ui.highJackLogger(a)
+	ui.screen.AddItem(ui.logView, 2, 0, 1, 1, 0, 0, false)
+
+	// banner ~5 rows, zones ~7, log fills the rest
+	ui.screen.SetRows(5, 7, 0)
+
+	return ui
+}
+
+func (ui *archiveUI) highJackLogger(a *app.Application) {
+	ui.logView.SetDynamicColors(true)
+	a.FileProcessor().Logger().SetLogger(a.Log().SetLogWriter(tview.ANSIWriter(ui.logView)))
+}
+
+func (ui *archiveUI) restoreLogger(a *app.Application) {
+	a.FileProcessor().Logger().SetLogger(a.Log().SetLogWriter(nil))
+}
+
+func (ui *archiveUI) counter(code fileevent.Code) *tview.TextView {
+	v, ok := ui.counts[code]
+	if !ok {
+		v = tview.NewTextView().SetText("     0").SetTextAlign(tview.AlignRight)
+		ui.counts[code] = v
+	}
+	return v
+}
+
+func (ui *archiveUI) addRow(g *tview.Grid, row int, label string, code fileevent.Code) {
+	g.AddItem(tview.NewTextView().SetText(label), row, 0, 1, 1, 0, 0, false)
+	g.AddItem(ui.counter(code), row, 1, 1, 1, 0, 0, false)
+}
+
+func (ui *archiveUI) addExtraRow(g *tview.Grid, row int, label, key string) {
+	v := tview.NewTextView().SetText("     0").SetTextAlign(tview.AlignRight)
+	ui.extraViews[key] = v
+	g.AddItem(tview.NewTextView().SetText(label), row, 0, 1, 1, 0, 0, false)
+	g.AddItem(v, row, 1, 1, 1, 0, 0, false)
+}
+
+func (ui *archiveUI) buildDiscoveryZone() *tview.Grid {
+	g := tview.NewGrid()
+	g.SetBorder(true).SetTitle("Discovered")
+	ui.addRow(g, 0, "Images", fileevent.DiscoveredImage)
+	ui.addRow(g, 1, "Videos", fileevent.DiscoveredVideo)
+	ui.addExtraRow(g, 2, "Total", "discoveredTotal")
+	g.SetSize(3, 2, 1, 1).SetColumns(22, 0)
+	return g
+}
+
+func (ui *archiveUI) buildResultsZone() *tview.Grid {
+	g := tview.NewGrid()
+	g.SetBorder(true).SetTitle("Results")
+	ui.addRow(g, 0, "Downloaded (new)", fileevent.ProcessedFileArchived)
+	ui.addRow(g, 1, "Skipped (no change)", fileevent.DiscardedLocalDuplicate)
+	ui.addRow(g, 2, "Metadata updated", fileevent.ProcessedMetadataUpdated)
+	ui.addRow(g, 3, "Moved / renamed", fileevent.ProcessedFileMoved)
+	ui.addRow(g, 4, "Errors", fileevent.ErrorFileAccess)
+	ui.addExtraRow(g, 5, "Processed", "processedTotal")
+	g.SetSize(6, 2, 1, 1).SetColumns(22, 0)
+	return g
+}
+
+func (ui *archiveUI) refresh(a *app.Application) {
+	counts := a.FileProcessor().Logger().GetCounts()
+	for code, view := range ui.counts {
+		view.SetText(fmt.Sprintf("%6d", counts[code]))
+	}
+
+	discovered := counts[fileevent.DiscoveredImage] + counts[fileevent.DiscoveredVideo]
+	if v, ok := ui.extraViews["discoveredTotal"]; ok {
+		v.SetText(fmt.Sprintf("%6d", discovered))
+	}
+
+	processed := counts[fileevent.ProcessedFileArchived] + counts[fileevent.ProcessedMetadataUpdated] +
+		counts[fileevent.ProcessedFileMoved] + counts[fileevent.DiscardedLocalDuplicate] +
+		counts[fileevent.ErrorFileAccess]
+	if v, ok := ui.extraViews["processedTotal"]; ok {
+		if discovered > 0 {
+			v.SetText(fmt.Sprintf("%d / %d", processed, discovered))
+		} else {
+			v.SetText(fmt.Sprintf("%d", processed))
+		}
+	}
+}
+
+func formatCount(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	s := fmt.Sprintf("%d", n)
+	result := make([]byte, 0, len(s)+(len(s)-1)/3)
+	for i, c := range s {
+		if i > 0 && (len(s)-i)%3 == 0 {
+			result = append(result, ',')
+		}
+		result = append(result, byte(c))
+	}
+	return string(result)
+}

--- a/internal/assets/asset.go
+++ b/internal/assets/asset.go
@@ -107,6 +107,9 @@ func (a *Asset) UseMetadata(md *Metadata) *Metadata {
 	if md == nil {
 		return nil
 	}
+	if md.FileName != "" {
+		a.OriginalFileName = md.FileName
+	}
 	a.Description = md.Description
 	a.Latitude = md.Latitude
 	a.Longitude = md.Longitude

--- a/internal/assets/metadata.go
+++ b/internal/assets/metadata.go
@@ -12,6 +12,7 @@ import (
 
 type Metadata struct {
 	File        fshelper.FSAndName `json:"-"`                     // File name and file system that holds the metadata. Could be empty
+	Checksum    string             `json:"checksum,omitempty"`    // Base64 SHA1 from Immich; persistent identity key for reruns
 	FileName    string             `json:"fileName,omitempty"`    // File name as presented to users
 	Latitude    float64            `json:"latitude,omitempty"`    // GPS
 	Longitude   float64            `json:"longitude,omitempty"`   // GPS

--- a/internal/fileevent/fileevents.go
+++ b/internal/fileevent/fileevents.go
@@ -48,6 +48,7 @@ const (
 	ProcessedUploadUpgraded  // Server asset upgraded with input
 	ProcessedMetadataUpdated // Asset metadata updated on server
 	ProcessedFileArchived    // Asset successfully archived to disk
+	ProcessedFileMoved       // Asset moved or renamed on disk (archive rerun)
 
 	// ===== Asset Lifecycle Events - To DISCARDED =====
 	DiscardedServerDuplicate // Server already has this asset
@@ -95,6 +96,7 @@ var _code = map[Code]string{
 	ProcessedUploadUpgraded:  "server asset upgraded",
 	ProcessedMetadataUpdated: "metadata updated",
 	ProcessedFileArchived:    "file archived",
+	ProcessedFileMoved:       "file moved/renamed",
 
 	// To DISCARDED
 	DiscardedServerDuplicate: "server has duplicate",
@@ -139,6 +141,7 @@ var _logLevels = map[Code]slog.Level{
 	ProcessedUploadUpgraded:  slog.LevelInfo,
 	ProcessedMetadataUpdated: slog.LevelInfo,
 	ProcessedFileArchived:    slog.LevelInfo,
+	ProcessedFileMoved:       slog.LevelInfo,
 
 	// To DISCARDED
 	DiscardedServerDuplicate: slog.LevelInfo,

--- a/internal/fshelper/extendedFS.go
+++ b/internal/fshelper/extendedFS.go
@@ -27,6 +27,10 @@ type FSCanStat interface {
 	Stat(name string) (fs.FileInfo, error)
 }
 
+type FSCanRename interface {
+	Rename(oldPath, newPath string) error
+}
+
 type FSCanLink interface {
 	Lstat(name string) (fs.FileInfo, error)
 	Readlink(name string) (string, error)
@@ -74,6 +78,13 @@ func MkdirAll(fsys fs.FS, path string, perm fs.FileMode) error {
 	} else {
 		return errors.New("mkdirAll not supported")
 	}
+}
+
+func Rename(fsys fs.FS, oldPath, newPath string) error {
+	if fsys, ok := fsys.(FSCanRename); ok {
+		return fsys.Rename(oldPath, newPath)
+	}
+	return errors.New("rename not supported")
 }
 
 func Remove(fsys fs.FS, name string) error {

--- a/internal/fshelper/osfs/osfs.go
+++ b/internal/fshelper/osfs/osfs.go
@@ -24,6 +24,7 @@ var (
 	_ fshelper.FSCanRemove = dirFS("")
 	_ fshelper.FSCanStat   = dirFS("")
 	_ fshelper.FSCanLink   = dirFS("")
+	_ fshelper.FSCanRename = dirFS("")
 )
 
 type dirFS string
@@ -66,6 +67,10 @@ func (dir dirFS) MkSymlink(name, target string) error {
 
 func (dir dirFS) Remove(name string) error {
 	return os.Remove(filepath.Join(string(dir), name))
+}
+
+func (dir dirFS) Rename(oldPath, newPath string) error {
+	return os.Rename(filepath.Join(string(dir), oldPath), filepath.Join(string(dir), newPath))
 }
 
 type OSFS interface {


### PR DESCRIPTION
## Summary

_Built with Claude Code_

This PR makes `archive from-immich` fully idempotent and adds a live terminal UI, building on the filename and metadata fixes from [#1272](https://github.com/simulot/immich-go/pull/1272) by @x3rAx in the main immich-go repo.

### Fixes (inherited from #1272)
- **Correct filenames on disk** — archived files now use the original human-readable filename (e.g. `photo.jpg`) instead of a hash-derived name
- **Albums in sidecar** — album membership is now correctly written into the JSON sidecar alongside the asset

### Idempotent reruns (new)
- **Startup index** — on each run, all existing JSON sidecars are scanned and indexed by checksum (`map[checksum → location + metadata]`). This enables O(1) duplicate detection without any extra API calls.
- **No re-downloads** — if an asset's checksum is already in the local index, the binary is never re-downloaded.
- **Metadata sync** — if the server-side metadata has changed (new album, corrected date, renamed file), the JSON sidecar is refreshed. Unchanged sidecars are left untouched, preserving `mtime` for backup tools like rsync and Time Machine.
- **File moves** — if a capture date is corrected in Immich, the asset is moved to the right `YYYY/YYYY-MM/` folder on the next run. If a filename changes server-side, the file is renamed in place.
- **Collision handling** — files with the same name get a `-N` dash suffix (e.g. `photo-1.jpg`), tracked via an in-memory fileset for O(1) lookups.

### Live terminal UI (new)
- Modelled on the existing upload UI (`tview`, 100 ms refresh tick).
- **Discovered** zone: Images / Videos / Total.
- **Results** zone: Downloaded (new) / Skipped (no change) / Metadata updated / Moved-renamed / Errors / Processed N of M.
- **Log** zone: scrollable per-asset outcome lines.
- End-of-run modal: "You can quit the program safely" + Enter to exit.
- Falls back to plain log output if no TTY is available.

## Steps to test
- [ ] `go test ./adapters/folder/... ./app/archive/...` — 7 new unit tests covering all write outcomes
- [ ] Run `archive from-immich` against a real server — verify human-readable filenames, JSON sidecars have `checksum` field, live UI appears
- [ ] Run a second time — verify "Skipped (no change)" dominates, zero bytes downloaded
- [ ] Correct a capture date or rename a file in Immich, rerun — verify file moves / renames correctly
- [ ] Add an asset to an album in Immich, rerun — verify JSON sidecar updated, binary not re-downloaded