### PR TITLE
doc: clarify that tgz takeout archives must be extracted before import

### DIFF
--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -14,7 +14,7 @@ This guide provides recommendations for optimal performance, reliability, and or
 
 #### ⚠️ Common Pitfalls
 - **Incomplete Downloads**: Verify all `takeout-001.zip`, `takeout-002.zip`, etc. files are present
-- **Archive Format**: Download takeouts as ZIP when possible. Immich-Go reads `.zip` archives directly but rejects `.tgz`/`.tar.gz`; extract TGZ takeouts first (all parts into the same folder tree) and import the extracted folder
+- **Archive Format**: Prefer ZIP; `.tgz`/`.tar.gz` archives must be extracted first. Import all parts in one command: pass each extracted `Takeout*` folder (or one merged tree), not their parent directory
 - **Partial Takeouts**: Some Google takeouts may be incomplete - request a new one if many files are missing
 
 ### Import Strategy

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -14,7 +14,7 @@ This guide provides recommendations for optimal performance, reliability, and or
 
 #### ⚠️ Common Pitfalls
 - **Incomplete Downloads**: Verify all `takeout-001.zip`, `takeout-002.zip`, etc. files are present
-- **Mixed Formats**: Don't mix ZIP and TGZ formats in the same import
+- **Archive Format**: Download takeouts as ZIP when possible. Immich-Go reads `.zip` archives directly but rejects `.tgz`/`.tar.gz`; extract TGZ takeouts first (all parts into the same folder tree) and import the extracted folder
 - **Partial Takeouts**: Some Google takeouts may be incomplete - request a new one if many files are missing
 
 ### Import Strategy

--- a/docs/commands/upload.md
+++ b/docs/commands/upload.md
@@ -128,7 +128,7 @@ Upload from Google Photos Takeout archives.
 immich-go upload from-google-photos [options] <takeout-path>
 ```
 
-> Note: `.tgz` takeout archives are not supported directly. Extract them first (all parts into the same folder tree) and pass the extracted folder(s).
+> Note: `.tgz` takeout archives are not supported — extract them first. Import all parts in one command: pass each extracted `Takeout*` folder (or one merged tree), not their parent directory.
 
 ### Takeout Handling
 

--- a/docs/commands/upload.md
+++ b/docs/commands/upload.md
@@ -128,6 +128,8 @@ Upload from Google Photos Takeout archives.
 immich-go upload from-google-photos [options] <takeout-path>
 ```
 
+> Note: `.tgz` takeout archives are not supported directly. Extract them first (all parts into the same folder tree) and pass the extracted folder(s).
+
 ### Takeout Handling
 
 | Option                    | Default | Description                        |


### PR DESCRIPTION
The docs imply tgz takeouts import directly — `best-practices.md` warns "Don't mix ZIP and TGZ formats in the same import" — but `internal/fshelper/parseArgs.go` rejects `.tgz`/`.tar.gz` with `immich-go can't use tgz archives`.

This updates the docs to match the code:

- `docs/best-practices.md`: replace the mixed-formats bullet with guidance to prefer ZIP, and to extract TGZ takeouts (all parts into one folder tree) before importing
- `docs/commands/upload.md`: add the same note under `from-google-photos` usage

Related: #36 (original tgz request), #1387 (error accumulation in the same code path).