### PR TITLE
feat(google-takeout): edited image match supplemental sidecar with index

### DIFF
--- a/adapters/googlePhotos/matcher_test.go
+++ b/adapters/googlePhotos/matcher_test.go
@@ -192,6 +192,51 @@ func Test_matchers(t *testing.T) {
 			jsonName: "Screenshot_2024-08-31-00-53-48-647_com.snapcha.json",
 			want:     "matchNormal",
 		},
+		// When (1) is part of the original filename, Google creates two groups with confusingly similar names:
+		//   groupA: no duplicate index — Negative0-36-35(1).jpg + sidecar ...supplemental-metadata.json
+		//   groupB: duplicate index (1) — Negative0-36-35(1)(1).jpg + sidecar ...supplemental-metadata(1).json
+		// These tests verify each sidecar only matches its own group's files.
+
+		{ // groupB original with its own sidecar
+			fileName: "Negative0-36-35(1)(1).jpg",
+			jsonName: "Negative0-36-35(1).jpg.supplemental-metadata(1).json",
+			want:     "matchNormal",
+		},
+		{ // groupB edited with its own sidecar
+			fileName: "Negative0-36-35(1)-editat(1).jpg",
+			jsonName: "Negative0-36-35(1).jpg.supplemental-metadata(1).json",
+			want:     "matchEditedName",
+		},
+		{ // groupA sidecar must NOT match groupB edited
+			fileName: "Negative0-36-35(1)-editat(1).jpg",
+			jsonName: "Negative0-36-35(1).jpg.supplemental-metadata.json",
+			want:     "",
+		},
+		{ // groupB sidecar must NOT match groupA edited
+			fileName: "Negative0-36-35(1)-editat.jpg",
+			jsonName: "Negative0-36-35(1).jpg.supplemental-metadata(1).json",
+			want:     "",
+		},
+		{ // groupA original with its own sidecar
+			fileName: "Negative0-36-35(1).jpg",
+			jsonName: "Negative0-36-35(1).jpg.supplemental-metadata.json",
+			want:     "matchNormal",
+		},
+		{ // groupA edited with its own sidecar
+			fileName: "Negative0-36-35(1)-editat.jpg",
+			jsonName: "Negative0-36-35(1).jpg.supplemental-metadata.json",
+			want:     "matchEditedName",
+		},
+		{ // groupA sidecar must NOT match groupB original
+			fileName: "Negative0-36-35(1)(1).jpg",
+			jsonName: "Negative0-36-35(1).jpg.supplemental-metadata.json",
+			want:     "",
+		},
+		{ // groupB sidecar must NOT match groupA original
+			fileName: "Negative0-36-35(1).jpg",
+			jsonName: "Negative0-36-35(1).jpg.supplemental-metadata(1).json",
+			want:     "",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.fileName, func(t *testing.T) {

--- a/adapters/googlePhotos/matchers.go
+++ b/adapters/googlePhotos/matchers.go
@@ -68,7 +68,10 @@ func matchNormal(jsonName string, fileName string, _ filetypes.SupportedMedia) b
 // but not DSC_0104.JPG.json with DSC_0104(1).JPG
 
 func matchEditedName(jsonName string, fileName string, sm filetypes.SupportedMedia) bool {
-	if _, index := getFileIndex(fileName); index != "" {
+	// Extract indexes from both names - they must match
+	fileName, fileIndex := getFileIndex(fileName)
+	jsonName, jsonIndex := getFileIndex(jsonName)
+	if fileIndex != jsonIndex {
 		return false
 	}
 	base := strings.TrimSuffix(jsonName, path.Ext(jsonName))
@@ -84,7 +87,13 @@ func matchEditedName(jsonName string, fileName string, sm filetypes.SupportedMed
 		base = strings.TrimSuffix(base, ext)
 		fileName = strings.TrimSuffix(fileName, path.Ext(fileName))
 	}
-	return strings.HasPrefix(fileName, base)
+	if !strings.HasPrefix(fileName, base) {
+		return false
+	}
+	// The edited suffix must start with "-" to avoid false positives when
+	// getFileIndex strips a (N) that is part of the original filename.
+	suffix := fileName[len(base):]
+	return len(suffix) > 0 && suffix[0] == '-'
 }
 
 // matchForgottenDuplicates

--- a/docs/misc/google-takeout.md
+++ b/docs/misc/google-takeout.md
@@ -65,6 +65,16 @@ Group B (duplicate):
 
 Both sidecars share the same `"title": "Negative0-36-35(1).jpg"` inside the JSON. The only difference is the trailing `(1)` on the sidecar filename and the stacked `(1)(1)` on the image. The edited file inserts the localized edit suffix before the duplicate index.
 
+### Known ambiguity: (N) as part of a base name vs. duplicate index
+
+When a folder contains both `Negative0-36-35.jpg` and `Negative0-36-35(1).jpg`, their sidecars are:
+  - `Negative0-36-35.jpg.supplemental-metadata(1).json`  ← for the duplicate of `Negative0-36-35.jpg`
+  - `Negative0-36-35(1).jpg.supplemental-metadata.json`  ← for the original `Negative0-36-35(1).jpg`
+
+The file `Negative0-36-35(1).jpg` matches **both** sidecars by filename alone — the matcher cannot tell whether the `(1)` belongs to the base name or is a duplicate index. The current implementation resolves this by first-match on sorted JSON filenames, which may assign the wrong sidecar.
+
+The correct fix would be to read the `"title"` field inside each JSON and prefer the sidecar whose title matches the image filename exactly. This is not implemented yet.
+
 ## Images are duplicated with no apparent logic
 Example from the  [#380](https://github.com/simulot/immich-go/issues/380)
 ```sh

--- a/docs/misc/google-takeout.md
+++ b/docs/misc/google-takeout.md
@@ -48,6 +48,23 @@ but one JSON
 
 Note that "edited" name is localized.
 
+### Duplicate index combined with edited suffix and supplemental-metadata
+When a file already has a duplicate index and is also edited, Google stacks both the duplicate index and the edited suffix. The supplemental-metadata sidecar keeps the duplicate index at the end of the JSON name, separate from the original filename's index.
+
+This creates an ambiguity: `(1)` in a filename can be part of the original name OR a duplicate index. When both groups coexist in the same folder, the sidecars look almost identical:
+
+Group A (no duplicate):
+  - Original: `Negative0-36-35(1).jpg`
+  - Sidecar: `Negative0-36-35(1).jpg.supplemental-metadata.json`
+  - Edited: `Negative0-36-35(1)-editat.jpg`
+
+Group B (duplicate):
+  - Original: `Negative0-36-35(1)(1).jpg`
+  - Sidecar: `Negative0-36-35(1).jpg.supplemental-metadata(1).json`
+  - Edited: `Negative0-36-35(1)-editat(1).jpg`
+
+Both sidecars share the same `"title": "Negative0-36-35(1).jpg"` inside the JSON. The only difference is the trailing `(1)` on the sidecar filename and the stacked `(1)(1)` on the image. The edited file inserts the localized edit suffix before the duplicate index.
+
 ## Images are duplicated with no apparent logic
 Example from the  [#380](https://github.com/simulot/immich-go/issues/380)
 ```sh

--- a/docs/misc/google-takeout.md
+++ b/docs/misc/google-takeout.md
@@ -112,6 +112,7 @@ Here is the list of translations for the "-edited" suffix in the requested langu
 | Language   | Translation      | Confirmed |
 | ---------- | ---------------- | --------- |
 | Spanish    | -editado         | [ ]       |
+| Catalan    | -editat          | [X]       |
 | French     | -modifié         | [X]       |
 | German     | -bearbeitet      | [X]       |
 | Italian    | -modificato      | [X]       |


### PR DESCRIPTION
Hi! Running immich-go on my google takeout I noticed it does not currently support matching edited images that contain an index so I am creating this PR to add support for this & update the docs regarding this (cause it's quite confusing naming from google takeout itself...)

For example the following files should match the sidecar correctly:
``` bash
original: Negative0-36-35(1).jpg # filename contains `(1)`
edited: Negative0-36-35(1)-editat.jpg
sidecar: Negative0-36-35(1).jpg.supplemental-metadata.json
```

In addition to this case (which currently doesn't work and what this PR provides support for):
``` bash
original: Negative0-36-35(1)(1).jpg # filename contains `(1)` AND has a `(1)` index because it's a duplicate name of the above
edited: Negative0-36-35(1)-editat(1).jpg
sidecar: Negative0-36-35(1).jpg.supplemental-metadata(1).json
```

I also found a potential bug of mismatching sidecars and documented this edge-case in the docs. There is a potential fix that would need investigating, but it requires actually reading the sidecar so I did not fix it here. It can either be left as a documented edge-case, or if you wish I can create a separate issue for it to be addressed.

> Note: I made this PR targeting `develop` as per the contribution guidelines, but I notice develop is out-of-date compared to main. Is this still the right workflow, and should develop be updated with changes from main ? I can also rebase and target main if needed