### PR TITLE
fix: don't resume Immich jobs on finish if they were never paused

### DIFF
--- a/app/upload/run.go
+++ b/app/upload/run.go
@@ -101,10 +101,15 @@ func (uc *UpCmd) finishing(ctx context.Context) error {
 	uc.albumsCache.Close()
 	uc.tagsCache.Close()
 
-	// Resume immich background jobs if requested
-	err := uc.resumeJobs(ctx)
-	if err != nil {
-		return err
+	// Resume immich background jobs, but only if this run actually paused
+	// them (pauseJobs is gated on PauseImmichBackgroundJobs; resumeJobs was
+	// being called unconditionally, which both requires job.create on keys
+	// that never needed it and, on failure, skips GenerateReport below).
+	if uc.client.PauseImmichBackgroundJobs {
+		err := uc.resumeJobs(ctx)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Generate FileProcessor report


### PR DESCRIPTION
\`finishing()\` calls \`resumeJobs()\` unconditionally at the end of every upload run, regardless of whether \`pauseJobs()\` actually ran. \`pauseJobs()\` is gated behind \`--pause-immich-jobs\` (default \`true\`), but the matching \`resumeJobs()\` call wasn't gated the same way.

This causes two problems when running with \`--pause-immich-jobs=false\`:
- \`resumeJobs()\` requires the \`job.create\` API key permission, which a run that never touched job state shouldn't need.
- If that call fails (e.g. the key genuinely lacks \`job.create\`), \`finishing()\` returns early and \`GenerateReport()\` never runs — so the run silently ends with no Asset Tracking Report at all, even though the upload itself completed successfully.

This fix gates \`resumeJobs()\` behind the same \`uc.client.PauseImmichBackgroundJobs\` flag that already gates \`pauseJobs()\`, so a run that never paused jobs never tries to resume them.

## Testing

\`go build\`, \`go vet ./...\`, and \`go test ./...\` all pass (note: \`app/upload\` has no existing test files, so this doesn't add regression coverage for the fix itself — just confirms nothing else broke).

Reproduced against a live v0.32.0 Immich server by running \`upload from-google-photos --pause-immich-jobs=false\` with an API key scoped only for uploads (no \`job.create\`): before the fix, the run completed the upload but exited with a \`job.create\` permission error and no report; after, it completes cleanly with the report generated.