### PR TITLE
fix(fromimmich): populate NameInfo so archive writes original filenames

### DIFF
--- a/adapters/fromimmich/command.go
+++ b/adapters/fromimmich/command.go
@@ -386,6 +386,7 @@ func (fic *FromImmichCmd) getAssets(ctx context.Context, grpChan chan *assets.Gr
 		}
 
 		asset := a.AsAsset()
+		asset.SetNameInfo(fic.ic.GetInfo(a.OriginalFileName))
 		asset.FromApplication = &assets.Metadata{
 			FileName:    a.OriginalFileName,
 			Latitude:    a.ExifInfo.Latitude,


### PR DESCRIPTION
## Summary

`archive from-immich` writes every media file as `~1`, `~2`, `~3`, … with no extension. This makes the resulting archive unbrowsable (no extension → not associated with any viewer) and non-re-importable (`upload from-folder` reports every file as `discovered unknown file … reason=useless file`).

The image data itself is intact — renaming a `~N` file to its real name (present in the sibling `.JSON`) opens correctly.

## Root cause

`writeFolder.WriteAsset` (`adapters/folder/writeFolder.go`) uses `a.Base` (from the embedded `NameInfo`) to name the output file. When `Base` is empty, its collision-avoidance loop treats the destination directory itself as a name collision and falls through to the `~N` placeholder pattern.

Every other source adapter populates `NameInfo` via the `InfoCollector`:

- `adapters/folder/run.go:551` — `a.SetNameInfo(ifc.infoCollector.GetInfo(n))`
- `adapters/googlePhotos/googlephotos.go:509` — `a.SetNameInfo(toc.infoCollector.GetInfo(a.OriginalFileName))`
- `app/stack/stack.go:97` — `asset.SetNameInfo(o.InfoCollector.GetInfo(asset.OriginalFileName))`

`fromimmich/command.go` was setting `Asset.OriginalFileName` but never `NameInfo`. `FromImmichCmd` already initialises `fic.ic` (an `InfoCollector`), so the fix reuses it in the same pattern.

## Fix

One line in `adapters/fromimmich/command.go`, immediately after `asset := a.AsAsset()`:

```go
asset.SetNameInfo(fic.ic.GetInfo(a.OriginalFileName))
```

## Verification

Rebuilt from this branch and re-ran `archive from-immich` against Immich v3.1.0. Output now matches the format described in `docs/commands/archive.md`:

```
originals/2021/2021-09/IMG_5809.HEIC
originals/2021/2021-09/IMG_5809.HEIC.JSON
originals/2021/2021-08/IMG_5772.JPG
originals/2021/2021-08/IMG_5772.JPG.JSON
```

Fixes #1412