### PR TITLE
fix: immich v3 support

### DIFF
--- a/app/upload/run.go
+++ b/app/upload/run.go
@@ -187,14 +187,25 @@ func (uc *UpCmd) getImmichAlbums(ctx context.Context) error {
 					uc.app.Log().Error("can't get the album info from the server", "album", a.AlbumName, "err", err)
 					continue
 				}
-				ids := make([]string, 0, len(r.Assets))
-				for _, aa := range r.Assets {
-					ids = append(ids, aa.ID)
+
+				ids := make([]string, 0, r.AssetCount)
+
+				// v3 requires using the paginated `/api/search/metadata` endpoint to get the assets in an album
+				if uc.client.Immich.Version().Major() >= 3 {
+					ids, err = uc.client.Immich.GetAlbumAssetIDs(ctx, a.ID)
+					if err != nil {
+						uc.app.Log().Error("can't get the album assets from the server", "album", a.AlbumName, "err", err)
+						continue
+					}
+				} else {
+					for _, aa := range r.Assets {
+						ids = append(ids, aa.ID)
+					}
 				}
 
 				album := assets.NewAlbum(a.ID, a.AlbumName, a.Description)
 				uc.albumsCache.NewCollection(a.AlbumName, album, ids)
-				uc.app.Log().Info("got album from the server", "album", a.AlbumName, "assets", len(r.Assets))
+				uc.app.Log().Info("got album from the server", "album", a.AlbumName, "assets", len(ids))
 				uc.app.Log().Debug("got album from the server", "album", a.AlbumName, "assets", ids)
 				// assign the album to the assets
 				for _, id := range ids {

--- a/app/upload/run.go
+++ b/app/upload/run.go
@@ -181,26 +181,11 @@ func (uc *UpCmd) getImmichAlbums(ctx context.Context) error {
 			case <-ctx.Done():
 				return ctx.Err()
 			default:
-				// Get the album info from the server, with assets.
-				r, err := uc.client.Immich.GetAlbumInfo(ctx, a.ID, false)
+				ids := []string{}
+				ids, err = uc.client.Immich.GetAlbumAssetIDs(ctx, a.ID)
 				if err != nil {
-					uc.app.Log().Error("can't get the album info from the server", "album", a.AlbumName, "err", err)
+					uc.app.Log().Error("can't get the album assets from the server", "album", a.AlbumName, "err", err)
 					continue
-				}
-
-				ids := make([]string, 0, r.AssetCount)
-
-				// v3 requires using the paginated `/api/search/metadata` endpoint to get the assets in an album
-				if uc.client.Immich.Version().Major() >= 3 {
-					ids, err = uc.client.Immich.GetAlbumAssetIDs(ctx, a.ID)
-					if err != nil {
-						uc.app.Log().Error("can't get the album assets from the server", "album", a.AlbumName, "err", err)
-						continue
-					}
-				} else {
-					for _, aa := range r.Assets {
-						ids = append(ids, aa.ID)
-					}
 				}
 
 				album := assets.NewAlbum(a.ID, a.AlbumName, a.Description)

--- a/docs/releases/release-notes-v0.32.0.md
+++ b/docs/releases/release-notes-v0.32.0.md
@@ -1,0 +1,40 @@
+# Release Notes - v0.32.0
+
+This release brings full compatibility with Immich V3.0.0. All upload, album, and server
+communication paths have been updated to work with the new API while maintaining backward
+compatibility with Immich V2.
+
+## ✨ New Features
+
+- **Immich V3 support** – Full compatibility with Immich V3.0.0. The tool now detects the
+  server version and adapts its behavior accordingly, ensuring smooth operation regardless
+  of which version you're running.
+- **Server version detection** – `immich-go` now reads and exposes the server version at
+  startup, enabling version-aware API calls.
+
+## 🚀 Improvements
+
+- **Album contents via search** – Album asset retrieval now uses the paginated
+  `POST /api/search/metadata` endpoint instead of relying on `GET /api/albums/{id}` to
+  return assets. This works with both Immich V2 and V3 and is more reliable for large
+  albums.
+- **Error handling overhaul** – Server error messages are now parsed according to the
+  server version (Zod-based errors for V3, legacy format for V2), providing clearer and
+  more actionable error output.
+
+
+## 🔧 Internal Changes
+
+- **Asset upload field changes** – Removed `deviceId` and `deviceAssetId` from the upload
+  payload (dropped in Immich V3's `AssetMediaCreateDto`). These fields are silently
+  ignored by V2, so this change is safe across versions.
+- **Duration field handling** – The `duration` field has been updated to use `"0"` as a
+  plain string value, which is accepted by both Immich V2 and V3.
+
+- **Removed deprecated `replaceAsset`** – The `ReplaceAsset` method and its associated
+  `asset.replace` permission have been removed entirely. Use `CopyAsset` instead.
+- **Error processing moved to `immich/error.go`** – All server error parsing logic is now
+  centralized with a `serverError` interface and separate `serverErrorV2`/`serverErrorV3`
+  implementations.
+- **Album contents E2E test** – Added `Test_GetImmichAlbums` to verify that album uploads
+  and duplicate detection work correctly with the new search-based album retrieval.

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/simulot/immich-go
 go 1.25
 
 require (
+	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/disintegration/imaging v1.6.2
 	github.com/gdamore/tcell/v2 v2.11.0
 	github.com/google/uuid v1.6.0

--- a/immich/albums.go
+++ b/immich/albums.go
@@ -62,7 +62,7 @@ type AlbumContent struct {
 	// AlbumThumbnailAssetID      string    `json:"albumThumbnailAssetId"`
 	// SharedUsers                []string  `json:"sharedUsers"`
 	// Owner                      User      `json:"owner"`
-	AssetCount int `json:"assetCount"`
+	// AssetCount int `json:"assetCount"`
 	// LastModifiedAssetTimestamp time.Time `json:"lastModifiedAssetTimestamp"
 }
 
@@ -105,8 +105,7 @@ func (ic *ImmichClient) GetAlbumInfo(ctx context.Context, id string, withoutAsse
 func (ic *ImmichClient) GetAlbumAssetIDs(ctx context.Context, albumID string) ([]string, error) {
 	ids := []string{}
 	query := &SearchMetadataQuery{
-		AlbumIds:    []string{albumID},
-		WithDeleted: true,
+		AlbumIds: []string{albumID},
 	}
 	err := ic.callSearchMetadata(ctx, query, func(a *Asset) error {
 		ids = append(ids, a.ID)

--- a/immich/albums.go
+++ b/immich/albums.go
@@ -62,7 +62,7 @@ type AlbumContent struct {
 	// AlbumThumbnailAssetID      string    `json:"albumThumbnailAssetId"`
 	// SharedUsers                []string  `json:"sharedUsers"`
 	// Owner                      User      `json:"owner"`
-	// AssetCount                 int       `json:"assetCount"`
+	AssetCount int `json:"assetCount"`
 	// LastModifiedAssetTimestamp time.Time `json:"lastModifiedAssetTimestamp"
 }
 
@@ -100,6 +100,22 @@ func (ic *ImmichClient) GetAlbumInfo(ctx context.Context, id string, withoutAsse
 	}
 	err := ic.newServerCall(ctx, EndPointGetAlbumInfo).do(getRequest("/albums/"+query, setAcceptJSON()), responseJSON(&album))
 	return album, err
+}
+
+func (ic *ImmichClient) GetAlbumAssetIDs(ctx context.Context, albumID string) ([]string, error) {
+	ids := []string{}
+	query := &SearchMetadataQuery{
+		AlbumIds:    []string{albumID},
+		WithDeleted: true,
+	}
+	err := ic.callSearchMetadata(ctx, query, func(a *Asset) error {
+		ids = append(ids, a.ID)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return ids, nil
 }
 
 func (ic *ImmichClient) GetAssetsAlbums(ctx context.Context, id string) ([]assets.Album, error) {

--- a/immich/asset.go
+++ b/immich/asset.go
@@ -3,7 +3,6 @@ package immich
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -20,7 +19,10 @@ type Asset struct {
 	DeviceAssetID string `json:"deviceAssetId"`
 	DeviceID      string `json:"deviceId"`
 	// duplicateId
-	Duration       string     `json:"duration"`
+
+	// Not used and has changes in immich v3
+	// Duration       string     `json:"duration"`
+
 	ExifInfo       ExifInfo   `json:"exifInfo"`
 	FileCreatedAt  ImmichTime `json:"fileCreatedAt"`
 	FileModifiedAt ImmichTime `json:"fileModifiedAt"`
@@ -149,12 +151,6 @@ const (
 
 func (ic *ImmichClient) AssetUpload(ctx context.Context, la *assets.Asset) (AssetResponse, error) {
 	return ic.uploadAsset(ctx, la, EndPointAssetUpload, "")
-}
-
-// ReplaceAsset is deprecated, use CopyAsset
-func (ic *ImmichClient) ReplaceAsset(ctx context.Context, ID string, la *assets.Asset) (AssetResponse, error) {
-	return AssetResponse{}, errors.New("ReplaceAsset end point is deprecated, use CopyAsset")
-	// return ic.uploadAsset(ctx, la, EndPointAssetReplace, ID)
 }
 
 type GetAssetOptions struct {

--- a/immich/call.go
+++ b/immich/call.go
@@ -10,7 +10,6 @@ import (
 	"mime"
 	"net/http"
 	"net/url"
-	"strings"
 	"sync/atomic"
 
 	"github.com/simulot/immich-go/internal/assets"
@@ -69,53 +68,6 @@ type serverCall struct {
 	hasResponseHandler bool
 }
 
-// callError represents errors returned by the server
-type callError struct {
-	endPoint string
-	method   string
-	url      string
-	status   int
-	err      error
-	message  *ServerErrorMessage
-}
-
-type ServerErrorMessage struct {
-	Error         string `json:"error"`
-	StatusCode    int    `json:"statusCode"`
-	Message       string `json:"message"`
-	CorrelationID string `json:"correlationId"`
-}
-
-func (ce callError) Is(target error) bool {
-	_, ok := target.(*callError)
-	return ok
-}
-
-func (ce callError) Error() string {
-	b := strings.Builder{}
-	b.WriteString(ce.endPoint)
-	b.WriteString(", ")
-	b.WriteString(ce.method)
-	b.WriteString(", ")
-	b.WriteString(ce.url)
-	if ce.status > 0 {
-		b.WriteString(", ")
-		b.WriteString(fmt.Sprintf("%d %s", ce.status, http.StatusText(ce.status)))
-	}
-	b.WriteRune('\n')
-	if ce.err != nil && !errors.Is(ce.err, &callError{}) {
-		b.WriteString(ce.err.Error())
-		b.WriteRune('\n')
-	}
-
-	if ce.message != nil {
-		b.WriteString(ce.message.Message)
-		b.WriteRune('\n')
-	}
-
-	return b.String()
-}
-
 func (ic *ImmichClient) newServerCall(ctx context.Context, api string) *serverCall {
 	sc := &serverCall{
 		endPoint: api,
@@ -125,7 +77,7 @@ func (ic *ImmichClient) newServerCall(ctx context.Context, api string) *serverCa
 	return sc
 }
 
-func (sc *serverCall) Err(req *http.Request, resp *http.Response, msg *ServerErrorMessage) error {
+func (sc *serverCall) Err(req *http.Request, resp *http.Response, msg serverError) error {
 	ce := callError{
 		endPoint: sc.endPoint,
 		err:      sc.err,
@@ -139,6 +91,27 @@ func (sc *serverCall) Err(req *http.Request, resp *http.Response, msg *ServerErr
 	}
 	ce.message = msg
 	return ce
+}
+
+// Builds the correct error message based on server version
+func (sc *serverCall) decodeServerError(resp *http.Response) serverError {
+	var body []byte
+	if resp.Body != nil {
+		defer resp.Body.Close()
+		if isJSON(resp.Header.Get("Content-Type")) {
+			body, _ = io.ReadAll(resp.Body)
+		}
+	}
+
+	if v := sc.ic.serverVersion; v != nil && v.Major() >= 3 {
+		e := serverErrorV3{CorrelationID: resp.Header.Get("X-Correlation-ID")}
+		json.Unmarshal(body, &e)
+		return e
+	}
+
+	var e serverErrorV2
+	json.Unmarshal(body, &e)
+	return e
 }
 
 func (sc *serverCall) joinError(err error) error {
@@ -237,16 +210,7 @@ func (sc *serverCall) do(fnRequest requestFunction, opts ...serverResponseOption
 
 	// Any StatusCode above 300 denotes a problem, we expect a JSON with the server's error
 	if resp.StatusCode >= 300 {
-		msg := ServerErrorMessage{}
-		if resp.Body != nil {
-			defer resp.Body.Close()
-			if isJSON(resp.Header.Get("Content-Type")) {
-				if json.NewDecoder(resp.Body).Decode(&msg) == nil {
-					return sc.Err(req, resp, &msg)
-				}
-			}
-		}
-		return sc.Err(req, resp, &msg)
+		return sc.Err(req, resp, sc.decodeServerError(resp))
 	}
 
 	// We have a success

--- a/immich/call.go
+++ b/immich/call.go
@@ -103,13 +103,13 @@ func (sc *serverCall) decodeServerError(resp *http.Response) serverError {
 		}
 	}
 
-	if v := sc.ic.serverVersion; v != nil && v.Major() >= 3 {
-		e := serverErrorV3{CorrelationID: resp.Header.Get("X-Correlation-ID")}
+	if v := sc.ic.serverVersion; v != nil && v.Major() < 3 {
+		var e serverErrorV2
 		json.Unmarshal(body, &e)
 		return e
 	}
 
-	var e serverErrorV2
+	e := serverErrorV3{CorrelationID: resp.Header.Get("X-Correlation-ID")}
 	json.Unmarshal(body, &e)
 	return e
 }

--- a/immich/client.go
+++ b/immich/client.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/simulot/immich-go/internal/filetypes"
 )
 
@@ -29,6 +30,11 @@ type ImmichClient struct {
 
 	supportedMediaTypes filetypes.SupportedMedia // Server's list of supported medias
 	dryRun              bool                     //  If true, do not send any data to the server
+	serverVersion       *semver.Version          // Parsed version of the connected server, set by GetAboutInfo
+}
+
+func (ic *ImmichClient) Version() *semver.Version {
+	return ic.serverVersion
 }
 
 func (ic *ImmichClient) SetEndPoint(endPoint string) {

--- a/immich/error.go
+++ b/immich/error.go
@@ -1,0 +1,74 @@
+package immich
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// callError represents errors returned by the server
+type callError struct {
+	endPoint string
+	method   string
+	url      string
+	status   int
+	err      error
+	message  serverError
+}
+
+type serverError interface {
+	lines() []string
+}
+
+type serverErrorV2 struct {
+	Error         string `json:"error"`
+	StatusCode    int    `json:"statusCode"`
+	Message       string `json:"message"`
+	CorrelationID string `json:"correlationId"`
+}
+
+func (e serverErrorV2) lines() []string {
+	return []string{e.Message}
+}
+
+type serverErrorV3 struct {
+	Message       string          `json:"message"`
+	Errors        json.RawMessage `json:"errors"`
+	CorrelationID string          `json:"-"` // from the X-Correlation-ID header
+}
+
+func (e serverErrorV3) lines() []string {
+	var out []string
+	if e.Message != "" {
+		out = append(out, e.Message)
+	}
+	if len(e.Errors) > 0 {
+		out = append(out, string(e.Errors))
+	}
+	if e.CorrelationID != "" {
+		out = append(out, "correlationId: "+e.CorrelationID)
+	}
+	return out
+}
+
+func (ce callError) Is(target error) bool {
+	_, ok := target.(*callError)
+	return ok
+}
+
+func (ce callError) Error() string {
+	head := fmt.Sprintf("%s, %s, %s", ce.endPoint, ce.method, ce.url)
+	if ce.status > 0 {
+		head += fmt.Sprintf(", %d %s", ce.status, http.StatusText(ce.status))
+	}
+	lines := []string{head}
+	if ce.err != nil && !errors.Is(ce.err, &callError{}) {
+		lines = append(lines, ce.err.Error())
+	}
+	if ce.message != nil {
+		lines = append(lines, ce.message.lines()...)
+	}
+	return strings.Join(lines, "\n") + "\n"
+}

--- a/immich/immich.go
+++ b/immich/immich.go
@@ -28,7 +28,6 @@ type ImmichAssetInterface interface {
 	GetAssetInfo(ctx context.Context, id string) (*Asset, error)
 	DownloadAsset(ctx context.Context, id string) (io.ReadCloser, error)
 	UpdateAsset(ctx context.Context, id string, param UpdAssetField) (*Asset, error)
-	ReplaceAsset(ctx context.Context, ID string, la *assets.Asset) (AssetResponse, error) // Deprecated
 	CopyAsset(ctx context.Context, sourceID string, targetID string) error
 	GetAllAssets(ctx context.Context, fn func(*Asset) error) error
 	AddAssetToAlbum(context.Context, string, []string) ([]UpdateAlbumResult, error)

--- a/immich/immich.go
+++ b/immich/immich.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/simulot/immich-go/internal/assets"
 	"github.com/simulot/immich-go/internal/filetypes"
 )
@@ -68,11 +69,13 @@ type ImmichClientInterface interface {
 	GetAssetStatistics(ctx context.Context) (UserStatistics, error)
 	SupportedMedia() filetypes.SupportedMedia
 	GetAboutInfo(ctx context.Context) (AboutInfo, error)
+	Version() *semver.Version
 }
 
 type ImmichAlbumInterface interface {
 	GetAllAlbums(ctx context.Context) ([]AlbumSimplified, error)
 	GetAlbumInfo(ctx context.Context, id string, withoutAssets bool) (AlbumContent, error)
+	GetAlbumAssetIDs(ctx context.Context, albumID string) ([]string, error)
 	CreateAlbum(
 		ctx context.Context,
 		tilte string,

--- a/immich/ping.go
+++ b/immich/ping.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/simulot/immich-go/internal/filetypes"
 )
 
@@ -94,6 +95,13 @@ type AboutInfo struct {
 func (ic *ImmichClient) GetAboutInfo(ctx context.Context) (AboutInfo, error) {
 	var a AboutInfo
 	err := ic.newServerCall(ctx, EndPointGetAboutInfo).do(getRequest("/server/about", setAcceptJSON()), responseJSON(&a))
+	if err == nil {
+		ic.serverVersion, err = semver.NewVersion(a.Version)
+
+		if err != nil {
+			return a, fmt.Errorf("error parsing server version: %w", err)
+		}
+	}
 	return a, err
 }
 

--- a/immich/upload.go
+++ b/immich/upload.go
@@ -134,11 +134,7 @@ func (ic *ImmichClient) prepareCallValues(la *assets.Asset, s fs.FileInfo, ext, 
 	callValues["isFavorite"] = myBool(la.Favorite).String()
 	callValues["fileExtension"] = ext
 
-	if ic.serverVersion.Major() >= 3 {
-		callValues["duration"] = "0"
-	} else {
-		callValues["duration"] = formatDuration(0)
-	}
+	callValues["duration"] = "0"
 	callValues["isReadOnly"] = "false"
 	if la.Archived {
 		callValues["visibility"] = "archive"

--- a/immich/upload.go
+++ b/immich/upload.go
@@ -133,7 +133,12 @@ func (ic *ImmichClient) prepareCallValues(la *assets.Asset, s fs.FileInfo, ext, 
 	callValues["fileModifiedAt"] = s.ModTime().UTC().Format(TimeFormat)
 	callValues["isFavorite"] = myBool(la.Favorite).String()
 	callValues["fileExtension"] = ext
-	callValues["duration"] = formatDuration(0)
+
+	if ic.serverVersion.Major() >= 3 {
+		callValues["duration"] = "0"
+	} else {
+		callValues["duration"] = formatDuration(0)
+	}
 	callValues["isReadOnly"] = "false"
 	if la.Archived {
 		callValues["visibility"] = "archive"

--- a/internal/e2e/client/albums_test.go
+++ b/internal/e2e/client/albums_test.go
@@ -1,0 +1,70 @@
+//go:build e2e
+
+package client
+
+import (
+	"context"
+	"testing"
+
+	"github.com/simulot/immich-go/app"
+	"github.com/simulot/immich-go/app/root"
+	e2eutils "github.com/simulot/immich-go/internal/e2e/e2eUtils"
+	"github.com/simulot/immich-go/internal/fileevent"
+)
+
+func Test_GetImmichAlbums(t *testing.T) {
+	adm, err := getUser("admin@immich.app")
+	if err != nil {
+		t.Fatalf("can't get admin user: %v", err)
+	}
+	// A fresh user so the album namespace is clean.
+	u1, err := createUser("minimal")
+	if err != nil {
+		t.Fatalf("can't create user: %v", err)
+	}
+
+	const albumName = "getImmichAlbums"
+	const expectedAssets = 40
+
+	// uploadIntoAlbum runs `upload from-folder --into-album=<albumName>` and
+	// returns the application so the caller can inspect the file processor.
+	uploadIntoAlbum := func(ctx context.Context) *app.Application {
+		t.Helper()
+		c, a := root.RootImmichGoCommand(ctx)
+		c.SetArgs([]string{
+			"upload", "from-folder",
+			"--server=" + ImmichURL,
+			"--api-key=" + u1.APIKey,
+			"--admin-api-key=" + adm.APIKey,
+			"--into-album=" + albumName,
+			"--no-ui",
+			"--api-trace",
+			"--log-level=debug",
+			"DATA/fromFolder/recursive",
+		})
+		if err := c.ExecuteContext(ctx); err != nil {
+			if a.Log().GetSLog() != nil {
+				a.Log().Error(err.Error())
+			}
+			t.Fatalf("unexpected error during upload: %v", err)
+		}
+		return a
+	}
+
+	// First run: every asset is uploaded and added to the album.
+	a1 := uploadIntoAlbum(t.Context())
+	e2eutils.CheckResults(t, map[fileevent.Code]int64{
+		fileevent.ProcessedUploadSuccess: expectedAssets,
+		fileevent.ProcessedAlbumAdded:    expectedAssets,
+	}, false, a1.FileProcessor())
+
+	// Second run: assets already exist on the server and already belong to the
+	// album. getImmichAlbums must surface that membership so nothing is
+	// re-uploaded and nothing is re-added to the album.
+	a2 := uploadIntoAlbum(t.Context())
+	e2eutils.CheckResults(t, map[fileevent.Code]int64{
+		fileevent.ProcessedUploadSuccess:   0,
+		fileevent.ProcessedAlbumAdded:      0,
+		fileevent.DiscardedServerDuplicate: expectedAssets,
+	}, false, a2.FileProcessor())
+}

--- a/internal/e2e/client/common_test.go
+++ b/internal/e2e/client/common_test.go
@@ -184,7 +184,6 @@ var permissions map[string][]string = map[string][]string{
 		`asset.update`,
 		`asset.upload`,
 		`asset.copy`,
-		`asset.replace`,
 		`asset.delete`,
 		`asset.download`,
 		`album.create`,

--- a/internal/e2e/e2eUtils/cmd/createUser/createUser.go
+++ b/internal/e2e/e2eUtils/cmd/createUser/createUser.go
@@ -129,7 +129,6 @@ var permissions map[string][]string = map[string][]string{
 		`asset.update`,
 		`asset.upload`,
 		`asset.copy`,
-		`asset.replace`,
 		`asset.delete`,
 		`asset.download`,
 		`album.create`,

--- a/internal/fakeImmich/immich.go
+++ b/internal/fakeImmich/immich.go
@@ -96,3 +96,7 @@ func (c *MockedCLient) GetJobs(ctx context.Context) (map[string]immich.Job, erro
 func (c *MockedCLient) GetAlbumInfo(context.Context, string, bool) (immich.AlbumContent, error) {
 	return immich.AlbumContent{}, nil
 }
+
+func (c *MockedCLient) GetAlbumAssetIDs(context.Context, string) ([]string, error) {
+	return []string{}, nil
+}

--- a/scripts/e2e/e2e-provision.sh
+++ b/scripts/e2e/e2e-provision.sh
@@ -21,6 +21,7 @@ INSTALL_DIR="${1:-${PROJECT_DIR}/internal/e2e/testdata/immich-server}"
 IMMICH_PORT="${2:-2283}"
 COMPOSE_URL="https://github.com/immich-app/immich/releases/latest/download/docker-compose.yml"
 ENV_URL="https://github.com/immich-app/immich/releases/latest/download/example.env"
+REQUIRED_VERSION="v3.0.0-rc.2"
 TIMEOUT=180  # seconds to wait for API
 
 echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
@@ -65,6 +66,10 @@ if [ "${IMMICH_PORT}" != "2283" ]; then
     echo "# E2E Test Override" >> .env
     echo "IMMICH_PORT=${IMMICH_PORT}" >> .env
 fi
+
+# Override the version in .env to ensure we are using the required version
+echo "# E2E Test Override" >> .env
+echo "IMMICH_VERSION=${REQUIRED_VERSION}" >> .env
 
 # Create pgAdmin docker-compose file
 echo -e "${YELLOW}📝 Creating pgAdmin docker-compose file...${NC}"


### PR DESCRIPTION
This PR includes the necessary changes to support Immich V3.0.0.

Closes #1372 #1374 

## Changes

This PR covers the following breaking changes for Immich V3 and the fixes applied:
- Duration is now a `number | null` for requests and responses
  - Since `duration` is not used in responses, the field has been commented out to avoid parsing
  - Asset upload now sends `0` which is an accepted format on both v2 and v3
- `deviceId` and `deviceAssetId` are removed from `AssetMediaCreateDto`
  - Immich does not currently use `strictObject` in Zod so those fields are ignored on newer servers. This may change in a future Immich major release
- Retrieving an album via `GET /api/albums/{id}` no longer returns the assets inside of it. 
	- `POST /api/search/metadata` is the recommended method for listing album contents and was marked as stable in V2. Listing the contents of an album now uses that paginated endpoint for all server versions.
- `replaceAsset` has been removed in V3
  - `immich-go` already deprecated `replaceAsset`, this PR removes the dead code from the codebase
- Error formats have changed with the introduction of Zod schemas
  - There is now a error parsing interface that exposes a `lines()` method. All error processing code has moved to `immich/error.go`
  - `serverErrorV2` and `serverErrorV3` structs handle the parsing and formatting of error messages from Immich
  - Error handling now conditionally selects the error handler based on server version and then calls `lines()` to format
  
 ## Testing

I have run the e2e test suite with both `v2` tags (`v2.7.5`) and the `v3.0.0-rc.2` tags. You can see the override I placed in `scripts/e2e/e2e-provision.sh`.

Additionally, I have written a e2e test to cover the album contents changes.