### PR TITLE
fix: replace worker pool with semaphore to prevent deadlock in recurs…

### DIFF
--- a/adapters/folder/run.go
+++ b/adapters/folder/run.go
@@ -101,7 +101,9 @@ func (ifc *ImportFolderCmd) run(cmd *cobra.Command, args []string, app *app.Appl
 const icloudMetadataExt = ".csv"
 
 func (ifc *ImportFolderCmd) Browse(ctx context.Context) chan *assets.Group {
-	gOut := make(chan *assets.Group)
+	// Buffered channel to prevent scanner goroutines from blocking on slow consumers
+	// Buffer size of 10000 allows scanning to complete independently of upload speed
+	gOut := make(chan *assets.Group, 10000)
 	go func() {
 		defer func() {
 			close(gOut)
@@ -126,7 +128,8 @@ func (ifc *ImportFolderCmd) Browse(ctx context.Context) chan *assets.Group {
 func (ifc *ImportFolderCmd) concurrentParseDir(ctx context.Context, fsys fs.FS, dir string, gOut chan *assets.Group) {
 	ifc.wg.Add(1)
 	ctx, cancel := context.WithCancelCause(ctx)
-	go ifc.pool.Submit(func() {
+	// Submit directly - pool.Submit() already handles goroutines internally
+	ifc.pool.Submit(func() {
 		defer ifc.wg.Done()
 		err := ifc.parseDir(ctx, fsys, dir, gOut)
 		if err != nil {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -1,59 +1,53 @@
 package worker
 
-import (
-	"sync"
-)
+// Semaphore limits concurrent execution using a buffered channel.
+// Unlike a worker pool, it allows unlimited goroutines but only N run concurrently.
+// This prevents deadlock in recursive directory scanning scenarios.
+type Semaphore struct {
+	sem chan struct{}
+}
 
-// Task represents a unit of work to be processed by the worker pool.
-type Task func()
+// NewSemaphore creates a new Semaphore with the specified concurrency limit.
+func NewSemaphore(limit int) *Semaphore {
+	return &Semaphore{
+		sem: make(chan struct{}, limit),
+	}
+}
 
-// Pool manages a pool of worker goroutines.
+// Acquire acquires a semaphore slot, blocking if limit is reached.
+func (s *Semaphore) Acquire() {
+	s.sem <- struct{}{}
+}
+
+// Release releases a semaphore slot, allowing another goroutine to proceed.
+func (s *Semaphore) Release() {
+	<-s.sem
+}
+
+// Pool is kept for backward compatibility but now uses Semaphore internally.
 type Pool struct {
-	tasks  chan Task
-	wg     sync.WaitGroup
-	quit   chan struct{}
-	closed bool
+	semaphore *Semaphore
 }
 
-// NewPool creates a new Pool with a specified number of workers.
+// NewPool creates a new Pool that uses a Semaphore for concurrency control.
 func NewPool(numWorkers int) *Pool {
-	pool := &Pool{
-		tasks: make(chan Task),
-		quit:  make(chan struct{}),
-	}
-
-	for i := 0; i < numWorkers; i++ {
-		pool.wg.Add(1)
-		go pool.worker()
-	}
-
-	return pool
-}
-
-// worker is the function that each worker goroutine runs.
-func (p *Pool) worker() {
-	defer p.wg.Done()
-	for {
-		select {
-		case task := <-p.tasks:
-			task()
-		case <-p.quit:
-			return
-		}
+	return &Pool{
+		semaphore: NewSemaphore(numWorkers),
 	}
 }
 
-// Submit adds a task to the worker pool.
-func (p *Pool) Submit(task Task) {
-	p.tasks <- task
+// Submit executes a task with semaphore-based concurrency control.
+// The task runs in its own goroutine but is limited by the semaphore.
+func (p *Pool) Submit(task func()) {
+	go func() {
+		p.semaphore.Acquire()
+		defer p.semaphore.Release()
+		task()
+	}()
 }
 
-// Stop stops all the workers and waits for them to finish.
+// Stop is a no-op for backward compatibility.
+// With semaphore approach, there are no workers to stop.
 func (p *Pool) Stop() {
-	if !p.closed {
-		close(p.quit)
-		p.wg.Wait()
-		close(p.tasks)
-		p.closed = true
-	}
+	// No-op: semaphore doesn't need cleanup
 }


### PR DESCRIPTION
…ive dir scan

The previous fixed-size worker pool pattern caused deadlocks when recursive directory scanning submitted tasks faster than workers could consume them. The pool's task channel would block, causing all goroutines to stall.

Changes:
- worker.go: Replace Pool (fixed goroutines + task channel) with Semaphore (unlimited goroutines, N concurrent). Semaphore allows each submitted task to spawn its own goroutine immediately, avoiding channel backpressure. Pool type retained for backward compatibility; Stop() is now a no-op.
- run.go: Buffer the gOut channel (10000) so folder scanning goroutines don't block waiting for the upload consumer. Removes go wrapper around pool.Submit() since Submit() now spawns its own goroutine internally.

Tested against large library (100k+ files) — no deadlock observed.