### PR TITLE
Fix Google Photos stopping discovery when a symbolic link is present

### DIFF
--- a/adapters/googlePhotos/googlephotos.go
+++ b/adapters/googlePhotos/googlephotos.go
@@ -3,6 +3,7 @@ package gp
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io/fs"
 	"log/slog"
 	"path"
@@ -95,6 +96,11 @@ func (toc *TakeoutCmd) Browse(ctx context.Context) chan *assets.Group {
 func (toc *TakeoutCmd) passOneFsWalk(ctx context.Context, w fs.FS) error {
 	err := fs.WalkDir(w, ".", func(name string, d fs.DirEntry, err error) error {
 		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				// This branch can happen when you have symbolic links.
+				return nil
+			}
+
 			return err
 		}
 

--- a/adapters/googlePhotos/googlephotos_test.go
+++ b/adapters/googlePhotos/googlephotos_test.go
@@ -1,0 +1,32 @@
+package gp
+
+import (
+	"io/fs"
+	"testing"
+)
+
+// mockFS implements a simple fs.FS for testing
+type mockFS struct{}
+
+func (m mockFS) Open(name string) (fs.File, error) {
+	return nil, fs.ErrNotExist
+}
+
+func (m mockFS) Name() string {
+	return "test.zip"
+}
+
+func Test_TakeoutCmd_passOneFsWalk(t *testing.T) {
+	t.Parallel()
+
+	t.Run("pass: fs.ErrNotExist should not error", func(t *testing.T) {
+		t.Parallel()
+
+		toc := &TakeoutCmd{}
+
+		err := toc.passOneFsWalk(t.Context(), mockFS{})
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+	})
+}


### PR DESCRIPTION
# Summary

When uploading a google photos takeout from a filesystem with symbolic links present, for example: `@eaDir`  
The bannedFiles does not stop the fs walk from erroring and stopping the first passthrough.

To reproduce, you should execute the following command on a takeout where there is a symbolic link within.
In my case it was synology `@eaDir` for thumbnails:
```bash
immich-go upload from-google-photos --server=http://localhost:2283 --api-key=XXX ./data
```

Issue: #1157