### PR TITLE
folder-as-album = 'TOP' for importing only top level folder names as albums

### DIFF
--- a/adapters/folder/commands.go
+++ b/adapters/folder/commands.go
@@ -62,7 +62,7 @@ func (ifc *ImportFolderCmd) RegisterFlags(flags *pflag.FlagSet, cmd *cobra.Comma
 
 	flags.Var(&ifc.BannedFiles, "ban-file", "Exclude a file based on a pattern (case-insensitive). Can be specified multiple times.")
 	flags.StringVar(&ifc.ImportIntoAlbum, "into-album", "", "Specify an album to import all files into")
-	flags.Var(&ifc.UsePathAsAlbumName, "folder-as-album", "Import all files in albums defined by the folder structure. Can be set to 'FOLDER' to use the folder name as the album name, or 'PATH' to use the full path as the album name")
+	flags.Var(&ifc.UsePathAsAlbumName, "folder-as-album", "Import all files in albums defined by the folder structure. Can be set to 'FOLDER' to use the folder name as the album name, 'PATH' to use the full path as the album name, or 'TOP' to use the top-level folder name as the album name for the whole sub-tree")
 	flags.StringVar(&ifc.AlbumNamePathSeparator, "album-path-joiner", " / ", "Specify a string to use when joining multiple folder names to create an album name (e.g. ' ',' - ')")
 	flags.BoolVar(&ifc.Recursive, "recursive", true, "Explore the folder and all its sub-folders")
 	flags.BoolVar(&ifc.IgnoreSideCarFiles, "ignore-sidecar-files", false, "Don't upload sidecar with the photo.")

--- a/adapters/folder/folderCli.go
+++ b/adapters/folder/folderCli.go
@@ -14,6 +14,7 @@ const (
 	FolderModeNone   AlbumFolderMode = "NONE"
 	FolderModeFolder AlbumFolderMode = "FOLDER"
 	FolderModePath   AlbumFolderMode = "PATH"
+	FolderModeTop    AlbumFolderMode = "TOP"
 )
 
 func (m AlbumFolderMode) String() string {
@@ -23,10 +24,10 @@ func (m AlbumFolderMode) String() string {
 func (m *AlbumFolderMode) Set(v string) error {
 	v = strings.TrimSpace(strings.ToUpper(v))
 	switch v {
-	case string(FolderModeFolder), string(FolderModePath), string(FolderModeNone):
+	case string(FolderModeFolder), string(FolderModePath), string(FolderModeTop), string(FolderModeNone):
 		*m = AlbumFolderMode(v)
 	default:
-		return fmt.Errorf("invalid value for folder mode, expected %s, %s or %s", FolderModeFolder, FolderModePath, FolderModeNone)
+		return fmt.Errorf("invalid value for folder mode, expected %s, %s, %s or %s", FolderModeFolder, FolderModePath, FolderModeTop, FolderModeNone)
 	}
 	return nil
 }

--- a/adapters/folder/folderCli_test.go
+++ b/adapters/folder/folderCli_test.go
@@ -1,0 +1,49 @@
+package folder
+
+import "testing"
+
+func TestAlbumFolderModeSet(t *testing.T) {
+	tests := []struct {
+		value   string
+		want    AlbumFolderMode
+		wantErr bool
+	}{
+		{value: "FOLDER", want: FolderModeFolder},
+		{value: "PATH", want: FolderModePath},
+		{value: "TOP", want: FolderModeTop},
+		{value: "NONE", want: FolderModeNone},
+		{value: "top", want: FolderModeTop},
+		{value: "  Top  ", want: FolderModeTop},
+		{value: "TOPMOST", wantErr: true},
+		{value: "", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			var m AlbumFolderMode
+			err := m.Set(tt.value)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Set(%q) error = %v, wantErr %v", tt.value, err, tt.wantErr)
+			}
+			if err == nil && m != tt.want {
+				t.Errorf("Set(%q) = %q, want %q", tt.value, m, tt.want)
+			}
+		})
+	}
+}
+
+func TestAlbumFolderModeTextRoundTrip(t *testing.T) {
+	for _, want := range []AlbumFolderMode{FolderModeNone, FolderModeFolder, FolderModePath, FolderModeTop} {
+		b, err := want.MarshalText()
+		if err != nil {
+			t.Fatalf("MarshalText(%q): %v", want, err)
+		}
+		var got AlbumFolderMode
+		if err := got.UnmarshalText(b); err != nil {
+			t.Fatalf("UnmarshalText(%q): %v", b, err)
+		}
+		if got != want {
+			t.Errorf("round trip = %q, want %q", got, want)
+		}
+	}
+}

--- a/adapters/folder/run.go
+++ b/adapters/folder/run.go
@@ -441,6 +441,12 @@ func (ifc *ImportFolderCmd) parseDir(ctx context.Context, fsys fs.FS, dir string
 						} else {
 							Album = filepath.Base(dir)
 						}
+					case FolderModeTop:
+						if dir == "." {
+							Album = fsName
+						} else {
+							Album = strings.Split(dir, "/")[0]
+						}
 					case FolderModePath:
 						parts := []string{}
 						if fsName != "" {

--- a/docs/commands/upload.md
+++ b/docs/commands/upload.md
@@ -87,7 +87,7 @@ immich-go upload from-folder [options] <folder-path>
 
 | Option                | Default | Description                                             |
 | --------------------- | ------- | ------------------------------------------------------- |
-| `--folder-as-album`   | `NONE`  | Create albums from folders: `FOLDER`, `PATH`, or `NONE` |
+| `--folder-as-album`   | `NONE`  | Create albums from folders: `FOLDER`, `PATH`, `TOP`, or `NONE` |
 | `--folder-as-tags`    | `false` | Use folder structure as tags                            |
 | `--album-path-joiner` | `" / "` | String for joining folder names in album titles         |
 | `--album-picasa`      | `false` | Use Picasa album names from `.picasa.ini` files         |

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -29,7 +29,7 @@ The following environment variables can be used to configure `immich-go`.
 | `IMMICH_GO_ARCHIVE_FROM_FOLDER_DATE_FROM_NAME` | `--date-from-name` | `true` | Use the date from the filename if the date isn't available in the metadata (Only for jpg, mp4, heic, dng, cr2, cr3, arw, raf, nef, mov) |
 | `IMMICH_GO_ARCHIVE_FROM_FOLDER_DATE_RANGE` | `--date-range` | `unset` | Only import photos taken within the specified date range |
 | `IMMICH_GO_ARCHIVE_FROM_FOLDER_EXCLUDE_EXTENSIONS` | `--exclude-extensions` |  | Comma-separated list of extension to exclude. (e.g. .gif,.PM) (default: none) |
-| `IMMICH_GO_ARCHIVE_FROM_FOLDER_FOLDER_AS_ALBUM` | `--folder-as-album` | `NONE` | Import all files in albums defined by the folder structure. Can be set to 'FOLDER' to use the folder name as the album name, or 'PATH' to use the full path as the album name |
+| `IMMICH_GO_ARCHIVE_FROM_FOLDER_FOLDER_AS_ALBUM` | `--folder-as-album` | `NONE` | Import all files in albums defined by the folder structure. Can be set to 'FOLDER' to use the folder name as the album name, 'PATH' to use the full path as the album name, or 'TOP' to use the top-level folder name as the album name for the whole sub-tree |
 | `IMMICH_GO_ARCHIVE_FROM_FOLDER_FOLDER_AS_TAGS` | `--folder-as-tags` | `false` | Use the folder structure as tags, (ex: the file  holiday/summer 2024/file.jpg will have the tag holiday/summer 2024) |
 | `IMMICH_GO_ARCHIVE_FROM_FOLDER_IGNORE_SIDECAR_FILES` | `--ignore-sidecar-files` | `false` | Don't upload sidecar with the photo. |
 | `IMMICH_GO_ARCHIVE_FROM_FOLDER_INCLUDE_EXTENSIONS` | `--include-extensions` |  | Comma-separated list of extension to include. (e.g. .jpg,.heic) (default: all) |
@@ -66,7 +66,7 @@ The following environment variables can be used to configure `immich-go`.
 | `IMMICH_GO_ARCHIVE_FROM_ICLOUD_DATE_FROM_NAME` | `--date-from-name` | `true` | Use the date from the filename if the date isn't available in the metadata (Only for jpg, mp4, heic, dng, cr2, cr3, arw, raf, nef, mov) |
 | `IMMICH_GO_ARCHIVE_FROM_ICLOUD_DATE_RANGE` | `--date-range` | `unset` | Only import photos taken within the specified date range |
 | `IMMICH_GO_ARCHIVE_FROM_ICLOUD_EXCLUDE_EXTENSIONS` | `--exclude-extensions` |  | Comma-separated list of extension to exclude. (e.g. .gif,.PM) (default: none) |
-| `IMMICH_GO_ARCHIVE_FROM_ICLOUD_FOLDER_AS_ALBUM` | `--folder-as-album` | `NONE` | Import all files in albums defined by the folder structure. Can be set to 'FOLDER' to use the folder name as the album name, or 'PATH' to use the full path as the album name |
+| `IMMICH_GO_ARCHIVE_FROM_ICLOUD_FOLDER_AS_ALBUM` | `--folder-as-album` | `NONE` | Import all files in albums defined by the folder structure. Can be set to 'FOLDER' to use the folder name as the album name, 'PATH' to use the full path as the album name, or 'TOP' to use the top-level folder name as the album name for the whole sub-tree |
 | `IMMICH_GO_ARCHIVE_FROM_ICLOUD_FOLDER_AS_TAGS` | `--folder-as-tags` | `false` | Use the folder structure as tags, (ex: the file  holiday/summer 2024/file.jpg will have the tag holiday/summer 2024) |
 | `IMMICH_GO_ARCHIVE_FROM_ICLOUD_IGNORE_SIDECAR_FILES` | `--ignore-sidecar-files` | `false` | Don't upload sidecar with the photo. |
 | `IMMICH_GO_ARCHIVE_FROM_ICLOUD_INCLUDE_EXTENSIONS` | `--include-extensions` |  | Comma-separated list of extension to include. (e.g. .jpg,.heic) (default: all) |
@@ -118,7 +118,7 @@ The following environment variables can be used to configure `immich-go`.
 | `IMMICH_GO_ARCHIVE_FROM_PICASA_DATE_FROM_NAME` | `--date-from-name` | `true` | Use the date from the filename if the date isn't available in the metadata (Only for jpg, mp4, heic, dng, cr2, cr3, arw, raf, nef, mov) |
 | `IMMICH_GO_ARCHIVE_FROM_PICASA_DATE_RANGE` | `--date-range` | `unset` | Only import photos taken within the specified date range |
 | `IMMICH_GO_ARCHIVE_FROM_PICASA_EXCLUDE_EXTENSIONS` | `--exclude-extensions` |  | Comma-separated list of extension to exclude. (e.g. .gif,.PM) (default: none) |
-| `IMMICH_GO_ARCHIVE_FROM_PICASA_FOLDER_AS_ALBUM` | `--folder-as-album` | `NONE` | Import all files in albums defined by the folder structure. Can be set to 'FOLDER' to use the folder name as the album name, or 'PATH' to use the full path as the album name |
+| `IMMICH_GO_ARCHIVE_FROM_PICASA_FOLDER_AS_ALBUM` | `--folder-as-album` | `NONE` | Import all files in albums defined by the folder structure. Can be set to 'FOLDER' to use the folder name as the album name, 'PATH' to use the full path as the album name, or 'TOP' to use the top-level folder name as the album name for the whole sub-tree |
 | `IMMICH_GO_ARCHIVE_FROM_PICASA_FOLDER_AS_TAGS` | `--folder-as-tags` | `false` | Use the folder structure as tags, (ex: the file  holiday/summer 2024/file.jpg will have the tag holiday/summer 2024) |
 | `IMMICH_GO_ARCHIVE_FROM_PICASA_IGNORE_SIDECAR_FILES` | `--ignore-sidecar-files` | `false` | Don't upload sidecar with the photo. |
 | `IMMICH_GO_ARCHIVE_FROM_PICASA_INCLUDE_EXTENSIONS` | `--include-extensions` |  | Comma-separated list of extension to include. (e.g. .jpg,.heic) (default: all) |
@@ -178,7 +178,7 @@ The following environment variables can be used to configure `immich-go`.
 | `IMMICH_GO_UPLOAD_FROM_FOLDER_DATE_FROM_NAME` | `--date-from-name` | `true` | Use the date from the filename if the date isn't available in the metadata (Only for jpg, mp4, heic, dng, cr2, cr3, arw, raf, nef, mov) |
 | `IMMICH_GO_UPLOAD_FROM_FOLDER_DATE_RANGE` | `--date-range` | `unset` | Only import photos taken within the specified date range |
 | `IMMICH_GO_UPLOAD_FROM_FOLDER_EXCLUDE_EXTENSIONS` | `--exclude-extensions` |  | Comma-separated list of extension to exclude. (e.g. .gif,.PM) (default: none) |
-| `IMMICH_GO_UPLOAD_FROM_FOLDER_FOLDER_AS_ALBUM` | `--folder-as-album` | `NONE` | Import all files in albums defined by the folder structure. Can be set to 'FOLDER' to use the folder name as the album name, or 'PATH' to use the full path as the album name |
+| `IMMICH_GO_UPLOAD_FROM_FOLDER_FOLDER_AS_ALBUM` | `--folder-as-album` | `NONE` | Import all files in albums defined by the folder structure. Can be set to 'FOLDER' to use the folder name as the album name, 'PATH' to use the full path as the album name, or 'TOP' to use the top-level folder name as the album name for the whole sub-tree |
 | `IMMICH_GO_UPLOAD_FROM_FOLDER_FOLDER_AS_TAGS` | `--folder-as-tags` | `false` | Use the folder structure as tags, (ex: the file  holiday/summer 2024/file.jpg will have the tag holiday/summer 2024) |
 | `IMMICH_GO_UPLOAD_FROM_FOLDER_IGNORE_SIDECAR_FILES` | `--ignore-sidecar-files` | `false` | Don't upload sidecar with the photo. |
 | `IMMICH_GO_UPLOAD_FROM_FOLDER_INCLUDE_EXTENSIONS` | `--include-extensions` |  | Comma-separated list of extension to include. (e.g. .jpg,.heic) (default: all) |
@@ -215,7 +215,7 @@ The following environment variables can be used to configure `immich-go`.
 | `IMMICH_GO_UPLOAD_FROM_ICLOUD_DATE_FROM_NAME` | `--date-from-name` | `true` | Use the date from the filename if the date isn't available in the metadata (Only for jpg, mp4, heic, dng, cr2, cr3, arw, raf, nef, mov) |
 | `IMMICH_GO_UPLOAD_FROM_ICLOUD_DATE_RANGE` | `--date-range` | `unset` | Only import photos taken within the specified date range |
 | `IMMICH_GO_UPLOAD_FROM_ICLOUD_EXCLUDE_EXTENSIONS` | `--exclude-extensions` |  | Comma-separated list of extension to exclude. (e.g. .gif,.PM) (default: none) |
-| `IMMICH_GO_UPLOAD_FROM_ICLOUD_FOLDER_AS_ALBUM` | `--folder-as-album` | `NONE` | Import all files in albums defined by the folder structure. Can be set to 'FOLDER' to use the folder name as the album name, or 'PATH' to use the full path as the album name |
+| `IMMICH_GO_UPLOAD_FROM_ICLOUD_FOLDER_AS_ALBUM` | `--folder-as-album` | `NONE` | Import all files in albums defined by the folder structure. Can be set to 'FOLDER' to use the folder name as the album name, 'PATH' to use the full path as the album name, or 'TOP' to use the top-level folder name as the album name for the whole sub-tree |
 | `IMMICH_GO_UPLOAD_FROM_ICLOUD_FOLDER_AS_TAGS` | `--folder-as-tags` | `false` | Use the folder structure as tags, (ex: the file  holiday/summer 2024/file.jpg will have the tag holiday/summer 2024) |
 | `IMMICH_GO_UPLOAD_FROM_ICLOUD_IGNORE_SIDECAR_FILES` | `--ignore-sidecar-files` | `false` | Don't upload sidecar with the photo. |
 | `IMMICH_GO_UPLOAD_FROM_ICLOUD_INCLUDE_EXTENSIONS` | `--include-extensions` |  | Comma-separated list of extension to include. (e.g. .jpg,.heic) (default: all) |
@@ -267,7 +267,7 @@ The following environment variables can be used to configure `immich-go`.
 | `IMMICH_GO_UPLOAD_FROM_PICASA_DATE_FROM_NAME` | `--date-from-name` | `true` | Use the date from the filename if the date isn't available in the metadata (Only for jpg, mp4, heic, dng, cr2, cr3, arw, raf, nef, mov) |
 | `IMMICH_GO_UPLOAD_FROM_PICASA_DATE_RANGE` | `--date-range` | `unset` | Only import photos taken within the specified date range |
 | `IMMICH_GO_UPLOAD_FROM_PICASA_EXCLUDE_EXTENSIONS` | `--exclude-extensions` |  | Comma-separated list of extension to exclude. (e.g. .gif,.PM) (default: none) |
-| `IMMICH_GO_UPLOAD_FROM_PICASA_FOLDER_AS_ALBUM` | `--folder-as-album` | `NONE` | Import all files in albums defined by the folder structure. Can be set to 'FOLDER' to use the folder name as the album name, or 'PATH' to use the full path as the album name |
+| `IMMICH_GO_UPLOAD_FROM_PICASA_FOLDER_AS_ALBUM` | `--folder-as-album` | `NONE` | Import all files in albums defined by the folder structure. Can be set to 'FOLDER' to use the folder name as the album name, 'PATH' to use the full path as the album name, or 'TOP' to use the top-level folder name as the album name for the whole sub-tree |
 | `IMMICH_GO_UPLOAD_FROM_PICASA_FOLDER_AS_TAGS` | `--folder-as-tags` | `false` | Use the folder structure as tags, (ex: the file  holiday/summer 2024/file.jpg will have the tag holiday/summer 2024) |
 | `IMMICH_GO_UPLOAD_FROM_PICASA_IGNORE_SIDECAR_FILES` | `--ignore-sidecar-files` | `false` | Don't upload sidecar with the photo. |
 | `IMMICH_GO_UPLOAD_FROM_PICASA_INCLUDE_EXTENSIONS` | `--include-extensions` |  | Comma-separated list of extension to include. (e.g. .jpg,.heic) (default: all) |

--- a/docs/upload-commands-overview.md
+++ b/docs/upload-commands-overview.md
@@ -41,7 +41,7 @@ The tool consults multiple sources for metadata, in the following order of prior
 You have several options for organizing your assets into albums:
 
 *   **`--into-album`**: The simplest option. All assets are placed into a single album you specify.
-*   **`--folder-as-album`**: A powerful feature that creates albums based on your folder structure. You can use the immediate parent folder name (`FOLDER`) or the full relative path (`PATH`) as the album title.
+*   **`--folder-as-album`**: A powerful feature that creates albums based on your folder structure. You can use the immediate parent folder name (`FOLDER`), the full relative path (`PATH`), or the top-level folder name (`TOP`) as the album title. With `TOP`, everything below a top-level folder — however deeply nested — goes into a single album named after that folder.
 *   **Source-Specific Albums**: When importing from Picasa (`--album-picasa`) or iCloud (`--memories`), `immich-go` can automatically create albums based on the metadata from those services.
 
 To avoid creating duplicate albums, `immich-go` first fetches your existing album list from the server. It then batches updates to minimize API calls.


### PR DESCRIPTION
Add TOP mode to --folder-as-album: fits nicely in already taken convention of specifying mode by name.

Adds a third value alongside FOLDER and PATH: TOP names the album after the top-level folder, so every asset below it, however deeply nested, lands in a single album rather than one album per leaf directory.

```
/photos/Vacation2020/Day1/img.jpg  ->  album "Vacation2020"
/photos/Vacation2020/Day2/img.jpg  ->  album "Vacation2020"
```

The album name is the first path segment relative to the folder given on the command line; files sitting directly in that folder use its own name, matching what FOLDER already does for the same case.

Previously this grouping was only reachable by invoking immich-go once per top-level folder with --into-album, which re-scanned and reconnected for each one.

The new value is accepted by AlbumFolderMode.Set, so it works from the command line, the configuration file and the IMMICH_GO_* environment variables alike. Documentation updated wherever the accepted values are listed.

Adds adapters/folder/folderCli_test.go covering flag parsing and text round-tripping - the first test file in this package.