### PR TITLE
fix(immich): drop idle connections before the server closes them

### DIFF
--- a/immich/client.go
+++ b/immich/client.go
@@ -109,10 +109,7 @@ func NewImmichClient(endPoint string, key string, options ...clientOption) (*Imm
 	ic := ImmichClient{
 		endPoint: endPoint + "/api",
 		transport: &http.Transport{
-			MaxIdleConns: 100,
-			// Immich (Node.js) closes a keep-alive connection that has been idle for 5 seconds. Drop
-			// idle connections well before that, so that a request is never sent on a connection the
-			// server is closing at the same time. Such a request fails with "EOF" and is not retried.
+			MaxIdleConns:        100,
 			IdleConnTimeout:     2 * time.Second,
 			TLSClientConfig:     &tls.Config{InsecureSkipVerify: true},
 			MaxIdleConnsPerHost: 100,

--- a/immich/client.go
+++ b/immich/client.go
@@ -112,9 +112,7 @@ func NewImmichClient(endPoint string, key string, options ...clientOption) (*Imm
 			MaxIdleConns: 100,
 			// Immich (Node.js) closes a keep-alive connection that has been idle for 5 seconds. Drop
 			// idle connections well before that, so that a request is never sent on a connection the
-			// server is closing at the same time. Such a request fails with "EOF", and Go's transport
-			// retries that only for idempotent requests (GET etc.), not for the POST/PUT requests made
-			// here, least of all uploads, whose multipart body is streamed and can't be replayed.
+			// server is closing at the same time. Such a request fails with "EOF" and is not retried.
 			IdleConnTimeout:     2 * time.Second,
 			TLSClientConfig:     &tls.Config{InsecureSkipVerify: true},
 			MaxIdleConnsPerHost: 100,

--- a/immich/client.go
+++ b/immich/client.go
@@ -110,10 +110,11 @@ func NewImmichClient(endPoint string, key string, options ...clientOption) (*Imm
 		endPoint: endPoint + "/api",
 		transport: &http.Transport{
 			MaxIdleConns: 100,
-			// Immich (Node.js) closes an idle keep-alive connection after 5 seconds. Drop idle
-			// connections well before that, so that a request is never sent on a connection the
-			// server is closing at the same time, which fails with "EOF" and is not retried for
-			// uploads (their body can't be replayed).
+			// Immich (Node.js) closes a keep-alive connection that has been idle for 5 seconds. Drop
+			// idle connections well before that, so that a request is never sent on a connection the
+			// server is closing at the same time. Such a request fails with "EOF", and Go's transport
+			// retries that only for idempotent requests (GET etc.), not for the POST/PUT requests made
+			// here, least of all uploads, whose multipart body is streamed and can't be replayed.
 			IdleConnTimeout:     2 * time.Second,
 			TLSClientConfig:     &tls.Config{InsecureSkipVerify: true},
 			MaxIdleConnsPerHost: 100,

--- a/immich/client.go
+++ b/immich/client.go
@@ -109,8 +109,12 @@ func NewImmichClient(endPoint string, key string, options ...clientOption) (*Imm
 	ic := ImmichClient{
 		endPoint: endPoint + "/api",
 		transport: &http.Transport{
-			MaxIdleConns:        100,
-			IdleConnTimeout:     90 * time.Second,
+			MaxIdleConns: 100,
+			// Immich (Node.js) closes an idle keep-alive connection after 5 seconds. Drop idle
+			// connections well before that, so that a request is never sent on a connection the
+			// server is closing at the same time, which fails with "EOF" and is not retried for
+			// uploads (their body can't be replayed).
+			IdleConnTimeout:     2 * time.Second,
 			TLSClientConfig:     &tls.Config{InsecureSkipVerify: true},
 			MaxIdleConnsPerHost: 100,
 			MaxConnsPerHost:     100,


### PR DESCRIPTION
What
----

Fix the occasional upload failure `Post "http://…/api/assets": EOF`, which under the default `--on-errors=stop` aborts the whole run. Refs #956.

Cause
-----

Immich's Node.js server drops keep-alive connections after 5 idle seconds; immich-go reused idle connections for up to 90. A request sent on a connection the server is closing at that moment fails with `EOF`, and Go's transport does not retry a streamed multipart upload.

Fix
---

`IdleConnTimeout` 90 s → 2 s. In a test harness paced to hit the closing window, that takes the failure rate from about a third of requests to zero. No unit test: it would hinge on timing.

Notes
-----

Based on `main` rather than `develop`, because it was tested against Immich v3, whose support is on `main` only.
