### PR TITLE
fix(upload): keep every asset's error when uploading a group

### DIFF
--- a/app/upload/run.go
+++ b/app/upload/run.go
@@ -313,7 +313,7 @@ func (uc *UpCmd) handleGroup(ctx context.Context, g *assets.Group) error {
 	// Upload assets from the group
 	for _, a := range g.Assets {
 		err := uc.handleAsset(ctx, a)
-		errGroup = errors.Join(err)
+		errGroup = errors.Join(errGroup, err)
 	}
 
 	// Manage groups

--- a/app/upload/run_test.go
+++ b/app/upload/run_test.go
@@ -1,0 +1,41 @@
+package upload
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/simulot/immich-go/app"
+	"github.com/simulot/immich-go/internal/assets"
+	"github.com/simulot/immich-go/internal/assettracker"
+	"github.com/simulot/immich-go/internal/fileevent"
+	"github.com/simulot/immich-go/internal/fileprocessor"
+	"github.com/spf13/cobra"
+)
+
+// handleGroup must return the error of every failed asset in the group, not just the last
+// asset's: uploadLoop feeds its result to ProcessError, which drives --on-errors accounting.
+func TestHandleGroupKeepsEarlierAssetErrors(t *testing.T) {
+	ctx := context.Background()
+	a := app.New(ctx, &cobra.Command{})
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	a.SetFileProcessor(fileprocessor.New(assettracker.New(), fileevent.NewRecorder(logger)))
+
+	uc := &UpCmd{app: a, assetIndex: newAssetIndex()}
+
+	// Fails: no checksum and no file to compute it from, so handleAsset errors in ShouldUpload.
+	failing := &assets.Asset{}
+	// Succeeds: its checksum is indexed as already uploaded, so handleAsset takes the
+	// AlreadyProcessed path and returns nil without needing an Immich client.
+	succeeding := &assets.Asset{Checksum: "abcd"}
+	uc.assetIndex.byChecksum.Store(succeeding.Checksum, succeeding)
+	uc.assetIndex.uploadsChecksum.Add(succeeding.Checksum)
+
+	// GroupByNone skips the stacking step, which would need an Immich client.
+	g := &assets.Group{Assets: []*assets.Asset{failing, succeeding}, Grouping: assets.GroupByNone}
+
+	if err := uc.handleGroup(ctx, g); err == nil {
+		t.Error("handleGroup returned nil, dropping the first asset's error")
+	}
+}


### PR DESCRIPTION
What
----

Fix upload errors inside a group (burst, RAW+JPEG, edited pair) not counting towards `--on-errors` when the group's last asset uploads fine: with the default `--on-errors=stop` the run carried on instead of stopping, and with `--on-errors=N` those errors did not count towards N. They were still logged and listed in the final report.

Cause
-----

`handleGroup` joined each asset's error with nothing (`errGroup = errors.Join(err)`) instead of with the errors collected so far, so it returned only the last asset's error, and `nil` when the last asset succeeded.

Fix
---

`errors.Join(errGroup, err)`.

Notes
-----

Based on `main` rather than `develop`; the changed line is the same on both branches. It sits next to a line that #1423 changes, so whichever of the two merges second needs a trivial rebase.
