### PR TITLE
fix(upload): resume only the Immich jobs this run paused

### DIFF
--- a/app/upload/jobs_test.go
+++ b/app/upload/jobs_test.go
@@ -2,6 +2,7 @@ package upload
 
 import (
 	"context"
+	"errors"
 	"io"
 	"slices"
 	"testing"
@@ -14,8 +15,9 @@ import (
 // jobsClient stubs the admin client's job endpoints and records the commands sent.
 type jobsClient struct {
 	immich.ImmichInterface
-	paused   []string // queues reported as paused by GetJobs
-	commands []string // "command:queue", in order
+	paused      []string // queues reported as paused by GetJobs
+	failPauseOf string   // queue whose pause command fails, if set
+	commands    []string // "command:queue", in order
 }
 
 func (c *jobsClient) GetJobs(context.Context) (map[string]immich.Job, error) {
@@ -30,6 +32,9 @@ func (c *jobsClient) GetJobs(context.Context) (map[string]immich.Job, error) {
 
 func (c *jobsClient) SendJobCommand(_ context.Context, jobID string, command immich.JobCommand, _ bool) (immich.SendJobCommandResponse, error) {
 	c.commands = append(c.commands, string(command)+":"+jobID)
+	if command == immich.Pause && jobID == c.failPauseOf {
+		return immich.SendJobCommandResponse{}, errors.New("pause failed")
+	}
 	return immich.SendJobCommandResponse{}, nil
 }
 
@@ -70,5 +75,22 @@ func TestResumeJobsWithoutPauseSendsNothing(t *testing.T) {
 	}
 	if len(client.commands) != 0 {
 		t.Errorf("commands sent without a prior pause: %v", client.commands)
+	}
+}
+
+func TestPauseJobsFailureResumesQueuesPausedSoFar(t *testing.T) {
+	client := &jobsClient{failPauseOf: "videoConversion"}
+	uc := newJobsUpCmd(t, client)
+
+	if err := uc.pauseJobs(context.Background()); err == nil {
+		t.Fatal("pauseJobs: expected an error")
+	}
+
+	want := []string{
+		"pause:thumbnailGeneration", "pause:metadataExtraction", "pause:videoConversion",
+		"resume:thumbnailGeneration", "resume:metadataExtraction",
+	}
+	if !slices.Equal(client.commands, want) {
+		t.Errorf("commands sent:\n got %v\nwant %v", client.commands, want)
 	}
 }

--- a/app/upload/jobs_test.go
+++ b/app/upload/jobs_test.go
@@ -1,0 +1,74 @@
+package upload
+
+import (
+	"context"
+	"io"
+	"slices"
+	"testing"
+
+	"github.com/simulot/immich-go/app"
+	"github.com/simulot/immich-go/immich"
+	"github.com/spf13/cobra"
+)
+
+// jobsClient stubs the admin client's job endpoints and records the commands sent.
+type jobsClient struct {
+	immich.ImmichInterface
+	paused   []string // queues reported as paused by GetJobs
+	commands []string // "command:queue", in order
+}
+
+func (c *jobsClient) GetJobs(context.Context) (map[string]immich.Job, error) {
+	jobs := map[string]immich.Job{}
+	for _, name := range c.paused {
+		var j immich.Job
+		j.QueueStatus.IsPaused = true
+		jobs[name] = j
+	}
+	return jobs, nil
+}
+
+func (c *jobsClient) SendJobCommand(_ context.Context, jobID string, command immich.JobCommand, _ bool) (immich.SendJobCommandResponse, error) {
+	c.commands = append(c.commands, string(command)+":"+jobID)
+	return immich.SendJobCommandResponse{}, nil
+}
+
+func newJobsUpCmd(t *testing.T, client *jobsClient) *UpCmd {
+	t.Helper()
+	a := app.New(context.Background(), &cobra.Command{})
+	a.Log().SetLogWriter(io.Discard)
+	return &UpCmd{app: a, client: app.Client{AdminImmich: client}}
+}
+
+func TestPauseResumeJobsSkipsAlreadyPausedQueues(t *testing.T) {
+	client := &jobsClient{paused: []string{"thumbnailGeneration"}}
+	uc := newJobsUpCmd(t, client)
+	ctx := context.Background()
+
+	if err := uc.pauseJobs(ctx); err != nil {
+		t.Fatalf("pauseJobs: %v", err)
+	}
+	if err := uc.resumeJobs(ctx); err != nil {
+		t.Fatalf("resumeJobs: %v", err)
+	}
+
+	want := []string{
+		"pause:metadataExtraction", "pause:videoConversion", "pause:faceDetection", "pause:smartSearch",
+		"resume:metadataExtraction", "resume:videoConversion", "resume:faceDetection", "resume:smartSearch",
+	}
+	if !slices.Equal(client.commands, want) {
+		t.Errorf("commands sent:\n got %v\nwant %v", client.commands, want)
+	}
+}
+
+func TestResumeJobsWithoutPauseSendsNothing(t *testing.T) {
+	client := &jobsClient{}
+	uc := newJobsUpCmd(t, client)
+
+	if err := uc.resumeJobs(context.Background()); err != nil {
+		t.Fatalf("resumeJobs: %v", err)
+	}
+	if len(client.commands) != 0 {
+		t.Errorf("commands sent without a prior pause: %v", client.commands)
+	}
+}

--- a/app/upload/run.go
+++ b/app/upload/run.go
@@ -63,25 +63,40 @@ func (uc *UpCmd) saveTags(ctx context.Context, tag assets.Tag, ids []string) (as
 	return tag, err
 }
 
+// backgroundJobs lists the Immich job queues paused during the upload.
+var backgroundJobs = []string{"thumbnailGeneration", "metadataExtraction", "videoConversion", "faceDetection", "smartSearch"}
+
+// pauseJobs pauses the Immich background jobs that aren't already paused, and records them in
+// uc.pausedJobs so that resumeJobs resumes only those. Queues paused by the user before the run
+// are left alone.
 func (uc *UpCmd) pauseJobs(ctx context.Context) error {
-	jobs := []string{"thumbnailGeneration", "metadataExtraction", "videoConversion", "faceDetection", "smartSearch"}
-	for _, name := range jobs {
+	status, err := uc.client.AdminImmich.GetJobs(ctx)
+	if err != nil {
+		uc.app.Log().Error("Immich Job status", "err", err.Error())
+		return err
+	}
+	for _, name := range backgroundJobs {
+		if status[name].QueueStatus.IsPaused {
+			uc.app.Log().Info("Immich Job already paused, leaving it as is", "job", name)
+			continue
+		}
 		_, err := uc.client.AdminImmich.SendJobCommand(ctx, name, "pause", true)
 		if err != nil {
 			uc.app.Log().Error("Immich Job command sent", "pause", name, "err", err.Error())
 			return err
 		}
+		uc.pausedJobs = append(uc.pausedJobs, name)
 		uc.app.Log().Info("Immich Job command sent", "pause", name)
 	}
 	return nil
 }
 
+// resumeJobs resumes the jobs paused by pauseJobs during this run. It does nothing when the
+// jobs weren't paused (--pause-immich-jobs=false), or for queues that were already paused before.
 func (uc *UpCmd) resumeJobs(_ context.Context) error {
-	jobs := []string{"thumbnailGeneration", "metadataExtraction", "videoConversion", "faceDetection", "smartSearch"}
-
 	// Start with a context not yet cancelled
 	ctx := context.Background() //nolint
-	for _, name := range jobs {
+	for _, name := range uc.pausedJobs {
 		_, err := uc.client.AdminImmich.SendJobCommand(ctx, name, "resume", true) //nolint:contextcheck
 		if err != nil {
 			uc.app.Log().Error("Immich Job command sent", "resume", name, "err", err.Error())
@@ -101,7 +116,7 @@ func (uc *UpCmd) finishing(ctx context.Context) error {
 	uc.albumsCache.Close()
 	uc.tagsCache.Close()
 
-	// Resume immich background jobs if requested
+	// Resume the immich background jobs paused by this run, if any
 	err := uc.resumeJobs(ctx)
 	if err != nil {
 		return err

--- a/app/upload/run.go
+++ b/app/upload/run.go
@@ -68,7 +68,8 @@ var backgroundJobs = []string{"thumbnailGeneration", "metadataExtraction", "vide
 
 // pauseJobs pauses the Immich background jobs that aren't already paused, and records them in
 // uc.pausedJobs so that resumeJobs resumes only those. Queues paused by the user before the run
-// are left alone.
+// are left alone. If pausing a queue fails, the queues paused so far are resumed (best effort)
+// before returning the error, since the upload is then aborted and finishing() never runs.
 func (uc *UpCmd) pauseJobs(ctx context.Context) error {
 	status, err := uc.client.AdminImmich.GetJobs(ctx)
 	if err != nil {
@@ -83,6 +84,7 @@ func (uc *UpCmd) pauseJobs(ctx context.Context) error {
 		_, err := uc.client.AdminImmich.SendJobCommand(ctx, name, "pause", true)
 		if err != nil {
 			uc.app.Log().Error("Immich Job command sent", "pause", name, "err", err.Error())
+			_ = uc.resumeJobs(ctx)
 			return err
 		}
 		uc.pausedJobs = append(uc.pausedJobs, name)

--- a/app/upload/upload.go
+++ b/app/upload/upload.go
@@ -76,6 +76,7 @@ type UpCmd struct {
 	albumsCache       *cache.CollectionCache[assets.Album] // List of albums present on the server
 	tagsCache         *cache.CollectionCache[assets.Tag]   // List of tags present on the server
 	finished          bool                                 // the finish task has been run
+	pausedJobs        []string                             // Immich jobs paused by this run, to be resumed at the end
 	infoCollector     *filenames.InfoCollector             // Collects information about the files being processed
 }
 


### PR DESCRIPTION
What
---

Fix immich-go resuming Immich background job queues that it never paused: with `--pause-immich-jobs=false` it still sent five `resume` commands after the upload, and with pausing enabled it also resumed queues the user had paused by hand before the run. A run now resumes only the queues it paused itself.

Fixes #1290

Cause
---

`finishing()` unconditionally calls `resumeJobs`, which sends `resume` to a hardcoded list of five queues. `pauseJobs` is guarded by `--pause-immich-jobs`; `resumeJobs` is not, and neither looks at the queues' current state.

Fix
---

`pauseJobs` first fetches queue status (`GET /api/jobs`), skips queues that are already paused, and records the queues it does pause in a new `UpCmd.pausedJobs` field; `resumeJobs` iterates that field. If pausing fails partway, `pauseJobs` resumes the queues it had paused before returning the error (the upload then aborts and `finishing()` never runs; previously those queues stayed paused).

Verified against a local Immich v3.1.0: with `thumbnailGeneration` paused by hand, a run with pausing disabled sends no job commands at all, and a run with pausing enabled pauses and later resumes only the other four queues.

Notes
---

Supersedes #1420, which gates the resume on the `--pause-immich-jobs` flag: same effect for that case, plus hand-paused queues left alone, rollback of a partial pause, and tests.

Based on `main` rather than `develop`, because it was tested against Immich v3, whose support is on `main` only.
