### PR TITLE
feat(upload): add --into-album to all upload subcommands

### DIFF
--- a/adapters/folder/commands.go
+++ b/adapters/folder/commands.go
@@ -26,7 +26,6 @@ type ImportFolderCmd struct {
 	// CLI flags
 	UsePathAsAlbumName     AlbumFolderMode
 	AlbumNamePathSeparator string
-	ImportIntoAlbum        string
 	BannedFiles            namematcher.List
 	Recursive              bool
 	InclusionFlags         cliflags.InclusionFlags
@@ -61,7 +60,6 @@ func (ifc *ImportFolderCmd) RegisterFlags(flags *pflag.FlagSet, cmd *cobra.Comma
 	ifc.BannedFiles, _ = namematcher.New(shared.DefaultBannedFiles...)
 
 	flags.Var(&ifc.BannedFiles, "ban-file", "Exclude a file based on a pattern (case-insensitive). Can be specified multiple times.")
-	flags.StringVar(&ifc.ImportIntoAlbum, "into-album", "", "Specify an album to import all files into")
 	flags.Var(&ifc.UsePathAsAlbumName, "folder-as-album", "Import all files in albums defined by the folder structure. Can be set to 'FOLDER' to use the folder name as the album name, or 'PATH' to use the full path as the album name")
 	flags.StringVar(&ifc.AlbumNamePathSeparator, "album-path-joiner", " / ", "Specify a string to use when joining multiple folder names to create an album name (e.g. ' ',' - ')")
 	flags.BoolVar(&ifc.Recursive, "recursive", true, "Explore the folder and all its sub-folders")

--- a/adapters/folder/run.go
+++ b/adapters/folder/run.go
@@ -33,7 +33,9 @@ import (
 
 func (ifc *ImportFolderCmd) run(cmd *cobra.Command, args []string, app *app.Application, runner adapters.Runner) error {
 	var err error
-	if ifc.ImportIntoAlbum != "" && ifc.UsePathAsAlbumName != FolderModeNone {
+
+	intoAlbum, _ := cmd.Flags().GetString("into-album")
+	if intoAlbum != "" && ifc.UsePathAsAlbumName != FolderModeNone {
 		return errors.New("cannot use both --into-album and --folder-as-album flags")
 	}
 
@@ -416,44 +418,40 @@ func (ifc *ImportFolderCmd) parseDir(ctx context.Context, fsys fs.FS, dir string
 			}
 
 			// Manage albums
-			if ifc.ImportIntoAlbum != "" {
-				a.Albums = []assets.Album{{Title: ifc.ImportIntoAlbum}}
-			} else {
-				done := false
-				if ifc.PicasaAlbum {
-					if album, ok := ifc.picasaAlbums.Load(dir); ok {
-						a.Albums = []assets.Album{{Title: album.Name, Description: album.Description}}
-						done = true
-					}
+			done := false
+			if ifc.PicasaAlbum {
+				if album, ok := ifc.picasaAlbums.Load(dir); ok {
+					a.Albums = []assets.Album{{Title: album.Name, Description: album.Description}}
+					done = true
 				}
-				if ifc.ICloudTakeout {
-					if meta, ok := ifc.icloudMetas.Load(a.OriginalFileName); ok {
-						a.Albums = meta.albums
-						done = true
-					}
+			}
+			if ifc.ICloudTakeout {
+				if meta, ok := ifc.icloudMetas.Load(a.OriginalFileName); ok {
+					a.Albums = meta.albums
+					done = true
 				}
-				if !done && ifc.UsePathAsAlbumName != FolderModeNone && ifc.UsePathAsAlbumName != "" {
-					Album := ""
-					switch ifc.UsePathAsAlbumName {
-					case FolderModeFolder:
-						if dir == "." {
-							Album = fsName
-						} else {
-							Album = filepath.Base(dir)
-						}
-					case FolderModePath:
-						parts := []string{}
-						if fsName != "" {
-							parts = append(parts, fsName)
-						}
-						if dir != "." {
-							parts = append(parts, strings.Split(dir, "/")...)
-						}
-						Album = strings.Join(parts, ifc.AlbumNamePathSeparator)
+			}
+			if !done && ifc.UsePathAsAlbumName != FolderModeNone && ifc.UsePathAsAlbumName != "" {
+				Album := ""
+				switch ifc.UsePathAsAlbumName {
+				case FolderModeFolder:
+					if dir == "." {
+						Album = fsName
+					} else {
+						Album = filepath.Base(dir)
 					}
-					if Album != "" {
-						a.Albums = []assets.Album{{Title: Album}}
+				case FolderModePath:
+					parts := []string{}
+					if fsName != "" {
+						parts = append(parts, fsName)
 					}
+					if dir != "." {
+						parts = append(parts, strings.Split(dir, "/")...)
+					}
+					Album = strings.Join(parts, ifc.AlbumNamePathSeparator)
+				}
+				if Album != "" {
+					a.Albums = []assets.Album{{Title: Album}}
 				}
 			}
 

--- a/adapters/folder/run.go
+++ b/adapters/folder/run.go
@@ -34,9 +34,14 @@ import (
 func (ifc *ImportFolderCmd) run(cmd *cobra.Command, args []string, app *app.Application, runner adapters.Runner) error {
 	var err error
 
-	intoAlbum, _ := cmd.Flags().GetString("into-album")
-	if intoAlbum != "" && ifc.UsePathAsAlbumName != FolderModeNone {
-		return errors.New("cannot use both --into-album and --folder-as-album flags")
+	if f := cmd.Flag("into-album"); f != nil {
+		intoAlbum, err := cmd.Flags().GetString("into-album")
+		if err != nil {
+			return err
+		}
+		if intoAlbum != "" && ifc.UsePathAsAlbumName != FolderModeNone {
+			return errors.New("cannot use both --into-album and --folder-as-album flags")
+		}
 	}
 
 	ifc.app = app

--- a/adapters/googlePhotos/cmdFromGooglePhotos.go
+++ b/adapters/googlePhotos/cmdFromGooglePhotos.go
@@ -34,7 +34,6 @@ type TakeoutCmd struct {
 	// CLI FLags
 	CreateAlbums       bool
 	ImportFromAlbum    string
-	ImportIntoAlbum    string
 	PartnerSharedAlbum string
 	KeepTrashed        bool
 	KeepPartner        bool

--- a/adapters/googlePhotos/googlephotos.go
+++ b/adapters/googlePhotos/googlephotos.go
@@ -396,29 +396,24 @@ func (toc *TakeoutCmd) handleDir(ctx context.Context, dir string, gOut chan *ass
 
 		for _, a := range dirEntries {
 			if toc.CreateAlbums {
-				if toc.ImportIntoAlbum != "" {
-					// Force this album
-					a.Albums = []assets.Album{{Title: toc.ImportIntoAlbum}}
-				} else {
-					// check if its duplicates are in some albums, and push them all at once
-					key := fileKeyTracker{baseName: filepath.Base(a.File.Name()), size: int64(a.FileSize)}
-					track, _ := toc.fileTracker.Load(key) // track := to.fileTracker[key]
-					for _, p := range track.paths {
-						if album, ok := toc.albums[p]; ok {
-							title := album.Title
-							if title == "" {
-								if !toc.KeepUntitled {
-									continue
-								}
-								title = filepath.Base(p)
+				// check if its duplicates are in some albums, and push them all at once
+				key := fileKeyTracker{baseName: filepath.Base(a.File.Name()), size: int64(a.FileSize)}
+				track, _ := toc.fileTracker.Load(key) // track := to.fileTracker[key]
+				for _, p := range track.paths {
+					if album, ok := toc.albums[p]; ok {
+						title := album.Title
+						if title == "" {
+							if !toc.KeepUntitled {
+								continue
 							}
-							a.Albums = append(a.Albums, assets.Album{
-								Title:       title,
-								Description: album.Description,
-								Latitude:    album.Latitude,
-								Longitude:   album.Longitude,
-							})
+							title = filepath.Base(p)
 						}
+						a.Albums = append(a.Albums, assets.Album{
+							Title:       title,
+							Description: album.Description,
+							Latitude:    album.Latitude,
+							Longitude:   album.Longitude,
+						})
 					}
 				}
 

--- a/app/upload/run.go
+++ b/app/upload/run.go
@@ -314,6 +314,12 @@ func (uc *UpCmd) handleGroup(ctx context.Context, g *assets.Group) error {
 		uc.app.FileProcessor().RecordAssetDiscarded(ctx, a.Asset.File, int64(a.Asset.FileSize), fileevent.DiscardedNotSelected, a.Reason)
 	}
 
+	if uc.ImportIntoAlbum != "" {
+		for _, a := range g.Assets {
+			a.Albums = []assets.Album{{Title: uc.ImportIntoAlbum}}
+		}
+	}
+
 	// Upload assets from the group
 	for _, a := range g.Assets {
 		err := uc.handleAsset(ctx, a)

--- a/app/upload/upload.go
+++ b/app/upload/upload.go
@@ -55,12 +55,13 @@ type UpCmd struct {
 	// Cli flags
 
 	shared.StackOptions
-	client     app.Client
-	NoUI       bool // Disable UI
-	Overwrite  bool // Always overwrite files on the server with local versions
-	Tags       []string
-	SessionTag bool
-	session    string // Session tag value
+	client          app.Client
+	NoUI            bool   // Disable UI
+	Overwrite       bool   // Always overwrite files on the server with local versions
+	ImportIntoAlbum string // Specify an album to import all files into
+	Tags            []string
+	SessionTag      bool
+	session         string // Session tag value
 
 	// Upload command state
 	// Filters           []filters.Filter
@@ -85,6 +86,7 @@ func (uc *UpCmd) RegisterFlags(flags *pflag.FlagSet) {
 	flags.BoolVar(&uc.Overwrite, "overwrite", false, "Always overwrite files on the server with local versions")
 	flags.StringSliceVar(&uc.Tags, "tag", nil, "Add tags to the imported assets. Can be specified multiple times. Hierarchy is supported using a / separator (e.g. 'tag1/subtag1')")
 	flags.BoolVar(&uc.SessionTag, "session-tag", false, "Tag uploaded photos with a tag \"{immich-go}/YYYY-MM-DD HH-MM-SS\"")
+	flags.StringVar(&uc.ImportIntoAlbum, "into-album", "", "Specify an album to import all files into")
 
 	uc.StackOptions.RegisterFlags(flags)
 }

--- a/docs/commands/upload.md
+++ b/docs/commands/upload.md
@@ -238,6 +238,11 @@ immich-go upload from-immich [source-options] [destination-options]
   | `--from-favorite`       | Include only favorite assets |
   | `--from-minimal-rating` | Minimum rating filter        |
 
+### Destination Options
+
+  | Option            | Description                                    |
+  | ----------------- | ---------------------------------------------- |
+  | `--into-album`    | Place all transferred assets into given album  |
 
 ### Examples
 ```bash
@@ -254,6 +259,12 @@ immich-go upload from-immich \
 # Transfer photos from a specific date range
 immich-go upload from-immich \
   --from-server=http://old-server:2283 --from-api-key=old-key --from-date-range=2023-01-01,2023-06-30 \
+  --server=http://new-server:2283 --api-key=new-key
+
+# Transfer all photos into a single album
+immich-go upload from-immich \
+  --into-album="Migrated Photos" \
+  --from-server=http://old-server:2283 --from-api-key=old-key \
   --server=http://new-server:2283 --api-key=new-key
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,7 +29,6 @@ folder-as-tags = false
 ignore-sidecar-files = false
 include-extensions = []
 include-type = ''
-into-album = ''
 recursive = true
 
 [archive.from-folder.ban-file]
@@ -62,7 +61,6 @@ folder-as-tags = false
 ignore-sidecar-files = false
 include-extensions = []
 include-type = ''
-into-album = ''
 memories = false
 recursive = true
 
@@ -112,7 +110,6 @@ folder-as-tags = false
 ignore-sidecar-files = false
 include-extensions = []
 include-type = ''
-into-album = ''
 recursive = true
 
 [archive.from-picasa.ban-file]
@@ -141,6 +138,7 @@ api-trace = false
 client-timeout = '20m'
 device-uuid = 'HOSTNAME'
 dry-run = false
+into-album = ''
 manage-burst = 'NoStack'
 manage-epson-fastfoto = false
 manage-heic-jpeg = 'NoStack'
@@ -163,7 +161,6 @@ folder-as-tags = false
 ignore-sidecar-files = false
 include-extensions = []
 include-type = ''
-into-album = ''
 recursive = true
 
 [upload.from-folder.ban-file]
@@ -196,7 +193,6 @@ folder-as-tags = false
 ignore-sidecar-files = false
 include-extensions = []
 include-type = ''
-into-album = ''
 memories = false
 recursive = true
 
@@ -246,7 +242,6 @@ folder-as-tags = false
 ignore-sidecar-files = false
 include-extensions = []
 include-type = ''
-into-album = ''
 recursive = true
 
 [upload.from-picasa.ban-file]
@@ -272,7 +267,6 @@ archive:
     ignore-sidecar-files: false
     include-extensions: []
     include-type: ""
-    into-album: ""
     recursive: true
   from-google-photos:
     ban-file: {}
@@ -301,7 +295,6 @@ archive:
     ignore-sidecar-files: false
     include-extensions: []
     include-type: ""
-    into-album: ""
     memories: false
     recursive: true
   from-immich:
@@ -345,7 +338,6 @@ archive:
     ignore-sidecar-files: false
     include-extensions: []
     include-type: ""
-    into-album: ""
     recursive: true
   write-to-folder: ""
 concurrent-tasks: 12
@@ -389,7 +381,6 @@ upload:
     ignore-sidecar-files: false
     include-extensions: []
     include-type: ""
-    into-album: ""
     recursive: true
   from-google-photos:
     ban-file: {}
@@ -418,7 +409,6 @@ upload:
     ignore-sidecar-files: false
     include-extensions: []
     include-type: ""
-    into-album: ""
     memories: false
     recursive: true
   from-immich:
@@ -462,8 +452,8 @@ upload:
     ignore-sidecar-files: false
     include-extensions: []
     include-type: ""
-    into-album: ""
     recursive: true
+  into-album: ""
   manage-burst: NoStack
   manage-epson-fastfoto: false
   manage-heic-jpeg: NoStack
@@ -497,7 +487,6 @@ upload:
       "ignore-sidecar-files": false,
       "include-extensions": null,
       "include-type": "",
-      "into-album": "",
       "recursive": true
     },
     "from-google-photos": {
@@ -528,7 +517,6 @@ upload:
       "ignore-sidecar-files": false,
       "include-extensions": null,
       "include-type": "",
-      "into-album": "",
       "memories": false,
       "recursive": true
     },
@@ -574,7 +562,6 @@ upload:
       "ignore-sidecar-files": false,
       "include-extensions": null,
       "include-type": "",
-      "into-album": "",
       "recursive": true
     },
     "write-to-folder": ""
@@ -621,7 +608,6 @@ upload:
       "ignore-sidecar-files": false,
       "include-extensions": null,
       "include-type": "",
-      "into-album": "",
       "recursive": true
     },
     "from-google-photos": {
@@ -652,7 +638,6 @@ upload:
       "ignore-sidecar-files": false,
       "include-extensions": null,
       "include-type": "",
-      "into-album": "",
       "memories": false,
       "recursive": true
     },
@@ -698,9 +683,9 @@ upload:
       "ignore-sidecar-files": false,
       "include-extensions": null,
       "include-type": "",
-      "into-album": "",
       "recursive": true
     },
+    "into-album": "",
     "manage-burst": "NoStack",
     "manage-epson-fastfoto": false,
     "manage-heic-jpeg": "NoStack",

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -34,7 +34,6 @@ The following environment variables can be used to configure `immich-go`.
 | `IMMICH_GO_ARCHIVE_FROM_FOLDER_IGNORE_SIDECAR_FILES` | `--ignore-sidecar-files` | `false` | Don't upload sidecar with the photo. |
 | `IMMICH_GO_ARCHIVE_FROM_FOLDER_INCLUDE_EXTENSIONS` | `--include-extensions` |  | Comma-separated list of extension to include. (e.g. .jpg,.heic) (default: all) |
 | `IMMICH_GO_ARCHIVE_FROM_FOLDER_INCLUDE_TYPE` | `--include-type` |  | Single file type to include. (VIDEO or IMAGE) (default: all) |
-| `IMMICH_GO_ARCHIVE_FROM_FOLDER_INTO_ALBUM` | `--into-album` |  | Specify an album to import all files into |
 | `IMMICH_GO_ARCHIVE_FROM_FOLDER_RECURSIVE` | `--recursive` | `true` | Explore the folder and all its sub-folders |
 
 ## archive from-google-photos
@@ -71,7 +70,6 @@ The following environment variables can be used to configure `immich-go`.
 | `IMMICH_GO_ARCHIVE_FROM_ICLOUD_IGNORE_SIDECAR_FILES` | `--ignore-sidecar-files` | `false` | Don't upload sidecar with the photo. |
 | `IMMICH_GO_ARCHIVE_FROM_ICLOUD_INCLUDE_EXTENSIONS` | `--include-extensions` |  | Comma-separated list of extension to include. (e.g. .jpg,.heic) (default: all) |
 | `IMMICH_GO_ARCHIVE_FROM_ICLOUD_INCLUDE_TYPE` | `--include-type` |  | Single file type to include. (VIDEO or IMAGE) (default: all) |
-| `IMMICH_GO_ARCHIVE_FROM_ICLOUD_INTO_ALBUM` | `--into-album` |  | Specify an album to import all files into |
 | `IMMICH_GO_ARCHIVE_FROM_ICLOUD_MEMORIES` | `--memories` | `false` | Import icloud memories as albums |
 | `IMMICH_GO_ARCHIVE_FROM_ICLOUD_RECURSIVE` | `--recursive` | `true` | Explore the folder and all its sub-folders |
 
@@ -123,7 +121,6 @@ The following environment variables can be used to configure `immich-go`.
 | `IMMICH_GO_ARCHIVE_FROM_PICASA_IGNORE_SIDECAR_FILES` | `--ignore-sidecar-files` | `false` | Don't upload sidecar with the photo. |
 | `IMMICH_GO_ARCHIVE_FROM_PICASA_INCLUDE_EXTENSIONS` | `--include-extensions` |  | Comma-separated list of extension to include. (e.g. .jpg,.heic) (default: all) |
 | `IMMICH_GO_ARCHIVE_FROM_PICASA_INCLUDE_TYPE` | `--include-type` |  | Single file type to include. (VIDEO or IMAGE) (default: all) |
-| `IMMICH_GO_ARCHIVE_FROM_PICASA_INTO_ALBUM` | `--into-album` |  | Specify an album to import all files into |
 | `IMMICH_GO_ARCHIVE_FROM_PICASA_RECURSIVE` | `--recursive` | `true` | Explore the folder and all its sub-folders |
 
 ## stack
@@ -156,6 +153,7 @@ The following environment variables can be used to configure `immich-go`.
 | `IMMICH_GO_UPLOAD_CLIENT_TIMEOUT` | `--client-timeout` | `20m0s` | Set server calls timeout |
 | `IMMICH_GO_UPLOAD_DEVICE_UUID` | `--device-uuid` | `gl65` | Set a device UUID |
 | `IMMICH_GO_UPLOAD_DRY_RUN` | `--dry-run` | `false` | Simulate all actions |
+| `IMMICH_GO_UPLOAD_INTO_ALBUM` | `--into-album` |  | Specify an album to import all files into |
 | `IMMICH_GO_UPLOAD_MANAGE_BURST` | `--manage-burst` | `NoStack` | Manage burst photos. Possible values: NoStack, Stack, StackKeepRaw, StackKeepJPEG |
 | `IMMICH_GO_UPLOAD_MANAGE_EPSON_FASTFOTO` | `--manage-epson-fastfoto` | `false` | Manage Epson FastFoto file (default: false) |
 | `IMMICH_GO_UPLOAD_MANAGE_HEIC_JPEG` | `--manage-heic-jpeg` | `NoStack` | Manage coupled HEIC and JPEG files. Possible values: NoStack, KeepHeic, KeepJPG, StackCoverHeic, StackCoverJPG |
@@ -183,7 +181,6 @@ The following environment variables can be used to configure `immich-go`.
 | `IMMICH_GO_UPLOAD_FROM_FOLDER_IGNORE_SIDECAR_FILES` | `--ignore-sidecar-files` | `false` | Don't upload sidecar with the photo. |
 | `IMMICH_GO_UPLOAD_FROM_FOLDER_INCLUDE_EXTENSIONS` | `--include-extensions` |  | Comma-separated list of extension to include. (e.g. .jpg,.heic) (default: all) |
 | `IMMICH_GO_UPLOAD_FROM_FOLDER_INCLUDE_TYPE` | `--include-type` |  | Single file type to include. (VIDEO or IMAGE) (default: all) |
-| `IMMICH_GO_UPLOAD_FROM_FOLDER_INTO_ALBUM` | `--into-album` |  | Specify an album to import all files into |
 | `IMMICH_GO_UPLOAD_FROM_FOLDER_RECURSIVE` | `--recursive` | `true` | Explore the folder and all its sub-folders |
 
 ## upload from-google-photos
@@ -220,7 +217,6 @@ The following environment variables can be used to configure `immich-go`.
 | `IMMICH_GO_UPLOAD_FROM_ICLOUD_IGNORE_SIDECAR_FILES` | `--ignore-sidecar-files` | `false` | Don't upload sidecar with the photo. |
 | `IMMICH_GO_UPLOAD_FROM_ICLOUD_INCLUDE_EXTENSIONS` | `--include-extensions` |  | Comma-separated list of extension to include. (e.g. .jpg,.heic) (default: all) |
 | `IMMICH_GO_UPLOAD_FROM_ICLOUD_INCLUDE_TYPE` | `--include-type` |  | Single file type to include. (VIDEO or IMAGE) (default: all) |
-| `IMMICH_GO_UPLOAD_FROM_ICLOUD_INTO_ALBUM` | `--into-album` |  | Specify an album to import all files into |
 | `IMMICH_GO_UPLOAD_FROM_ICLOUD_MEMORIES` | `--memories` | `false` | Import icloud memories as albums |
 | `IMMICH_GO_UPLOAD_FROM_ICLOUD_RECURSIVE` | `--recursive` | `true` | Explore the folder and all its sub-folders |
 
@@ -272,6 +268,5 @@ The following environment variables can be used to configure `immich-go`.
 | `IMMICH_GO_UPLOAD_FROM_PICASA_IGNORE_SIDECAR_FILES` | `--ignore-sidecar-files` | `false` | Don't upload sidecar with the photo. |
 | `IMMICH_GO_UPLOAD_FROM_PICASA_INCLUDE_EXTENSIONS` | `--include-extensions` |  | Comma-separated list of extension to include. (e.g. .jpg,.heic) (default: all) |
 | `IMMICH_GO_UPLOAD_FROM_PICASA_INCLUDE_TYPE` | `--include-type` |  | Single file type to include. (VIDEO or IMAGE) (default: all) |
-| `IMMICH_GO_UPLOAD_FROM_PICASA_INTO_ALBUM` | `--into-album` |  | Specify an album to import all files into |
 | `IMMICH_GO_UPLOAD_FROM_PICASA_RECURSIVE` | `--recursive` | `true` | Explore the folder and all its sub-folders |
 

--- a/docs/upload-commands-overview.md
+++ b/docs/upload-commands-overview.md
@@ -220,4 +220,5 @@ The strength of `from-immich` lies in its extensive filtering options, allowing 
 When migrating assets, `from-immich` ensures that all metadata is preserved:
 
 *   **Albums and Tags**: The assets' associations with albums and tags are fetched from the source server. When they are uploaded to the destination server, `immich-go` will recreate those albums and tags.
+*   **Destination Album**: Use `--into-album` to override album preservation and place all transferred assets into a single destination album instead.
 *   **Other Metadata**: Descriptions, GPS coordinates, ratings, and other EXIF/XMP information are all carried over to the destination server.

--- a/immich/upload.go
+++ b/immich/upload.go
@@ -133,7 +133,7 @@ func (ic *ImmichClient) prepareCallValues(la *assets.Asset, s fs.FileInfo, ext, 
 	callValues["fileModifiedAt"] = s.ModTime().UTC().Format(TimeFormat)
 	callValues["isFavorite"] = myBool(la.Favorite).String()
 	callValues["fileExtension"] = ext
-	callValues["duration"] = formatDuration(0)
+	callValues["duration"] = "0"
 	callValues["isReadOnly"] = "false"
 	if la.Archived {
 		callValues["visibility"] = "archive"

--- a/internal/e2e/client/fromImmich_test.go
+++ b/internal/e2e/client/fromImmich_test.go
@@ -1,0 +1,81 @@
+//go:build e2e
+
+package client
+
+import (
+	"testing"
+
+	"github.com/simulot/immich-go/app/root"
+	e2eutils "github.com/simulot/immich-go/internal/e2e/e2eUtils"
+	"github.com/simulot/immich-go/internal/fileevent"
+)
+
+func Test_FromImmich_IntoAlbum(t *testing.T) {
+	adm, err := getUser("admin@immich.app")
+	if err != nil {
+		t.Fatalf("can't get admin user: %v", err)
+	}
+
+	u1, err := createUser("all")
+	if err != nil {
+		t.Fatalf("can't create user1: %v", err)
+	}
+
+	u2, err := createUser("all")
+	if err != nil {
+		t.Fatalf("can't create user2: %v", err)
+	}
+
+	ctx := t.Context()
+
+	// Step 1: upload photos into user1's library
+	c, a := root.RootImmichGoCommand(ctx)
+	c.SetArgs([]string{
+		"upload", "from-folder",
+		"--server=" + ImmichURL,
+		"--api-key=" + u1.APIKey,
+		"--admin-api-key=" + adm.APIKey,
+		"--no-ui",
+		"--log-level=debug",
+		"DATA/fromFolder/recursive",
+	})
+	err = c.ExecuteContext(ctx)
+	if err != nil && a.Log().GetSLog() != nil {
+		a.Log().Error(err.Error())
+	}
+	if err != nil {
+		t.Error("Unexpected error uploading to user1", err)
+		return
+	}
+
+	// Step 2: transfer from user1 to user2 with --into-album
+	c, a = root.RootImmichGoCommand(ctx)
+	c.SetArgs([]string{
+		"upload", "from-immich",
+		"--server=" + ImmichURL,
+		"--api-key=" + u2.APIKey,
+		"--admin-api-key=" + adm.APIKey,
+		"--from-server=" + ImmichURL,
+		"--from-api-key=" + u1.APIKey,
+		"--from-admin-api-key=" + adm.APIKey,
+		"--into-album=bananas",
+		"--no-ui",
+		"--log-level=debug",
+	})
+	err = c.ExecuteContext(ctx)
+	if err != nil && a.Log().GetSLog() != nil {
+		a.Log().Error(err.Error())
+	}
+	if err != nil {
+		t.Error("Unexpected error on from-immich transfer", err)
+		return
+	}
+
+	e2u := a.FileProcessor()
+
+	e2eutils.CheckResults(t, map[fileevent.Code]int64{
+		fileevent.ProcessedUploadSuccess: 40,
+		fileevent.ProcessedAlbumAdded:    40,
+		fileevent.ProcessedTagged:        0,
+	}, false, e2u)
+}


### PR DESCRIPTION
The --into-album flag was wired separately in from-folder, from-icloud, and from-picasa, while from-immich and from-google-photos lacked it entirely. This hoists it onto the upload parent so all five subcommands get it, and removes the duplicated wiring from each adapter.

The override now runs in handleGroup instead of inside each adapter's Browse loop. Same place in the pipeline, just centralized.

Validation for --into-album + --folder-as-album is preserved on the folder-based subcommands.

Config files need a small update: if you had into-album under [upload.from-folder] (or icloud/picasa), move it to [upload]. The env var is now IMMICH_GO_UPLOAD_INTO_ALBUM.