### PR TITLE
fix(google-takeout): Live Photo video component matched to no metadata

### DIFF
--- a/adapters/googlePhotos/googlephotos.go
+++ b/adapters/googlePhotos/googlephotos.go
@@ -284,6 +284,7 @@ var matchers = []struct {
 }{
 	{name: "matchFastTrack", fn: matchFastTrack},
 	{name: "matchNormal", fn: matchNormal},
+	{name: "matchLivePhotoVideo", fn: matchLivePhotoVideo},
 	{name: "matchForgottenDuplicates", fn: matchForgottenDuplicates},
 	{name: "matchEditedName", fn: matchEditedName},
 }

--- a/adapters/googlePhotos/matcher_test.go
+++ b/adapters/googlePhotos/matcher_test.go
@@ -192,6 +192,54 @@ func Test_matchers(t *testing.T) {
 			jsonName: "Screenshot_2024-08-31-00-53-48-647_com.snapcha.json",
 			want:     "matchNormal",
 		},
+
+		// Live Photo pairs: Google Takeout only writes a JSON for the still image;
+		// the video half must be matched to the same sidecar.
+		{ // still image, base pair
+			fileName: "IMG_4488.HEIC",
+			jsonName: "IMG_4488.HEIC.supplemental-metadata.json",
+			want:     "matchNormal",
+		},
+		{ // video half, base pair, no JSON of its own
+			fileName: "IMG_4488.MP4",
+			jsonName: "IMG_4488.HEIC.supplemental-metadata.json",
+			want:     "matchLivePhotoVideo",
+		},
+		{ // still image, duplicate index 1
+			fileName: "IMG_4488(1).HEIC",
+			jsonName: "IMG_4488.HEIC.supplemental-metadata(1).json",
+			want:     "matchNormal",
+		},
+		{ // video half, duplicate index 1, no JSON of its own
+			fileName: "IMG_4488(1).MP4",
+			jsonName: "IMG_4488.HEIC.supplemental-metadata(1).json",
+			want:     "matchLivePhotoVideo",
+		},
+		{ // still image, duplicate index 2
+			fileName: "IMG_4488(2).HEIC",
+			jsonName: "IMG_4488.HEIC.supplemental-metadata(2).json",
+			want:     "matchNormal",
+		},
+		{ // video half, duplicate index 2, no JSON of its own
+			fileName: "IMG_4488(2).MP4",
+			jsonName: "IMG_4488.HEIC.supplemental-metadata(2).json",
+			want:     "matchLivePhotoVideo",
+		},
+		{ // video half must NOT bind to a sidecar of a different duplicate index
+			fileName: "IMG_4488(1).MP4",
+			jsonName: "IMG_4488.HEIC.supplemental-metadata(2).json",
+			want:     "",
+		},
+		{ // a video with its own dedicated sidecar keeps using it, not the live-photo fallback
+			fileName: "IMG_4488.MP4",
+			jsonName: "IMG_4488.MP4.supplemental-metadata.json",
+			want:     "matchNormal",
+		},
+		{ // video half where the "(1)" is part of the still image's base name, not a duplicate index
+			fileName: "PXL_20220615_101533000(1).MP4",
+			jsonName: "PXL_20220615_101533000(1).jpg.supplemental-metadata.json",
+			want:     "matchLivePhotoVideo",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.fileName, func(t *testing.T) {
@@ -202,6 +250,7 @@ func Test_matchers(t *testing.T) {
 			}{
 				{name: "matchFastTrack", fn: matchFastTrack},
 				{name: "matchNormal", fn: matchNormal},
+				{name: "matchLivePhotoVideo", fn: matchLivePhotoVideo},
 				{name: "matchForgottenDuplicates", fn: matchForgottenDuplicates},
 				{name: "matchEditedName", fn: matchEditedName},
 			}

--- a/adapters/googlePhotos/matchers.go
+++ b/adapters/googlePhotos/matchers.go
@@ -104,6 +104,54 @@ func matchForgottenDuplicates(jsonName string, fileName string, sm filetypes.Sup
 	return false
 }
 
+// matchLivePhotoVideo
+// Google Takeout writes a single supplemental-metadata JSON for a Live Photo
+// pair, named after the still image. The video half never gets a sidecar of
+// its own, which is most visible in duplicate-indexed sets:
+//
+//	IMG_4488.HEIC.supplemental-metadata(1).json   (JSON exists only for the still)
+//	IMG_4488(1).HEIC                              (still image, matched by matchNormal)
+//	IMG_4488(1).MP4                                (video half, no JSON of its own)
+//
+// It runs right after matchFastTrack/matchNormal, so a video that does have
+// its own sidecar is matched there first and never reaches this function.
+// It must stay ahead of matchForgottenDuplicates/matchEditedName: those use
+// loose prefix matching that can misfire on a plain video/image pair with no
+// index (see matchEditedName's own doc comment).
+func matchLivePhotoVideo(jsonName string, fileName string, sm filetypes.SupportedMedia) bool {
+	if sm.TypeFromExt(path.Ext(fileName)) != filetypes.TypeVideo {
+		return false
+	}
+
+	fileName, fileIndex := getFileIndex(fileName)
+	jsonName, jsonIndex := getFileIndex(jsonName)
+	if fileIndex != jsonIndex {
+		return false
+	}
+
+	// supplemental-metadata check, same as matchNormal
+	p2 := strings.LastIndex(jsonName, ".")
+	if p2 > 1 {
+		p1 := strings.LastIndex(jsonName[:p2], ".")
+		if p1 > 1 {
+			if strings.HasPrefix("supplemental-metadata", jsonName[p1+1:p2]) { //nolint:all
+				jsonName = jsonName[:p1] + jsonName[p2:]
+			}
+		}
+	}
+	jsonName = strings.TrimSuffix(jsonName, path.Ext(jsonName)) // drop ".json", keeps the still image's extension
+
+	// the sidecar must belong to the still-image half of the pair
+	jsonExt := path.Ext(jsonName)
+	if sm.TypeFromExt(jsonExt) != filetypes.TypeImage {
+		return false
+	}
+	jsonName = strings.TrimSuffix(jsonName, jsonExt)
+
+	fileName = strings.TrimSuffix(fileName, path.Ext(fileName))
+	return jsonName == fileName
+}
+
 func getFileIndex(name string) (string, string) {
 	// Extract the index from the file name
 	p1File := strings.LastIndex(name, "(")


### PR DESCRIPTION
**What**

The video half of a Live Photo pair comes out as missing metadata:

- Google Takeout writes a supplemental-metadata JSON only for the still image half of a Live Photo pair;
- the video half gets no sidecar of its own;
- none of the existing matchers account for that, so the video is reported missing even though the still image right next to it matched fine.

Fixes #1321

**Cause**

Every matcher requires the target file's own extension to show up somewhere in the reduced JSON name. `matchNormal` strips `.json` and collapses `supplemental-metadata`, but what's left still carries the still image's extension (e.g. `IMG_1234.HEIC`), and a `.MP4` file will never equal that. `matchFastTrack`, `matchForgottenDuplicates` and `matchEditedName` have the same gap for a different reason: none of them account for a still-image-only sidecar being the correct match for a video file.

**Fix**

`matchLivePhotoVideo` checks that the target file is a video and that the JSON, once reduced, belongs to an image, with the duplicate index matched between the two. It sits right after `matchNormal` in the matcher list rather than at the end, since `matchForgottenDuplicates`/`matchEditedName` use loose prefix matching that can misfire on a plain video/image pair with no index and no edit suffix.

Verified against a real ~90 GB Takeout export (~17,000 assets): `matchLivePhotoVideo` correctly matched around 4,700 video files that no other matcher touched, all with the expected index-matched JSON. Also reproduced the exact file layout from #1321 directly against the matcher and confirmed the reported file fails without this change and matches via `matchLivePhotoVideo` with it.

**Notes**

Based on `main` rather than `develop`, since testing this against a live Immich v3 server needs the v3 support that only landed on `main`.