### PR TITLE
fix(upload): apply --tag and --session-tag to replacement uploads too

### DIFF
--- a/app/upload/run.go
+++ b/app/upload/run.go
@@ -423,7 +423,7 @@ func (uc *UpCmd) handleAsset(ctx context.Context, a *assets.Asset) error {
 }
 
 // addCommandLineTags adds the --tag values and, if --session-tag is set, the session tag to the
-// asset. Tags are applied on the server later, by processUploadedAsset.
+// asset, so that manageAssetTags applies them on the server.
 func (uc *UpCmd) addCommandLineTags(a *assets.Asset) {
 	if uc.SessionTag {
 		a.AddTag(uc.session)
@@ -438,8 +438,6 @@ func (uc *UpCmd) addCommandLineTags(a *assets.Asset) {
 // return the duplicate condition and error.
 func (uc *UpCmd) uploadAsset(ctx context.Context, a *assets.Asset) (string, error) {
 	defer uc.app.Log().Debug("upload asset", "file", a)
-
-	uc.addCommandLineTags(a)
 
 	ar, err := uc.client.Immich.AssetUpload(ctx, a)
 	if err != nil {
@@ -496,8 +494,6 @@ func (uc *UpCmd) uploadAsset(ctx context.Context, a *assets.Asset) (string, erro
 // replaceAsset replaces an asset on the server. It uploads the new asset, copies the metadata from the old one and deletes the old one.
 // https://github.com/immich-app/immich/pull/23172#issue-3542430029
 func (uc *UpCmd) replaceAsset(ctx context.Context, newAsset, oldAsset *assets.Asset) (string, error) {
-	uc.addCommandLineTags(newAsset)
-
 	// 1. Upload the new asset
 	ar, err := uc.client.Immich.AssetUpload(ctx, newAsset)
 	if err != nil {
@@ -578,6 +574,7 @@ func (uc *UpCmd) processUploadedAsset(ctx context.Context, a *assets.Asset, serv
 		// TODO: current version of Immich doesn't allow to add same tag to an asset already tagged.
 		//       there is no mean to go the list of tagged assets for a given tag.
 		uc.manageAssetAlbums(ctx, a.File, a.ID, a.Albums)
+		uc.addCommandLineTags(a)
 		uc.manageAssetTags(ctx, a)
 	}
 }

--- a/app/upload/run.go
+++ b/app/upload/run.go
@@ -422,7 +422,8 @@ func (uc *UpCmd) handleAsset(ctx context.Context, a *assets.Asset) error {
 	return nil
 }
 
-// addCommandLineTags adds the --tag and --session-tag tags to the asset.
+// addCommandLineTags adds the --tag values and, if --session-tag is set, the session tag to the
+// asset. Tags are applied on the server later, by processUploadedAsset.
 func (uc *UpCmd) addCommandLineTags(a *assets.Asset) {
 	if uc.SessionTag {
 		a.AddTag(uc.session)

--- a/app/upload/run.go
+++ b/app/upload/run.go
@@ -422,18 +422,23 @@ func (uc *UpCmd) handleAsset(ctx context.Context, a *assets.Asset) error {
 	return nil
 }
 
-// uploadAsset uploads the asset to the server.
-// set the server's asset ID to the asset.
-// return the duplicate condition and error.
-func (uc *UpCmd) uploadAsset(ctx context.Context, a *assets.Asset) (string, error) {
-	defer uc.app.Log().Debug("upload asset", "file", a)
-
+// addCommandLineTags adds the --tag and --session-tag tags to the asset.
+func (uc *UpCmd) addCommandLineTags(a *assets.Asset) {
 	if uc.SessionTag {
 		a.AddTag(uc.session)
 	}
 	for _, tag := range uc.Tags {
 		a.AddTag(tag)
 	}
+}
+
+// uploadAsset uploads the asset to the server.
+// set the server's asset ID to the asset.
+// return the duplicate condition and error.
+func (uc *UpCmd) uploadAsset(ctx context.Context, a *assets.Asset) (string, error) {
+	defer uc.app.Log().Debug("upload asset", "file", a)
+
+	uc.addCommandLineTags(a)
 
 	ar, err := uc.client.Immich.AssetUpload(ctx, a)
 	if err != nil {
@@ -490,6 +495,8 @@ func (uc *UpCmd) uploadAsset(ctx context.Context, a *assets.Asset) (string, erro
 // replaceAsset replaces an asset on the server. It uploads the new asset, copies the metadata from the old one and deletes the old one.
 // https://github.com/immich-app/immich/pull/23172#issue-3542430029
 func (uc *UpCmd) replaceAsset(ctx context.Context, newAsset, oldAsset *assets.Asset) (string, error) {
+	uc.addCommandLineTags(newAsset)
+
 	// 1. Upload the new asset
 	ar, err := uc.client.Immich.AssetUpload(ctx, newAsset)
 	if err != nil {

--- a/internal/e2e/client/replace_test.go
+++ b/internal/e2e/client/replace_test.go
@@ -125,6 +125,7 @@ func Test_Replace(t *testing.T) {
 		"--no-ui",
 		"--api-trace",
 		"--log-level=debug",
+		"--tag=replaced", // must also reach the replacement uploads
 		"DATA/replace/high_quality",
 	})
 	err = c.ExecuteContext(ctx)
@@ -140,7 +141,7 @@ func Test_Replace(t *testing.T) {
 	e2eutils.CheckResults(t, map[fileevent.Code]int64{
 		fileevent.ProcessedUploadSuccess:  0,
 		fileevent.ProcessedAlbumAdded:     0,
-		fileevent.ProcessedTagged:         0,
+		fileevent.ProcessedTagged:         5,
 		fileevent.ProcessedUploadUpgraded: 5,
 	}, false, a.FileProcessor())
 


### PR DESCRIPTION
What
---

Fix `--tag` and `--session-tag` not being applied to replacement uploads (a bigger copy replacing a smaller server copy, reported as "server asset upgraded", or an `--overwrite` replacement); only assets uploaded as new got those tags.

Cause
---

`uploadAsset` adds the command-line tags to the asset before uploading; the upload itself does not send tags, `processUploadedAsset` applies them afterwards. `replaceAsset` uploads without adding them, so `processUploadedAsset` has nothing to apply.

Fix
---

Add the command-line tags in `processUploadedAsset` (the one place tags are applied) instead of in each upload path, so no upload path can forget them.

`Test_Replace` now passes `--tag=replaced` for the replacement run and expects the upgraded assets to be tagged; it fails without the fix.

Notes
---

Based on `main` rather than `develop`, because it was tested against Immich v3, whose support is on `main` only.
