### PR TITLE
fix(xmp): read tag lists with several items and single-Description sidecars

### DIFF
--- a/internal/exif/sidecars/xmpsidecar/DATA/multi-language.jpg.xmp
+++ b/internal/exif/sidecars/xmpsidecar/DATA/multi-language.jpg.xmp
@@ -1,0 +1,14 @@
+<?xpacket begin='﻿' id='W5M0MpCehiHzreSzNTczkc9d'?>
+<x:xmpmeta xmlns:x='adobe:ns:meta/' x:xmptk='handwritten'>
+<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'>
+ <rdf:Description rdf:about='' xmlns:tiff='http://ns.adobe.com/tiff/1.0/'>
+  <tiff:ImageDescription>
+   <rdf:Alt>
+    <rdf:li xml:lang='x-default'>Sunset over the bay</rdf:li>
+    <rdf:li xml:lang='fr'>Coucher de soleil sur la baie</rdf:li>
+   </rdf:Alt>
+  </tiff:ImageDescription>
+ </rdf:Description>
+</rdf:RDF>
+</x:xmpmeta>
+<?xpacket end='w'?>

--- a/internal/exif/sidecars/xmpsidecar/DATA/multi-tags.jpg.xmp
+++ b/internal/exif/sidecars/xmpsidecar/DATA/multi-tags.jpg.xmp
@@ -1,0 +1,16 @@
+<?xpacket begin='﻿' id='W5M0MpCehiHzreSzNTczkc9d'?>
+<x:xmpmeta xmlns:x='adobe:ns:meta/' x:xmptk='handwritten'>
+<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'>
+ <rdf:Description rdf:about='' xmlns:dc='http://purl.org/dc/elements/1.1/'>
+  <dc:description><rdf:Alt><rdf:li xml:lang='x-default'>Three of us</rdf:li></rdf:Alt></dc:description>
+  <dc:subject><rdf:Bag><rdf:li>ari</rdf:li><rdf:li>baldur</rdf:li><rdf:li>jakob</rdf:li></rdf:Bag></dc:subject>
+ </rdf:Description>
+ <rdf:Description rdf:about='' xmlns:tiff='http://ns.adobe.com/tiff/1.0/'>
+  <tiff:ImageDescription><rdf:Alt><rdf:li xml:lang='x-default'>Three of us</rdf:li></rdf:Alt></tiff:ImageDescription>
+ </rdf:Description>
+ <rdf:Description rdf:about='' xmlns:digiKam='http://www.digikam.org/ns/1.0/'>
+  <digiKam:TagsList><rdf:Seq><rdf:li>ari</rdf:li><rdf:li>baldur</rdf:li><rdf:li>people/jakob</rdf:li></rdf:Seq></digiKam:TagsList>
+ </rdf:Description>
+</rdf:RDF>
+</x:xmpmeta>
+<?xpacket end='w'?>

--- a/internal/exif/sidecars/xmpsidecar/DATA/multi-tags.jpg.xmp
+++ b/internal/exif/sidecars/xmpsidecar/DATA/multi-tags.jpg.xmp
@@ -8,6 +8,10 @@
  <rdf:Description rdf:about='' xmlns:tiff='http://ns.adobe.com/tiff/1.0/'>
   <tiff:ImageDescription><rdf:Alt><rdf:li xml:lang='x-default'>Three of us</rdf:li></rdf:Alt></tiff:ImageDescription>
  </rdf:Description>
+ <rdf:Description rdf:about='' xmlns:exif='http://ns.adobe.com/exif/1.0/'>
+  <exif:GPSLatitude>48,24.50256879N</exif:GPSLatitude>
+  <exif:GPSLongitude>3,5.43538761W</exif:GPSLongitude>
+ </rdf:Description>
  <rdf:Description rdf:about='' xmlns:digiKam='http://www.digikam.org/ns/1.0/'>
   <digiKam:TagsList><rdf:Seq><rdf:li>ari</rdf:li><rdf:li>baldur</rdf:li><rdf:li>people/jakob</rdf:li></rdf:Seq></digiKam:TagsList>
  </rdf:Description>

