### PR TITLE
report unknown files by extension

### DIFF
--- a/internal/fileevent/fileevents.go
+++ b/internal/fileevent/fileevents.go
@@ -12,6 +12,8 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -197,22 +199,35 @@ func (e Code) String() string {
 // When a bus is attached via NewRecorderWithBus, events are published
 // non-blocking to all subscribers after incrementing counters.
 type Recorder struct {
-	counts counts
-	sizes  counts // Size tracking for each event code
-	log    *slog.Logger
-	bus    *Bus
+	counts         counts
+	sizes          counts // Size tracking for each event code
+	unknownByExtMu sync.Mutex
+	unknownByExt   map[string]eventTotal
+	log            *slog.Logger
+	bus            *Bus
 }
 
 type counts []int64
+
+type eventTotal struct {
+	count int64
+	size  int64
+}
+
+type extensionTotal struct {
+	extension string
+	eventTotal
+}
 
 // NewRecorder creates a Recorder that logs events to the provided slog.Logger.
 // Events are not published to a bus. Use NewRecorderWithBus for bus integration.
 func NewRecorder(l *slog.Logger) *Recorder {
 	r := &Recorder{
-		counts: make([]int64, MaxCode),
-		sizes:  make([]int64, MaxCode),
-		log:    l,
-		bus:    nil,
+		counts:       make([]int64, MaxCode),
+		sizes:        make([]int64, MaxCode),
+		unknownByExt: make(map[string]eventTotal),
+		log:          l,
+		bus:          nil,
 	}
 	return r
 }
@@ -228,10 +243,11 @@ func NewRecorder(l *slog.Logger) *Recorder {
 // (>1000 events/sec), the bus may drop oldest buffered events per subscriber.
 func NewRecorderWithBus(l *slog.Logger, bus *Bus) *Recorder {
 	r := &Recorder{
-		counts: make([]int64, MaxCode),
-		sizes:  make([]int64, MaxCode),
-		log:    l,
-		bus:    bus,
+		counts:       make([]int64, MaxCode),
+		sizes:        make([]int64, MaxCode),
+		unknownByExt: make(map[string]eventTotal),
+		log:          l,
+		bus:          bus,
 	}
 	return r
 }
@@ -255,6 +271,9 @@ func (r *Recorder) RecordWithSize(ctx context.Context, code Code, file slog.LogV
 	atomic.AddInt64(&r.counts[code], 1)
 	if fileSize > 0 {
 		atomic.AddInt64(&r.sizes[code], fileSize)
+	}
+	if code == DiscoveredUnknown && file != nil {
+		r.recordUnknownExtension(file, fileSize)
 	}
 	if r.log != nil {
 		level := _logLevels[code]
@@ -285,6 +304,41 @@ func (r *Recorder) RecordWithSize(ctx context.Context, code Code, file slog.LogV
 			Args: args,
 		})
 	}
+}
+
+func (r *Recorder) recordUnknownExtension(file slog.LogValuer, fileSize int64) {
+	named, ok := file.(interface{ Name() string })
+	if !ok {
+		return
+	}
+	ext := strings.ToLower(filepath.Ext(named.Name()))
+	if ext == "" {
+		ext = "[no extension]"
+	}
+
+	r.unknownByExtMu.Lock()
+	total := r.unknownByExt[ext]
+	total.count++
+	total.size += fileSize
+	r.unknownByExt[ext] = total
+	r.unknownByExtMu.Unlock()
+}
+
+func (r *Recorder) unknownExtensions() []extensionTotal {
+	r.unknownByExtMu.Lock()
+	entries := make([]extensionTotal, 0, len(r.unknownByExt))
+	for ext, total := range r.unknownByExt {
+		entries = append(entries, extensionTotal{extension: ext, eventTotal: total})
+	}
+	r.unknownByExtMu.Unlock()
+
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].size != entries[j].size {
+			return entries[i].size > entries[j].size
+		}
+		return entries[i].extension < entries[j].extension
+	})
+	return entries
 }
 
 func (r *Recorder) SetLogger(l *slog.Logger) {
@@ -361,6 +415,11 @@ func (r *Recorder) GenerateEventReport() string {
 		if count := eventCounts[c]; count > 0 {
 			size := eventSizes[c]
 			sb.WriteString(fmt.Sprintf("  %-35s: %7d  (%s)\n", c.String(), count, FormatEventBytes(size)))
+			if c == DiscoveredUnknown {
+				for _, entry := range r.unknownExtensions() {
+					sb.WriteString(fmt.Sprintf("    %-33s: %7d  (%s)\n", entry.extension, entry.count, FormatEventBytes(entry.size)))
+				}
+			}
 		}
 	}
 

--- a/internal/fileevent/recorder_test.go
+++ b/internal/fileevent/recorder_test.go
@@ -2,11 +2,17 @@ package fileevent
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"os"
 	"strings"
 	"testing"
 )
