### PR TITLE
fix: keep accumulated errors when rejecting tgz archives in ParsePath

### DIFF
--- a/internal/fshelper/parseArgs.go
+++ b/internal/fshelper/parseArgs.go
@@ -41,7 +41,7 @@ func ParsePath(args []string) ([]fs.FS, error) {
 			lowF := strings.ToLower(f)
 			switch {
 			case strings.HasSuffix(lowF, ".tgz") || strings.HasSuffix(lowF, ".tar.gz"):
-				errs = errors.Join(fmt.Errorf("immich-go can't use tgz archives: %s", filepath.Base(a)))
+				errs = errors.Join(errs, fmt.Errorf("immich-go can't use tgz archives: %s", filepath.Base(a)))
 			case strings.HasSuffix(lowF, ".zip"):
 				fsys, err := zipname.OpenReader(f) //   zip.OpenReader(f)
 				if err != nil {

--- a/internal/fshelper/parseArgs.go
+++ b/internal/fshelper/parseArgs.go
@@ -34,7 +34,8 @@ func ParsePath(args []string) ([]fs.FS, error) {
 		a = filepath.ToSlash(a)
 		files, err := expandNames(a)
 		if err != nil {
-			return nil, err
+			errs = errors.Join(errs, err)
+			continue
 		}
 
 		for _, f := range files {

--- a/internal/fshelper/parseArgs_test.go
+++ b/internal/fshelper/parseArgs_test.go
@@ -77,3 +77,23 @@ func TestParsePathExpandFailureKeepsPriorErrors(t *testing.T) {
 		t.Errorf("glob-expansion error should also be reported, got: %v", err)
 	}
 }
+
+// The rejection/accumulation changes must not disturb normal parsing: a valid
+// path should still open as a filesystem and return no error.
+func TestParsePathOpensValidSource(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "photo.jpg"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	fsyss, err := ParsePath([]string{dir})
+	if err != nil {
+		t.Fatalf("valid directory should not produce an error, got: %v", err)
+	}
+	if len(fsyss) != 1 {
+		t.Fatalf("expected 1 filesystem, got %d", len(fsyss))
+	}
+	if err := CloseFSs(fsyss); err != nil {
+		t.Errorf("closing filesystems failed: %v", err)
+	}
+}

--- a/internal/fshelper/parseArgs_test.go
+++ b/internal/fshelper/parseArgs_test.go
@@ -54,3 +54,26 @@ func TestParsePathAccumulatesAcrossSources(t *testing.T) {
 		}
 	}
 }
+
+// A malformed glob pattern makes expandNames fail. That failure must not discard
+// errors already accumulated for earlier arguments; it should be recorded like any
+// other and processing should continue.
+func TestParsePathExpandFailureKeepsPriorErrors(t *testing.T) {
+	dir := t.TempDir()
+	tgz := filepath.Join(dir, "bad-archive.tgz")
+	if err := os.WriteFile(tgz, []byte("dummy"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// "[" is an unterminated character class: filepath.Glob returns ErrBadPattern.
+	_, err := ParsePath([]string{tgz, "bad["})
+	if err == nil {
+		t.Fatal("expected errors for a tgz and a malformed glob, got nil")
+	}
+	if !strings.Contains(err.Error(), "bad-archive.tgz") {
+		t.Errorf("tgz error must survive the glob-expansion failure, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "pattern") {
+		t.Errorf("glob-expansion error should also be reported, got: %v", err)
+	}
+}

--- a/internal/fshelper/parseArgs_test.go
+++ b/internal/fshelper/parseArgs_test.go
@@ -1,0 +1,30 @@
+package fshelper
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// ParsePath must accumulate one error per rejected tgz archive, not just keep the last one.
+func TestParsePathAccumulatesTgzErrors(t *testing.T) {
+	dir := t.TempDir()
+	first := filepath.Join(dir, "takeout-001.tgz")
+	second := filepath.Join(dir, "takeout-002.tgz")
+	for _, f := range []string{first, second} {
+		if err := os.WriteFile(f, []byte("dummy"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	_, err := ParsePath([]string{first, second})
+	if err == nil {
+		t.Fatal("expected an error for tgz archives, got nil")
+	}
+	for _, name := range []string{"takeout-001.tgz", "takeout-002.tgz"} {
+		if !strings.Contains(err.Error(), name) {
+			t.Errorf("error should mention %s, got: %v", name, err)
+		}
+	}
+}

--- a/internal/fshelper/parseArgs_test.go
+++ b/internal/fshelper/parseArgs_test.go
@@ -28,3 +28,29 @@ func TestParsePathAccumulatesTgzErrors(t *testing.T) {
 		}
 	}
 }
+
+// ParsePath accumulates errors across different branches of the switch: an error
+// recorded for one argument must survive a rejection recorded for a later one.
+// This guards the general accumulator, not just repeated tgz rejections.
+func TestParsePathAccumulatesAcrossSources(t *testing.T) {
+	dir := t.TempDir()
+	badZip := filepath.Join(dir, "broken.zip")
+	tgz := filepath.Join(dir, "bad-archive.tgz")
+	// broken.zip is not a valid zip, so zipname.OpenReader records an error and
+	// continues; bad-archive.tgz is then rejected by the tgz branch.
+	for _, f := range []string{badZip, tgz} {
+		if err := os.WriteFile(f, []byte("not a real archive"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	_, err := ParsePath([]string{badZip, tgz})
+	if err == nil {
+		t.Fatal("expected errors for a bad zip and a tgz, got nil")
+	}
+	for _, name := range []string{"broken.zip", "bad-archive.tgz"} {
+		if !strings.Contains(err.Error(), name) {
+			t.Errorf("error should mention %s, got: %v", name, err)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

`internal/fshelper/parseArgs.go` accumulates argument-parsing errors in `errs`, but the tgz branch calls `errors.Join` with only the new error:

```go
errs = errors.Join(fmt.Errorf("immich-go can't use tgz archives: %s", filepath.Base(a)))
```

This overwrites everything accumulated so far. Pass two `.tgz` files (a common shape for a multi-part Google Takeout) and the error output mentions only the last one; any earlier zip-open errors are silently dropped too.

## Fix

Join onto the accumulator:

```go
errs = errors.Join(errs, fmt.Errorf(...))
```

## Test

Added a regression test: `ParsePath` with two tgz arguments must report both. It fails on the old code (only `takeout-002.tgz` reported) and passes with the fix.

Found while investigating a takeout import (context in #1384).