--- a/internal/exif/sidecars/xmpsidecar/DATA/single-description.jpg.xmp
+++ b/internal/exif/sidecars/xmpsidecar/DATA/single-description.jpg.xmp
@@ -1,0 +1,18 @@
+<?xpacket begin='﻿' id='W5M0MpCehiHzreSzNTczkc9d'?>
+<x:xmpmeta xmlns:x='adobe:ns:meta/' x:xmptk='handwritten'>
+<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'>
+ <rdf:Description rdf:about=''
+  xmlns:tiff='http://ns.adobe.com/tiff/1.0/'
+  xmlns:digiKam='http://www.digikam.org/ns/1.0/'
+  xmlns:exif='http://ns.adobe.com/exif/1.0/'
+  xmlns:xmp='http://ns.adobe.com/xap/1.0/'>
+  <tiff:ImageDescription><rdf:Alt><rdf:li xml:lang='x-default'>All in one</rdf:li></rdf:Alt></tiff:ImageDescription>
+  <digiKam:TagsList><rdf:Seq><rdf:li>solo</rdf:li></rdf:Seq></digiKam:TagsList>
+  <exif:DateTimeOriginal>2020-02-02T10:20:30Z</exif:DateTimeOriginal>
+  <exif:GPSLatitude>48,24.50256879N</exif:GPSLatitude>
+  <exif:GPSLongitude>3,5.43538761W</exif:GPSLongitude>
+  <xmp:Rating>3</xmp:Rating>
+ </rdf:Description>
+</rdf:RDF>
+</x:xmpmeta>
+<?xpacket end='w'?>

--- a/internal/exif/sidecars/xmpsidecar/read.go
+++ b/internal/exif/sidecars/xmpsidecar/read.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"path"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/clbanning/mxj/v2"
@@ -27,25 +28,29 @@ func walk(m mxj.Map, md *assets.Metadata, path string) {
 		case map[string]interface{}:
 			walk(v, md, path+"/"+key)
 		case []interface{}:
-			path = path + "/" + key
+			listPath := path + "/" + key
 			for i, item := range v {
-				p := fmt.Sprintf("%s[%d]", path, i)
+				p := fmt.Sprintf("%s[%d]", listPath, i)
 				if itemMap, ok := item.(map[string]interface{}); ok {
 					walk(itemMap, md, p)
-				} else {
-					filter(md, p, item.(string))
+				} else if s, ok := item.(string); ok {
+					filter(md, p, s)
 				}
 			}
-		default:
-			filter(md, path+"/"+key, value.(string))
+		case string:
+			filter(md, path+"/"+key, v)
 		}
 	}
 }
 
-var reDescription = regexp.MustCompile(`/xmpmeta/RDF/Description\[\d+\]/`)
+// reIndex matches the index that walk appends to the elements of a list, such as the
+// rdf:Description elements of the document or the rdf:li items of a tag list. The same property
+// must be recognised whether it is the only element of its kind or one of several.
+var reIndex = regexp.MustCompile(`\[\d+\]`)
 
 func filter(md *assets.Metadata, p string, value string) {
-	p = reDescription.ReplaceAllString(p, "")
+	p = reIndex.ReplaceAllString(p, "")
+	p = strings.TrimPrefix(p, "/xmpmeta/RDF/Description/")
 	// debug 	fmt.Printf("%s: %s\n", p, value)
 	switch p {
 	case "DateTimeOriginal":
@@ -62,11 +67,11 @@ func filter(md *assets.Metadata, p string, value string) {
 				Name:  path.Base(value),
 				Value: value,
 			})
-	case "/xmpmeta/RDF/Description/GPSLatitude":
+	case "GPSLatitude":
 		if f, err := GPTStringToFloat(value); err == nil {
 			md.Latitude = f
 		}
-	case "/xmpmeta/RDF/Description/GPSLongitude":
+	case "GPSLongitude":
 		if f, err := GPTStringToFloat(value); err == nil {
 			md.Longitude = f
 		}

--- a/internal/exif/sidecars/xmpsidecar/read.go
+++ b/internal/exif/sidecars/xmpsidecar/read.go
@@ -58,7 +58,11 @@ func filter(md *assets.Metadata, p string, value string) {
 			md.DateTaken = d
 		}
 	case "ImageDescription/Alt/li/#text":
-		md.Description = value
+		// An Alt list may repeat the text in several languages; the XMP specification
+		// puts the x-default entry first, so the first item wins.
+		if md.Description == "" {
+			md.Description = value
+		}
 	case "Rating":
 		md.Rating = StringToByte(value)
 	case "TagsList/Seq/li":

--- a/internal/exif/sidecars/xmpsidecar/read_test.go
+++ b/internal/exif/sidecars/xmpsidecar/read_test.go
@@ -59,6 +59,13 @@ func TestRead(t *testing.T) {
 				},
 			},
 		},
