### PR TITLE
fix: log pending asset details at end of upload

### DIFF
--- a/app/upload/run.go
+++ b/app/upload/run.go
@@ -109,6 +109,7 @@ func (uc *UpCmd) finishing(ctx context.Context) error {
 
 	// Generate FileProcessor report
 	if uc.app.FileProcessor() != nil {
+		uc.app.FileProcessor().Finalize(ctx)
 		report := uc.app.FileProcessor().GenerateReport()
 		if len(report) > 0 {
 			lines := strings.Split(report, "\n")


### PR DESCRIPTION
Hey there 👋 

This addresses the issue reported at #1347 by making sure we finalize the file processor and log any pending files before exiting.

I saw that `Finalize` doesn't really have any other logic besides that logging and that it's called only here, so we could consider inlining this into `GenerateReport` and getting rid of that method. Let me know if it makes sense for you and I'll eventually push a commit for that (or you can do yourself, I gave you edit permissions for the branch).

To verify these changes you can run an upload and then interrupt it mid-execution with ctrl+c, you should see the `asset never reached final state` errors emitted by `Finalize` in the logs.

PS: thank you for writing and maintaining this tool!