### PR TITLE
fix(upload): ignore duplicate closed-pipe writer errors

### DIFF
--- a/immich/upload.go
+++ b/immich/upload.go
@@ -111,12 +111,21 @@ func (ic *ImmichClient) uploadAsset(ctx context.Context, la *assets.Asset, endPo
 		errCall = ic.newServerCall(ctx, EndPointAssetReplace).
 			do(putRequest("/assets/"+replaceID+"/original", setContextValue(callValues), setAcceptJSON(), setImmichChecksum(la), setContentType(m.FormDataContentType()), setBody(body)), responseJSON(&ar))
 	}
-	if ar.Status == "duplicate" && errors.Is(err, io.ErrClosedPipe) {
-		err = nil // immich closes the connection when we upload the x-immich-checksum header and it finds a duplicate
-	}
 	gErr := <-errChan
-	err = errors.Join(err, errCall, gErr)
-	return ar, err
+	return ar, joinUploadErrors(ar.Status, errCall, gErr)
+}
+
+func joinUploadErrors(status string, errCall, writerErr error) error {
+	if status == UploadDuplicate {
+		if errors.Is(errCall, io.ErrClosedPipe) {
+			errCall = nil
+		}
+		if errors.Is(writerErr, io.ErrClosedPipe) {
+			writerErr = nil
+		}
+	}
+
+	return errors.Join(errCall, writerErr)
 }
 
 func (ic *ImmichClient) prepareCallValues(la *assets.Asset, s fs.FileInfo, ext, mtype string) map[string]string {

--- a/immich/upload_test.go
+++ b/immich/upload_test.go
@@ -1,0 +1,67 @@
+package immich
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestJoinUploadErrors(t *testing.T) {
+	otherErr := errors.New("other error")
+
+	tests := []struct {
+		name      string
+		status    string
+		callErr   error
+		writerErr error
+		wantNil   bool
+		wantIs    error
+	}{
+		{
+			name:      "duplicate ignores writer closed pipe",
+			status:    UploadDuplicate,
+			writerErr: io.ErrClosedPipe,
+			wantNil:   true,
+		},
+		{
+			name:    "duplicate ignores wrapped call closed pipe",
+			status:  UploadDuplicate,
+			callErr: fmt.Errorf("upload request: %w", io.ErrClosedPipe),
+			wantNil: true,
+		},
+		{
+			name:      "duplicate preserves unrelated writer error",
+			status:    UploadDuplicate,
+			writerErr: otherErr,
+			wantIs:    otherErr,
+		},
+		{
+			name:      "duplicate drops closed pipe but preserves other error",
+			status:    UploadDuplicate,
+			callErr:   otherErr,
+			writerErr: io.ErrClosedPipe,
+			wantIs:    otherErr,
+		},
+		{
+			name:      "created upload preserves closed pipe",
+			status:    UploadCreated,
+			writerErr: io.ErrClosedPipe,
+			wantIs:    io.ErrClosedPipe,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := joinUploadErrors(test.status, test.callErr, test.writerErr)
+			if test.wantNil {
+				require.NoError(t, err)
+				return
+			}
+
+			require.ErrorIs(t, err, test.wantIs)
+		})
+	}
+}


### PR DESCRIPTION
Immich can close the multipart request body early when the x-immich-checksum header identifies an existing asset. PR #854 intended to tolerate the resulting io.ErrClosedPipe, but uploadAsset checked the stale error from the earlier file Stat call before receiving the request and multipart-writer errors. Repeated or resumed uploads therefore aborted when they encountered assets already present on the server.

Collect the request and multipart-writer errors before evaluating them. Suppress io.ErrClosedPipe only when Immich returned duplicate status, while preserving unrelated errors and closed-pipe failures for non-duplicate responses. Add regression coverage for direct and wrapped request errors, writer errors, mixed errors, and non-duplicate uploads.

Fixes: https://github.com/simulot/immich-go/issues/1271