+		{
+			// the description in several languages: the x-default entry comes first
+			path: "DATA/multi-language.jpg.xmp",
+			expect: assets.Metadata{
+				Description: "Sunset over the bay",
+			},
+		},
 	}
 
 	for _, c := range tc {

--- a/internal/exif/sidecars/xmpsidecar/read_test.go
+++ b/internal/exif/sidecars/xmpsidecar/read_test.go
@@ -36,6 +36,8 @@ func TestRead(t *testing.T) {
 			path: "DATA/multi-tags.jpg.xmp",
 			expect: assets.Metadata{
 				Description: "Three of us",
+				Latitude:    48.408376,
+				Longitude:   -3.090590,
 				Tags: []assets.Tag{
 					{Value: "ari", Name: "ari"},
 					{Value: "baldur", Name: "baldur"},

--- a/internal/exif/sidecars/xmpsidecar/read_test.go
+++ b/internal/exif/sidecars/xmpsidecar/read_test.go
@@ -31,6 +31,32 @@ func TestRead(t *testing.T) {
 				Longitude: -3.090590,
 			},
 		},
+		{
+			// several tags in one list, properties spread over several rdf:Description elements
+			path: "DATA/multi-tags.jpg.xmp",
+			expect: assets.Metadata{
+				Description: "Three of us",
+				Tags: []assets.Tag{
+					{Value: "ari", Name: "ari"},
+					{Value: "baldur", Name: "baldur"},
+					{Value: "people/jakob", Name: "jakob"},
+				},
+			},
+		},
+		{
+			// all properties in a single rdf:Description element
+			path: "DATA/single-description.jpg.xmp",
+			expect: assets.Metadata{
+				Description: "All in one",
+				DateTaken:   time.Date(2020, 2, 2, 10, 20, 30, 0, time.UTC),
+				Rating:      3,
+				Latitude:    48.408376,
+				Longitude:   -3.090590,
+				Tags: []assets.Tag{
+					{Value: "solo", Name: "solo"},
+				},
+			},
+		},
 	}
 
 	for _, c := range tc {


### PR DESCRIPTION
What
----

Fix XMP sidecar layouts that immich-go reads wrongly:

- a `digiKam:TagsList` with more than one item applied no tags at all (a single item worked);
- a description repeated in several languages (an `rdf:Alt` with more than one `rdf:li`) was dropped;
- a sidecar with all its properties in one `rdf:Description` element yielded nothing but the GPS coordinates (description, date, rating and tags dropped).

Fixes #1430

Cause
-----

`walk` appends an index to the elements of a list (`Description[2]`, `li[1]`) and `filter` stripped only the index of the `Description` element, so a multi-item list's paths gained a `li[N]` segment and a single-Description sidecar's paths kept the `/xmpmeta/RDF/Description/` prefix; neither matched the property names `filter` looks for. The GPS cases were written for the unindexed prefix, which is why only they worked in that layout (and they missed the indexed one). `walk` also reassigned its `path` variable on meeting a list, so the keys after the list in the same element got a wrong prefix.

Fix
---

`filter` strips every `[N]` index and the `Description` prefix before matching, and GPS is matched on the normalised path like the other properties. A multi-language description takes its first entry, which the XMP specification requires to be the x-default one. `walk` keeps the list path in a local variable.

Three sidecars are added as test data, one per layout, and the multi-Description one also covers GPS spread over several `rdf:Description` elements; the tests fail before the fix (`expected 3 tags, got 0`; the single-Description one loses description, date, rating and tags) and pass after.

Notes
-----

Based on `main` rather than `develop`, because the fix was tested against Immich v3, whose support is on `main` only.
