### PR TITLE
fix: don't send empty asset IDs to the album, tag and stack endpoints

### DIFF
--- a/app/upload/run.go
+++ b/app/upload/run.go
@@ -313,7 +313,7 @@ func (uc *UpCmd) handleGroup(ctx context.Context, g *assets.Group) error {
 	// Upload assets from the group
 	for _, a := range g.Assets {
 		err := uc.handleAsset(ctx, a)
-		errGroup = errors.Join(err)
+		errGroup = errors.Join(errGroup, err)
 	}
 
 	// Manage groups
@@ -321,7 +321,10 @@ func (uc *UpCmd) handleGroup(ctx context.Context, g *assets.Group) error {
 
 	if len(g.Assets) > 1 && g.Grouping != assets.GroupByNone {
 		client := uc.client.Immich.(immich.ImmichStackInterface)
-		ids := []string{g.Assets[g.CoverIndex].ID}
+		var ids []string
+		if cover := g.Assets[g.CoverIndex]; cover.ID != "" {
+			ids = append(ids, cover.ID)
+		}
 		for i, a := range g.Assets {
 			// Record stacking event
 			uc.app.FileProcessor().RecordNonAsset(ctx, g.Assets[i].File, 0, fileevent.ProcessedStacked)
@@ -378,6 +381,7 @@ func (uc *UpCmd) handleAsset(ctx context.Context, a *assets.Asset) error {
 		return nil
 
 	case AlreadyProcessed: // SHA1 already processed
+		a.ID = advice.ServerAsset.ID
 		// Record as discarded - duplicate in input
 		uc.app.FileProcessor().RecordNonAsset(ctx, a.File, int64(a.FileSize), fileevent.DiscardedLocalDuplicate)
 		uc.app.FileProcessor().RecordAssetProcessed(ctx, a.File, int64(a.FileSize), fileevent.ProcessedMetadataUpdated)

--- a/app/upload/run_test.go
+++ b/app/upload/run_test.go
@@ -1,0 +1,103 @@
+package upload
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"slices"
+	"testing"
+	"testing/fstest"
+
+	"github.com/spf13/cobra"
+
+	"github.com/simulot/immich-go/app"
+	"github.com/simulot/immich-go/internal/assets"
+	"github.com/simulot/immich-go/internal/assets/cache"
+	"github.com/simulot/immich-go/internal/assettracker"
+	"github.com/simulot/immich-go/internal/fileevent"
+	"github.com/simulot/immich-go/internal/fileprocessor"
+	"github.com/simulot/immich-go/internal/fshelper"
+)
+
+// newTestUpCmd returns an UpCmd wired with the collaborators handleAsset needs, and the
+// map where the album cache records what it would have sent to the server.
+func newTestUpCmd(t *testing.T) (*UpCmd, map[string][]string) {
+	t.Helper()
+
+	a := app.New(context.Background(), &cobra.Command{})
+	a.SetFileProcessor(fileprocessor.New(
+		assettracker.New(),
+		fileevent.NewRecorder(slog.New(slog.NewTextHandler(io.Discard, nil))),
+	))
+
+	savedAlbums := map[string][]string{}
+	uc := &UpCmd{
+		app:        a,
+		assetIndex: newAssetIndex(),
+	}
+	uc.albumsCache = cache.NewCollectionCache(50, func(album assets.Album, ids []string) (assets.Album, error) {
+		savedAlbums[album.Title] = append(savedAlbums[album.Title], ids...)
+		return album, nil
+	})
+	uc.tagsCache = cache.NewCollectionCache(50, func(tag assets.Tag, ids []string) (assets.Tag, error) {
+		return tag, nil
+	})
+	return uc, savedAlbums
+}
+
+// A file that duplicates one already uploaded during the same run must join the albums with the
+// ID of the asset it duplicates. Sending an empty ID makes the server reject the whole batch.
+func TestHandleAssetAlreadyProcessedJoinsAlbumsWithTheServerID(t *testing.T) {
+	const (
+		serverID  = "9a2fff7a-f226-48e8-a888-fdac199f3d56"
+		albumName = "an album"
+	)
+
+	content := []byte("the very same photo, twice")
+	fsys := fstest.MapFS{
+		"photo.jpg":     &fstest.MapFile{Data: content},
+		"photo (1).jpg": &fstest.MapFile{Data: content},
+	}
+
+	uc, savedAlbums := newTestUpCmd(t)
+	ctx := context.Background()
+
+	uploaded := &assets.Asset{
+		ID:               serverID,
+		File:             fshelper.FSName(fsys, "photo.jpg"),
+		OriginalFileName: "photo.jpg",
+	}
+	if _, err := uploaded.GetChecksum(); err != nil {
+		t.Fatalf("can't compute the checksum of the uploaded asset: %v", err)
+	}
+	if _, added := uc.assetIndex.addLocalAsset(uploaded); !added {
+		t.Fatal("the uploaded asset should have been added to the index")
+	}
+
+	duplicate := &assets.Asset{
+		File:             fshelper.FSName(fsys, "photo (1).jpg"),
+		OriginalFileName: "photo (1).jpg",
+		Albums:           []assets.Album{assets.NewAlbum("", albumName, "")},
+	}
+	uc.app.FileProcessor().RecordAssetDiscovered(ctx, duplicate.File, int64(len(content)), fileevent.DiscoveredImage)
+
+	advice, err := uc.assetIndex.ShouldUpload(duplicate, uc)
+	if err != nil {
+		t.Fatalf("ShouldUpload: %v", err)
+	}
+	if advice.Advice != AlreadyProcessed {
+		t.Fatalf("expected the advice %v, got %v", AlreadyProcessed, advice.Advice)
+	}
+
+	if err := uc.handleAsset(ctx, duplicate); err != nil {
+		t.Fatalf("handleAsset: %v", err)
+	}
+	if duplicate.ID != serverID {
+		t.Errorf("expected the asset ID %q, got %q", serverID, duplicate.ID)
+	}
+
+	uc.albumsCache.Close() // flush what the cache holds to the save function
+	if got := savedAlbums[albumName]; !slices.Equal(got, []string{serverID}) {
+		t.Errorf("expected the album to receive %q, got %q", []string{serverID}, got)
+	}
+}


### PR DESCRIPTION
In a directory with multiple, identical copies of the same photos, I kept running into errors like:

```
ERR failed to add assets to album err=AddAssetToAlbum, PUT /api/albums/{id}/assets, 400 Bad Request
Validation failed
[{"code":"invalid_format","format":"uuid","path":["ids",25],"message":"Invalid UUID"}]
```

This was because assets that hit the `AlreadyProcessed` path never had an `id` assigned, leading to an empty id getting pushed to albums/tags/etc.

I've added a test around duplicates to avoid these kinds of downstream effects.