+
+type namedLogValue string
+
+func (n namedLogValue) Name() string         { return string(n) }
+func (n namedLogValue) LogValue() slog.Value { return slog.StringValue(string(n)) }
 
 func TestRecorderSizeTracking(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
@@ -117,6 +123,53 @@ func TestGenerateEventReport(t *testing.T) {
 		t.Error("Report should mention 'uploaded successfully'")
 	}
 }
+
+func TestGenerateEventReportGroupsUnknownFilesByExtension(t *testing.T) {
+	recorder := NewRecorder(nil)
+	ctx := context.Background()
+
+	recorder.RecordWithSize(ctx, DiscoveredUnknown, namedLogValue("takeout/clip.MP"), 2048)
+	recorder.RecordWithSize(ctx, DiscoveredUnknown, namedLogValue("takeout/another.mp"), 1024)
+	recorder.RecordWithSize(ctx, DiscoveredUnknown, namedLogValue("takeout/video.3g2"), 4096)
+	recorder.RecordWithSize(ctx, DiscoveredUnknown, namedLogValue("takeout/MVIMG_123"), 512)
+	recorder.RecordWithSize(ctx, DiscoveredUnknown, namedLogValue("takeout/archive.asf"), 3072)
+
+	report := recorder.GenerateEventReport()
+	for _, want := range []string{
+		"discovered unknown file            :       5  (10.5 KB)",
+		".3g2                             :       1  (4.0 KB)",
+		".asf                             :       1  (3.0 KB)",
+		".mp                              :       2  (3.0 KB)",
+		"[no extension]                   :       1  (512 B)",
+	} {
+		if !strings.Contains(report, want) {
+			t.Errorf("report does not contain %q:\n%s", want, report)
+		}
+	}
+
+	last := -1
+	for _, extension := range []string{".3g2", ".asf", ".mp", "[no extension]"} {
+		index := strings.Index(report, fmt.Sprintf("    %-33s:", extension))
+		if index <= last {
+			t.Fatalf("extension %q is not in deterministic size/name order:\n%s", extension, report)
+		}
+		last = index
+	}
+}
+
+func TestUnknownExtensionGroupingIgnoresUnnamedLogValues(t *testing.T) {
+	recorder := NewRecorder(nil)
+	recorder.RecordWithSize(context.Background(), DiscoveredUnknown, unnamedLogValue{}, 42)
+
+	report := recorder.GenerateEventReport()
+	if strings.Contains(report, "[no extension]") {
+		t.Fatalf("unnamed log value should not be grouped as a filename:\n%s", report)
+	}
+}
+
+type unnamedLogValue struct{}
+
+func (unnamedLogValue) LogValue() slog.Value { return slog.StringValue("unknown") }
 
 func TestEmptyRecorder(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))


### PR DESCRIPTION
## Summary
- keep the existing aggregate unknown-file total
- add a per-extension count and byte-size breakdown beneath it
- sort groups by size descending, then extension name, and combine case variants

This is limited to the reporting portion of #1388; it does not change file classification or supported formats.

## Validation
- `go test ./internal/fileevent`
- `go test ./...`
- `go build -o $env:TEMP\immich-go-agent.exe main.go`
- `git diff --check`

The optional race test could not run on this Windows environment because CGO is disabled.

Closes #1388