### PR TITLE
mTLS support - allow client certificate validation

### DIFF
--- a/app/client.go
+++ b/app/client.go
@@ -25,6 +25,9 @@ type Client struct {
 	AdminAPIKey               string         `mapstructure:"admin_api_key" json:"admin_api_key" toml:"admin_api_key" yaml:"admin_api_key"`                                                             // API Key for admin
 	APITrace                  bool           `mapstructure:"api_trace" json:"api_trace" toml:"api_trace" yaml:"api_trace"`                                                                             // Enable API call traces
 	SkipSSL                   bool           `mapstructure:"skip_ssl" json:"skip_ssl" toml:"skip_ssl" yaml:"skip_ssl"`                                                                                 // Skip SSL Verification
+	ClientCert                string         `mapstructure:"client_cert" json:"client_cert" toml:"client_cert" yaml:"client_cert"`                                                                     // Client certificate (PEM) for mTLS
+	ClientKey                 string         `mapstructure:"client_key" json:"client_key" toml:"client_key" yaml:"client_key"`                                                                         // Client private key (PEM) for mTLS
+	CACert                    string         `mapstructure:"ca_cert" json:"ca_cert" toml:"ca_cert" yaml:"ca_cert"`                                                                                     // CA certificate (PEM) to verify the server
 	ClientTimeout             time.Duration  `mapstructure:"client_timeout" json:"client_timeout" toml:"client_timeout" yaml:"client_timeout"`                                                         // Set the client request timeout
 	DeviceUUID                string         `mapstructure:"device_uuid" json:"device_uuid" toml:"device_uuid" yaml:"device_uuid"`                                                                     // Set a device UUID
 	TimeZone                  string         `mapstructure:"time_zone" json:"time_zone" toml:"time_zone" yaml:"time_zone"`                                                                             // Override default TZ
@@ -57,6 +60,9 @@ func (client *Client) RegisterFlags(flags *pflag.FlagSet, prefix string) {
 	flags.BoolVar(&client.APITrace, prefix+"api-trace", false, "Enable trace of api calls")
 	flags.BoolVar(&client.PauseImmichBackgroundJobs, prefix+"pause-immich-jobs", true, "Pause Immich background jobs during upload operations")
 	flags.BoolVar(&client.SkipSSL, prefix+"skip-verify-ssl", false, "Skip SSL verification")
+	flags.StringVar(&client.ClientCert, prefix+"client-cert", client.ClientCert, "Path to a PEM client certificate for mutual TLS (mTLS) authentication")
+	flags.StringVar(&client.ClientKey, prefix+"client-key", client.ClientKey, "Path to the PEM private key matching --client-cert")
+	flags.StringVar(&client.CACert, prefix+"ca-cert", client.CACert, "Path to a PEM CA certificate bundle used to verify the server")
 	flags.DurationVar(&client.ClientTimeout, prefix+"client-timeout", 20*time.Minute, "Set server calls timeout")
 	flags.StringVar(&client.DeviceUUID, prefix+"device-uuid", client.DeviceUUID, "Set a device UUID")
 	flags.BoolVar(&client.DryRun, prefix+"dry-run", false, "Simulate all actions")
@@ -137,6 +143,8 @@ func (client *Client) Open(ctx context.Context, app *Application) error {
 		client.Server,
 		client.APIKey,
 		immich.OptionVerifySSL(client.SkipSSL),
+		immich.OptionClientCertificate(client.ClientCert, client.ClientKey),
+		immich.OptionCACertificate(client.CACert),
 		immich.OptionConnectionTimeout(client.ClientTimeout),
 		immich.OptionDryRun(client.DryRun),
 	)
@@ -153,6 +161,8 @@ func (client *Client) Open(ctx context.Context, app *Application) error {
 		client.Server,
 		client.AdminAPIKey,
 		immich.OptionVerifySSL(client.SkipSSL),
+		immich.OptionClientCertificate(client.ClientCert, client.ClientKey),
+		immich.OptionCACertificate(client.CACert),
 		immich.OptionConnectionTimeout(adminTime),
 		// no trace pulling job status
 	)

--- a/docs/commands/upload.md
+++ b/docs/commands/upload.md
@@ -28,6 +28,58 @@ All upload sub-commands require these connection parameters:
 | `-k, --api-key`     |    Y     | Your API key                                      |
 | `--skip-verify-ssl` |          | Skip SSL certificate verification                 |
 | `--client-timeout`  |          | Server call timeout (default: `20m`)              |
+| `--client-cert`     |          | PEM client certificate, for mTLS authentication   |
+| `--client-key`      |          | PEM private key matching `--client-cert`          |
+| `--ca-cert`         |          | PEM CA bundle used to verify the server           |
+
+### Mutual TLS (mTLS)
+
+If your Immich server is behind a reverse proxy that requires a client
+certificate, supply the certificate and its key. Both must be given together —
+providing only one is an error:
+
+```sh
+immich-go upload from-folder \
+  --server=https://immich.example.com --api-key=your-key \
+  --client-cert=client-cert.pem \
+  --client-key=client-key.pem \
+  /photos
+```
+
+When the server's own certificate is issued by a private CA, add `--ca-cert` so
+it can be verified. The CA is *added* to the system trust store rather than
+replacing it, so publicly-signed certificates keep working:
+
+```sh
+  --ca-cert=ca-cert.pem
+```
+
+Use `--ca-cert` in preference to `--skip-verify-ssl`, which disables server
+verification entirely.
+
+#### Converting a `.pfx` / `.p12` bundle
+
+`immich-go` reads PEM files. If your certificate was issued as a PKCS#12 bundle
+(common on Windows), split it first with `openssl`:
+
+```sh
+# Client certificate
+openssl pkcs12 -in client.pfx -clcerts -nokeys -out client-cert.pem
+
+# Private key, decrypted — immich-go cannot prompt for a passphrase
+openssl pkcs12 -in client.pfx -nocerts -nodes -out client-key.pem
+
+# CA chain, if the bundle contains one
+openssl pkcs12 -in client.pfx -cacerts -nokeys -out ca-cert.pem
+```
+
+Each command asks for the bundle's import password. The resulting key is
+unencrypted, so restrict access to it with `chmod 600 client-key.pem`.
+
+These options can also be set in the configuration file or through the
+`IMMICH_GO_UPLOAD_CLIENT_CERT`, `IMMICH_GO_UPLOAD_CLIENT_KEY` and
+`IMMICH_GO_UPLOAD_CA_CERT` environment variables, which avoids repeating them
+on every run.
 
 ## Upload Behavior Options
 
@@ -226,6 +278,9 @@ immich-go upload from-immich [source-options] [destination-options]
   | `--from-api-key`         | Source server API key            |
   | `--from-client-timeout`  | Source server timeout            |
   | `--from-skip-verify-ssl` | Skip SSL verification for source |
+  | `--from-client-cert`     | PEM client certificate for the source server (mTLS) |
+  | `--from-client-key`      | PEM private key matching `--from-client-cert`       |
+  | `--from-ca-cert`         | PEM CA bundle used to verify the source server      |
 
 ### Source Filtering
 

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -85,6 +85,9 @@ The following environment variables can be used to configure `immich-go`.
 | `IMMICH_GO_ARCHIVE_FROM_IMMICH_FROM_API_TRACE` | `--from-api-trace` | `false` | Enable trace of api calls |
 | `IMMICH_GO_ARCHIVE_FROM_IMMICH_FROM_ARCHIVED` | `--from-archived` | `false` | Get only archived assets |
 | `IMMICH_GO_ARCHIVE_FROM_IMMICH_FROM_CITY` | `--from-city` |  | Get only assets from this city |
+| `IMMICH_GO_ARCHIVE_FROM_IMMICH_FROM_CA_CERT` | `--from-ca-cert` |  | Path to a PEM CA certificate bundle used to verify the server |
+| `IMMICH_GO_ARCHIVE_FROM_IMMICH_FROM_CLIENT_CERT` | `--from-client-cert` |  | Path to a PEM client certificate for mutual TLS (mTLS) authentication |
+| `IMMICH_GO_ARCHIVE_FROM_IMMICH_FROM_CLIENT_KEY` | `--from-client-key` |  | Path to the PEM private key matching --client-cert |
 | `IMMICH_GO_ARCHIVE_FROM_IMMICH_FROM_CLIENT_TIMEOUT` | `--from-client-timeout` | `20m0s` | Set server calls timeout |
 | `IMMICH_GO_ARCHIVE_FROM_IMMICH_FROM_COUNTRY` | `--from-country` |  | Get only assets from this country |
 | `IMMICH_GO_ARCHIVE_FROM_IMMICH_FROM_DATE_RANGE` | `--from-date-range` | `unset` | Only import photos taken within the specified date range |
@@ -133,6 +136,9 @@ The following environment variables can be used to configure `immich-go`.
 | `IMMICH_GO_STACK_ADMIN_API_KEY` | `--admin-api-key` |  | Admin's API Key for managing server's jobs |
 | `IMMICH_GO_STACK_API_KEY` | `--api-key` |  | API Key |
 | `IMMICH_GO_STACK_API_TRACE` | `--api-trace` | `false` | Enable trace of api calls |
+| `IMMICH_GO_STACK_CA_CERT` | `--ca-cert` |  | Path to a PEM CA certificate bundle used to verify the server |
+| `IMMICH_GO_STACK_CLIENT_CERT` | `--client-cert` |  | Path to a PEM client certificate for mutual TLS (mTLS) authentication |
+| `IMMICH_GO_STACK_CLIENT_KEY` | `--client-key` |  | Path to the PEM private key matching --client-cert |
 | `IMMICH_GO_STACK_CLIENT_TIMEOUT` | `--client-timeout` | `20m0s` | Set server calls timeout |
 | `IMMICH_GO_STACK_DATE_RANGE` | `--date-range` | `unset` | photos must be taken in the date range |
 | `IMMICH_GO_STACK_DEVICE_UUID` | `--device-uuid` | `gl65` | Set a device UUID |
@@ -153,6 +159,9 @@ The following environment variables can be used to configure `immich-go`.
 | `IMMICH_GO_UPLOAD_ADMIN_API_KEY` | `--admin-api-key` |  | Admin's API Key for managing server's jobs |
 | `IMMICH_GO_UPLOAD_API_KEY` | `--api-key` |  | API Key |
 | `IMMICH_GO_UPLOAD_API_TRACE` | `--api-trace` | `false` | Enable trace of api calls |
+| `IMMICH_GO_UPLOAD_CA_CERT` | `--ca-cert` |  | Path to a PEM CA certificate bundle used to verify the server |
+| `IMMICH_GO_UPLOAD_CLIENT_CERT` | `--client-cert` |  | Path to a PEM client certificate for mutual TLS (mTLS) authentication |
+| `IMMICH_GO_UPLOAD_CLIENT_KEY` | `--client-key` |  | Path to the PEM private key matching --client-cert |
 | `IMMICH_GO_UPLOAD_CLIENT_TIMEOUT` | `--client-timeout` | `20m0s` | Set server calls timeout |
 | `IMMICH_GO_UPLOAD_DEVICE_UUID` | `--device-uuid` | `gl65` | Set a device UUID |
 | `IMMICH_GO_UPLOAD_DRY_RUN` | `--dry-run` | `false` | Simulate all actions |
@@ -234,6 +243,9 @@ The following environment variables can be used to configure `immich-go`.
 | `IMMICH_GO_UPLOAD_FROM_IMMICH_FROM_API_TRACE` | `--from-api-trace` | `false` | Enable trace of api calls |
 | `IMMICH_GO_UPLOAD_FROM_IMMICH_FROM_ARCHIVED` | `--from-archived` | `false` | Get only archived assets |
 | `IMMICH_GO_UPLOAD_FROM_IMMICH_FROM_CITY` | `--from-city` |  | Get only assets from this city |
+| `IMMICH_GO_UPLOAD_FROM_IMMICH_FROM_CA_CERT` | `--from-ca-cert` |  | Path to a PEM CA certificate bundle used to verify the server |
+| `IMMICH_GO_UPLOAD_FROM_IMMICH_FROM_CLIENT_CERT` | `--from-client-cert` |  | Path to a PEM client certificate for mutual TLS (mTLS) authentication |
+| `IMMICH_GO_UPLOAD_FROM_IMMICH_FROM_CLIENT_KEY` | `--from-client-key` |  | Path to the PEM private key matching --client-cert |
 | `IMMICH_GO_UPLOAD_FROM_IMMICH_FROM_CLIENT_TIMEOUT` | `--from-client-timeout` | `20m0s` | Set server calls timeout |
 | `IMMICH_GO_UPLOAD_FROM_IMMICH_FROM_COUNTRY` | `--from-country` |  | Get only assets from this country |
 | `IMMICH_GO_UPLOAD_FROM_IMMICH_FROM_DATE_RANGE` | `--from-date-range` | `unset` | Only import photos taken within the specified date range |

--- a/immich/client.go
+++ b/immich/client.go
@@ -2,6 +2,9 @@ package immich
 
 import (
 	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -67,6 +70,52 @@ func OptionSetAPITrace(rtd RoundTripperDecorator) clientOption {
 func OptionVerifySSL(verify bool) clientOption {
 	return func(ic *ImmichClient) error {
 		ic.transport.TLSClientConfig.InsecureSkipVerify = verify
+		return nil
+	}
+}
+
+// OptionClientCertificate configures a client certificate and key for mutual TLS
+// (mTLS) authentication. The server will receive this certificate during the TLS
+// handshake. Both certFile and keyFile must point to PEM-encoded files. When both
+// are empty the option is a no-op.
+func OptionClientCertificate(certFile, keyFile string) clientOption {
+	return func(ic *ImmichClient) error {
+		if certFile == "" && keyFile == "" {
+			return nil
+		}
+		if certFile == "" || keyFile == "" {
+			return errors.New("mTLS requires both --client-cert and --client-key to be set")
+		}
+		cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+		if err != nil {
+			return fmt.Errorf("loading client certificate: %w", err)
+		}
+		ic.transport.TLSClientConfig.Certificates = append(ic.transport.TLSClientConfig.Certificates, cert)
+		return nil
+	}
+}
+
+// OptionCACertificate adds a PEM-encoded certificate authority bundle used to
+// verify the server's certificate. This is typically needed when the Immich
+// server presents a certificate signed by a private CA, as is common in mTLS
+// deployments. When caFile is empty the option is a no-op.
+func OptionCACertificate(caFile string) clientOption {
+	return func(ic *ImmichClient) error {
+		if caFile == "" {
+			return nil
+		}
+		caCert, err := os.ReadFile(caFile)
+		if err != nil {
+			return fmt.Errorf("reading CA certificate: %w", err)
+		}
+		pool, err := x509.SystemCertPool()
+		if err != nil || pool == nil {
+			pool = x509.NewCertPool()
+		}
+		if !pool.AppendCertsFromPEM(caCert) {
+			return fmt.Errorf("no valid certificate found in CA file %q", caFile)
+		}
+		ic.transport.TLSClientConfig.RootCAs = pool
 		return nil
 	}
 }

--- a/immich/mtls_test.go
+++ b/immich/mtls_test.go
@@ -1,0 +1,156 @@
+package immich_test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/simulot/immich-go/immich"
+)
+
+// certPEM holds a PEM-encoded certificate and its private key.
+type certPEM struct {
+	cert []byte
+	key  []byte
+	tls  tls.Certificate
+}
+
+// makeCert issues a certificate signed by the given parent (or self-signed when
+// parent is nil). It returns the PEM material and a usable tls.Certificate.
+func makeCert(t *testing.T, cn string, isCA bool, parent *x509.Certificate, parentKey *ecdsa.PrivateKey) (certPEM, *x509.Certificate, *ecdsa.PrivateKey) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: cn},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		DNSNames:              []string{"127.0.0.1", "localhost"},
+		IsCA:                  isCA,
+		BasicConstraintsValid: true,
+	}
+
+	signer, signerKey := tmpl, key
+	if parent != nil {
+		signer, signerKey = parent, parentKey
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, signer, &key.PublicKey, signerKey)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+
+	certOut := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	keyOut := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	tlsCert, err := tls.X509KeyPair(certOut, keyOut)
+	if err != nil {
+		t.Fatalf("build tls keypair: %v", err)
+	}
+
+	parsed, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse certificate: %v", err)
+	}
+
+	return certPEM{cert: certOut, key: keyOut, tls: tlsCert}, parsed, key
+}
+
+// TestMutualTLS stands up a TLS server that requires and verifies a client
+// certificate, then confirms the client authenticates successfully when
+// configured with a client certificate and the trust anchor, and fails when
+// the client certificate is omitted.
+func TestMutualTLS(t *testing.T) {
+	_, caCert, caKey := makeCert(t, "immich-go-test-ca", true, nil, nil)
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caCert.Raw})
+
+	serverCert, _, _ := makeCert(t, "127.0.0.1", false, caCert, caKey)
+	clientCert, _, _ := makeCert(t, "immich-go-client", false, caCert, caKey)
+
+	clientCAs := x509.NewCertPool()
+	clientCAs.AppendCertsFromPEM(caPEM)
+
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"res":"pong"}`))
+	}))
+	server.TLS = &tls.Config{
+		Certificates: []tls.Certificate{serverCert.tls},
+		ClientCAs:    clientCAs,
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+	}
+	server.StartTLS()
+	defer server.Close()
+
+	dir := t.TempDir()
+	caFile := filepath.Join(dir, "ca.pem")
+	certFile := filepath.Join(dir, "client.pem")
+	keyFile := filepath.Join(dir, "client.key")
+	writeFile(t, caFile, caPEM)
+	writeFile(t, certFile, clientCert.cert)
+	writeFile(t, keyFile, clientCert.key)
+
+	t.Run("with client certificate", func(t *testing.T) {
+		client, err := immich.NewImmichClient(server.URL, "test-key",
+			immich.OptionCACertificate(caFile),
+			immich.OptionClientCertificate(certFile, keyFile),
+		)
+		if err != nil {
+			t.Fatalf("NewImmichClient: %v", err)
+		}
+		if err := client.PingServer(context.Background()); err != nil {
+			t.Fatalf("expected mTLS ping to succeed, got %v", err)
+		}
+	})
+
+	t.Run("without client certificate", func(t *testing.T) {
+		client, err := immich.NewImmichClient(server.URL, "test-key",
+			immich.OptionCACertificate(caFile),
+		)
+		if err != nil {
+			t.Fatalf("NewImmichClient: %v", err)
+		}
+		if err := client.PingServer(context.Background()); err == nil {
+			t.Fatal("expected ping to fail without a client certificate, got nil error")
+		}
+	})
+
+	t.Run("mismatched cert and key", func(t *testing.T) {
+		_, err := immich.NewImmichClient(server.URL, "test-key",
+			immich.OptionClientCertificate(certFile, ""),
+		)
+		if err == nil {
+			t.Fatal("expected error when only one of cert/key is supplied")
+		}
+	})
+}
+
+func writeFile(t *testing.T, path string, data []byte) {
+	t.Helper()
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}


### PR DESCRIPTION
Add mutual TLS (mTLS) support for Immich server connections. immich supports client certificate in the app and web, it secures the installation considerably without a need for VPN (assuming sharing pfx with immich instance users).

Originally I implemented a hackish way to hook into original node [immich-cli](https://github.com/t00/immich-bulk-import) but immich-go is so much lighter and easier to use, why not here as well.

Adds three client options and their matching CLI flags so immich-go can authenticate to servers that require a client certificate:

  --client-cert PEM client certificate
  --client-key PEM private key matching the certificate
  --ca-cert PEM CA bundle used to verify the server certificate

OptionClientCertificate loads the pair with tls.LoadX509KeyPair and appends it to the transport's TLS config; supplying only one of the two is rejected up front. OptionCACertificate extends a copy of the system cert pool, so a private CA can be added without losing public trust roots. Both are no-ops when their flags are unset, leaving the default TLS behaviour unchanged.

The flags are registered on Client.RegisterFlags, so they are picked up by every command that opens a server connection (upload, stack) and are configurable via config file and IMMICH_GO_* environment variables like any other client setting.

Covered by immich/mtls_test.go: a client cert is accepted, a connection without one is refused, and a mismatched cert/key pair errors.

Documentation is in a separate commit.