### PR TITLE
Don't resume jobs if ----pause-immich-jobs=FALSE is used

### DIFF
--- a/app/upload/run.go
+++ b/app/upload/run.go
@@ -101,10 +101,12 @@ func (uc *UpCmd) finishing(ctx context.Context) error {
 	uc.albumsCache.Close()
 	uc.tagsCache.Close()
 
-	// Resume immich background jobs if requested
-	err := uc.resumeJobs(ctx)
-	if err != nil {
-		return err
+	// Resume immich background jobs only when they were paused at upload start.
+	if uc.client.PauseImmichBackgroundJobs {
+		err := uc.resumeJobs(ctx)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Generate FileProcessor report


### PR DESCRIPTION
I found this issue when running with a non-admin user api key. Despite I've used --pause-immich-jobs=FALSE, it still tried to resume jobs at the end and got 403 errors from the server. So, it makes sense to me to only resume jobs if it paused it at the beginning. 