### PR TITLE
Change .heic extension to .jpg if the file content is jpg

### DIFF
--- a/immich/upload.go
+++ b/immich/upload.go
@@ -62,6 +62,11 @@ func (ic *ImmichClient) uploadAsset(ctx context.Context, la *assets.Asset, endPo
 		return ar, err
 	}
 	defer f.Close()
+	la.OriginalFileName, err = fixExtension(la.OriginalFileName, f)
+	if err != nil {
+		return ar, err
+	}
+	ext = path.Ext(la.OriginalFileName)
 
 	s, err := f.Stat()
 	if err != nil {
@@ -117,6 +122,31 @@ func (ic *ImmichClient) uploadAsset(ctx context.Context, la *assets.Asset, endPo
 	gErr := <-errChan
 	err = errors.Join(err, errCall, gErr)
 	return ar, err
+}
+
+func fixExtension(originalFileName string, f io.ReadSeeker) (string, error) {
+	ext := path.Ext(originalFileName)
+
+	// Some photo export tools (e.g., google takeout) convert HEIC images to
+	// JPEG without changing the filename. Immich may then apply HEIF-specific
+	// metadata handling based on the stale suffix:
+	// https://github.com/immich-app/immich/pull/30393
+	if !strings.EqualFold(ext, ".heic") {
+		return originalFileName, nil
+	}
+
+	var header [512]byte
+	n, readErr := io.ReadFull(f, header[:])
+	if readErr != nil && !errors.Is(readErr, io.EOF) && !errors.Is(readErr, io.ErrUnexpectedEOF) {
+		return originalFileName, readErr
+	}
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return originalFileName, err
+	}
+	if http.DetectContentType(header[:n]) == "image/jpeg" {
+		return strings.TrimSuffix(originalFileName, ext) + ".jpg", nil
+	}
+	return originalFileName, nil
 }
 
 func (ic *ImmichClient) prepareCallValues(la *assets.Asset, s fs.FileInfo, ext, mtype string) map[string]string {

--- a/immich/upload_test.go
+++ b/immich/upload_test.go
@@ -1,0 +1,97 @@
+package immich
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"testing/fstest"
+
+	"github.com/simulot/immich-go/internal/assets"
+	"github.com/simulot/immich-go/internal/filetypes"
+	"github.com/simulot/immich-go/internal/fshelper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAssetUploadCorrectsJPEGWithHEICSuffix(t *testing.T) {
+	t.Parallel()
+
+	jpeg := []byte{0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 'J', 'F', 'I', 'F', 0x00, 0xff, 0xd9}
+	type uploadRequest struct {
+		name   string
+		data   []byte
+		fields map[string]string
+		err    error
+	}
+	received := make(chan uploadRequest, 1)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		result := uploadRequest{fields: make(map[string]string)}
+		defer func() { received <- result }()
+		if r.URL.Path != "/api/assets" {
+			result.err = fmt.Errorf("unexpected request path %q", r.URL.Path)
+			http.Error(w, result.err.Error(), http.StatusNotFound)
+			return
+		}
+
+		reader, err := r.MultipartReader()
+		if err != nil {
+			result.err = err
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		for {
+			part, err := reader.NextPart()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				result.err = err
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+
+			value, err := io.ReadAll(part)
+			if err != nil {
+				result.err = err
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			if part.FormName() == "assetData" {
+				result.name = part.FileName()
+				result.data = value
+			} else {
+				result.fields[part.FormName()] = string(value)
+			}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"asset-id","status":"created"}`)
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := NewImmichClient(server.URL, "test-key")
+	require.NoError(t, err)
+	client.supportedMediaTypes = filetypes.DefaultSupportedMedia
+
+	fileSystem := fstest.MapFS{
+		"photo.HEIC": &fstest.MapFile{Data: jpeg, Mode: fs.ModePerm},
+	}
+	asset := &assets.Asset{
+		File:             fshelper.FSName(fileSystem, "photo.HEIC"),
+		FileSize:         len(jpeg),
+		OriginalFileName: "photo.HEIC",
+	}
+
+	_, err = client.AssetUpload(context.Background(), asset)
+	require.NoError(t, err)
+	uploaded := <-received
+	require.NoError(t, uploaded.err)
+	require.Equal(t, "photo.jpg", uploaded.name)
+	require.Equal(t, ".jpg", uploaded.fields["fileExtension"])
+	require.Equal(t, "photo.jpg-13", uploaded.fields["deviceAssetId"])
+	require.Equal(t, jpeg, uploaded.data)
+}


### PR DESCRIPTION
Immich has [an issue](https://github.com/immich-app/immich/pull/30393) handling files whose extension is .heic with actually JPEG content. 

In this PR, I added a new function `fixExtension`, which renames the file based on the actual content. It currently only handles the heic vs jpeg case, but can be easily extended to handle other cases in the future.